### PR TITLE
Serializer modified to have projectReadiness field on post/patch request

### DIFF
--- a/infraohjelmointi_api/serializers.py
+++ b/infraohjelmointi_api/serializers.py
@@ -114,8 +114,13 @@ class ProjectGetSerializer(serializers.ModelSerializer):
 
 
 class ProjectCreateSerializer(serializers.ModelSerializer):
+    projectReadiness = serializers.SerializerMethodField()
+
     class Meta(BaseMeta):
         model = Project
+
+    def get_projectReadiness(self, obj):
+        return obj.projectReadiness()
 
     @override
     def to_representation(self, instance):


### PR DESCRIPTION
Change to projectCreateSerializer to have projectReadiness returned with response in a Post or Patch request