### PR TITLE
Story/io 245/free search endpoint alter project filter

### DIFF
--- a/infraohjelmointi_api/serializers.py
+++ b/infraohjelmointi_api/serializers.py
@@ -33,53 +33,28 @@ class BaseMeta:
     exclude = ["createdDate", "updatedDate"]
 
 
-class ProjectGroupSerializer(serializers.ModelSerializer):
-    projects = serializers.ListField(
-        child=serializers.UUIDField(), write_only=True, required=False, allow_empty=True
-    )
+class DynamicFieldsModelSerializer(serializers.ModelSerializer):
+    """
+    A ModelSerializer that takes an additional `fields` argument that
+    controls which fields should be displayed.
+    """
 
-    def validate_projects(self, projectIds):
-        """
-        Check that project doesn't already belong to a group
-        """
+    def __init__(self, *args, **kwargs):
+        # Don't pass the 'fields' arg up to the superclass
+        fields = kwargs.pop("fields", None)
 
-        if projectIds is not None and len(projectIds) > 0:
-            for projectId in projectIds:
-                project = get_object_or_404(Project, pk=projectId)
-                if project.projectGroup is not None:
-                    raise serializers.ValidationError(
-                        "Project: {} with id: {} already belongs to the group: {} with id: {}".format(
-                            project.name,
-                            projectId,
-                            project.projectGroup.name,
-                            project.projectGroup_id,
-                        )
-                    )
-        return projectIds
+        # Instantiate the superclass normally
+        super().__init__(*args, **kwargs)
 
-    class Meta(BaseMeta):
-        model = ProjectGroup
-        validators = [
-            UniqueTogetherValidator(
-                queryset=ProjectGroup.objects.all(),
-                fields=["name", "classRelation", "districtRelation"],
-            ),
-        ]
-
-    @override
-    def create(self, validated_data):
-        projectIds = validated_data.pop("projects", None)
-        projectGroup = self.Meta.model.objects.create(**validated_data)
-        if projectIds is not None and len(projectIds) > 0:
-            for projectId in projectIds:
-                project = get_object_or_404(Project, pk=projectId)
-                project.projectGroup = projectGroup
-                project.save()
-
-        return projectGroup
+        if fields is not None:
+            # Drop any fields that are not specified in the `fields` argument.
+            allowed = set(fields)
+            existing = set(self.fields)
+            for field_name in existing - allowed:
+                self.fields.pop(field_name)
 
 
-class ProjectGroupSerializer(serializers.ModelSerializer):
+class ProjectGroupSerializer(DynamicFieldsModelSerializer):
     projects = serializers.ListField(
         child=serializers.UUIDField(), write_only=True, required=False, allow_empty=True
     )

--- a/infraohjelmointi_api/serializers.py
+++ b/infraohjelmointi_api/serializers.py
@@ -100,27 +100,6 @@ class ProjectGroupSerializer(DynamicFieldsModelSerializer):
         return projectGroup
 
 
-class DynamicFieldsModelSerializer(serializers.ModelSerializer):
-    """
-    A ModelSerializer that takes an additional `fields` argument that
-    controls which fields should be displayed.
-    """
-
-    def __init__(self, *args, **kwargs):
-        # Don't pass the 'fields' arg up to the superclass
-        fields = kwargs.pop("fields", None)
-
-        # Instantiate the superclass normally
-        super().__init__(*args, **kwargs)
-
-        if fields is not None:
-            # Drop any fields that are not specified in the `fields` argument.
-            allowed = set(fields)
-            existing = set(self.fields)
-            for field_name in existing - allowed:
-                self.fields.pop(field_name)
-
-
 class ProjectHashtagSerializer(DynamicFieldsModelSerializer):
     class Meta(BaseMeta):
         model = ProjectHashTag

--- a/infraohjelmointi_api/tests/test_ProjectGroups.py
+++ b/infraohjelmointi_api/tests/test_ProjectGroups.py
@@ -149,6 +149,40 @@ class projectGroupTestCase(TestCase):
             ProjectGroup.objects.get(id=new_createdId),
             msg="Newly created ProjectGroup not assignd to Project",
         )
+        response = self.client.post(
+            "/project-groups/", data, content_type="application/json"
+        )
+        self.assertEqual(
+            response.status_code,
+            400,
+            msg="Status code != 400",
+        )
+        errorMessage = response.json()["projects"][0]
+        self.assertEqual(
+            errorMessage,
+            "Project: {} with id: {} already belongs to the group: {} with id: {}".format(
+                self.project.name,
+                self.projectId,
+                Project.objects.get(id=self.projectId).projectGroup.name,
+                Project.objects.get(id=self.projectId).projectGroup_id,
+            ),
+            msg="Project which already belongs to a group should not be assigned to another group",
+        )
+        data["projects"] = ["6e3993ab-f15d-4acf-b151-8dd641098a26"]
+        response = self.client.post(
+            "/project-groups/", data, content_type="application/json"
+        )
+        self.assertEqual(
+            response.status_code,
+            404,
+            msg="Status code != 404",
+        )
+        errorMessage = response.json()["detail"]
+        self.assertEqual(
+            errorMessage,
+            "Not found.",
+            msg="Should throw error if project is not found in DB",
+        )
 
     def test_PATCH_projectGroup(self):
         data = {

--- a/infraohjelmointi_api/tests/test_Projects.py
+++ b/infraohjelmointi_api/tests/test_Projects.py
@@ -1023,12 +1023,12 @@ class ProjectTestCase(TestCase):
             msg="Status code != 200, Error: {}".format(response.json()),
         )
         self.assertEqual(
-            len(response.json()["data"]["projects"]),
+            len(response.json()["projects"]),
             1,
             msg="Filtered result should contain 1 project with the string 'jira' appearing in name field",
         )
         self.assertEqual(
-            len(response.json()["data"]["hashtags"]),
+            len(response.json()["hashtags"]),
             1,
             msg="Filtered result should contain 1 hashTag with the string 'jira' appearing in value field",
         )
@@ -1041,12 +1041,12 @@ class ProjectTestCase(TestCase):
             msg="Status code != 200, Error: {}".format(response.json()),
         )
         self.assertEqual(
-            len(response.json()["data"]["hashtags"]),
+            len(response.json()["hashtags"]),
             1,
             msg="Filtered result should contain 1 hashTag with the string 'park' appearing in value field",
         )
         self.assertEqual(
-            len(response.json()["data"]["projects"]),
+            len(response.json()["projects"]),
             1,
             msg="Filtered result should contain 1 project with the string 'park' appearing in name field",
         )
@@ -1059,12 +1059,12 @@ class ProjectTestCase(TestCase):
             msg="Status code != 200, Error: {}".format(response.json()),
         )
         self.assertEqual(
-            len(response.json()["data"]["projects"]),
+            len(response.json()["projects"]),
             1,
             msg="Filtered result should contain 1 project with the string 'Parking' appearing in name field",
         )
         self.assertEqual(
-            len(response.json()["data"]["hashtags"]),
+            len(response.json()["hashtags"]),
             0,
             msg="Filtered result should contain no hashtags with the string 'Parking' appearing in value field",
         )

--- a/infraohjelmointi_api/tests/test_Projects.py
+++ b/infraohjelmointi_api/tests/test_Projects.py
@@ -992,7 +992,7 @@ class ProjectTestCase(TestCase):
         Project.objects.create(
             id=self.project_6_Id,
             hkrId=5555,
-            name="Futurice Office",
+            name="Futurice Office Jira",
             description="Random desc",
             programmed=False,
             category=category_2,
@@ -1023,11 +1023,14 @@ class ProjectTestCase(TestCase):
             msg="Status code != 200, Error: {}".format(response.json()),
         )
         self.assertEqual(
-            response.json()["count"],
-            2,
-            msg="Filtered result should contain 2 projects with the string 'jira' appearing in either name field or hashTags. Found: {}".format(
-                response.json()["count"]
-            ),
+            len(response.json()["data"]["projects"]),
+            1,
+            msg="Filtered result should contain 1 project with the string 'jira' appearing in name field",
+        )
+        self.assertEqual(
+            len(response.json()["data"]["hashtags"]),
+            1,
+            msg="Filtered result should contain 1 hashTag with the string 'jira' appearing in value field",
         )
         response = self.client.get(
             "/projects/?freeSearch={}".format("park"),
@@ -1038,11 +1041,14 @@ class ProjectTestCase(TestCase):
             msg="Status code != 200, Error: {}".format(response.json()),
         )
         self.assertEqual(
-            response.json()["count"],
-            3,
-            msg="Filtered result should contain 3 projects with the string 'park' appearing in either name field or hashTags. Found: {}".format(
-                response.json()["count"]
-            ),
+            len(response.json()["data"]["hashtags"]),
+            1,
+            msg="Filtered result should contain 1 hashTag with the string 'park' appearing in value field",
+        )
+        self.assertEqual(
+            len(response.json()["data"]["projects"]),
+            1,
+            msg="Filtered result should contain 1 project with the string 'park' appearing in name field",
         )
         response = self.client.get(
             "/projects/?freeSearch={}".format("Parking"),
@@ -1053,11 +1059,14 @@ class ProjectTestCase(TestCase):
             msg="Status code != 200, Error: {}".format(response.json()),
         )
         self.assertEqual(
-            response.json()["count"],
+            len(response.json()["data"]["projects"]),
             1,
-            msg="Filtered result should contain 1 projects with the string 'Parking' appearing in either name field or hashTags. Found: {}".format(
-                response.json()["count"]
-            ),
+            msg="Filtered result should contain 1 project with the string 'Parking' appearing in name field",
+        )
+        self.assertEqual(
+            len(response.json()["data"]["hashtags"]),
+            0,
+            msg="Filtered result should contain no hashtags with the string 'Parking' appearing in value field",
         )
         response = self.client.get(
             "/projects/?programmed={}".format("false"),
@@ -1223,8 +1232,8 @@ class ProjectTestCase(TestCase):
             ),
         )
         response = self.client.get(
-            "/projects/?mainDistrict={}&freeSearch={}".format(
-                self.projectMainDistrict_3_Id, "rain"
+            "/projects/?mainDistrict={}&hashtags={}".format(
+                self.projectMainDistrict_3_Id, self.projectHashTag_3_Id
             ),
         )
         self.assertEqual(
@@ -1236,8 +1245,10 @@ class ProjectTestCase(TestCase):
             response.json()["count"],
             1,
             msg="Filtered result should contain 1 project belonging to mainDistrict Id: {}, directly or indirectly, \
-                with the string 'rain' appearing in either name or hashTag fields. Found: {}".format(
-                self.projectMainDistrict_3_Id, response.json()["count"]
+                with the hashTag: {} . Found: {}".format(
+                self.projectMainDistrict_3_Id,
+                self.projectHashTag_3_Id,
+                response.json()["count"],
             ),
         )
         response = self.client.get(
@@ -1332,6 +1343,43 @@ class ProjectTestCase(TestCase):
                 self.projectMasterClass_2_Id,
                 self.projectSubClass_1_Id,
                 self.projectSubClass_2_Id,
+                response.json()["count"],
+            ),
+        )
+
+        response = self.client.get(
+            "/projects/?hashTags={}".format(self.projectHashTag_3_Id),
+        )
+        self.assertEqual(
+            response.status_code,
+            200,
+            msg="Status code != 200, Error: {}".format(response.json()),
+        )
+        self.assertEqual(
+            response.json()["count"],
+            2,
+            msg="Filtered result should contain 2 projects with hashTag: {}. Found: {}".format(
+                self.projectHashTag_3_Id,
+                response.json()["count"],
+            ),
+        )
+
+        response = self.client.get(
+            "/projects/?hashTags={}&hashTags={}".format(
+                self.projectHashTag_3_Id, self.projectHashTag_4_Id
+            ),
+        )
+        self.assertEqual(
+            response.status_code,
+            200,
+            msg="Status code != 200, Error: {}".format(response.json()),
+        )
+        self.assertEqual(
+            response.json()["count"],
+            3,
+            msg="Filtered result should contain 3 projects with hashTag: {} and {}. Found: {}".format(
+                self.projectHashTag_3_Id,
+                self.projectHashTag_4_Id,
                 response.json()["count"],
             ),
         )

--- a/infraohjelmointi_api/tests/test_Projects.py
+++ b/infraohjelmointi_api/tests/test_Projects.py
@@ -1003,7 +1003,7 @@ class ProjectTestCase(TestCase):
             projectGroup=projectGroup_2,
         )
         project_3.hashTags.add(hashTag_1, hashTag_2)
-        Project.objects.create(
+        project_4 = Project.objects.create(
             id=self.project_6_Id,
             hkrId=5555,
             name="Futurice Office Jira",
@@ -1014,6 +1014,7 @@ class ProjectTestCase(TestCase):
             projectClass=masterClass_2,
             projectGroup=projectGroup_3,
         )
+
         response = self.client.get(
             "/projects/?hkrId={}".format(2222),
         )
@@ -1365,7 +1366,7 @@ class ProjectTestCase(TestCase):
         self.assertEqual(
             response.json()["count"],
             2,
-            msg="Filtered result should contain 2 projects belonging to masterClass Id: {}, directly or indirectly, and subClass Id: {} and {} each. Found: {}".format(
+            msg="Filtered result should contain 2 projects belonging to masterClass Id: {}, directly or indirectly, and subClass Id: {} or {} each. Found: {}".format(
                 self.projectMasterClass_2_Id,
                 self.projectSubClass_1_Id,
                 self.projectSubClass_2_Id,
@@ -1403,7 +1404,7 @@ class ProjectTestCase(TestCase):
         self.assertEqual(
             response.json()["count"],
             3,
-            msg="Filtered result should contain 3 projects with hashTag: {} and {}. Found: {}".format(
+            msg="Filtered result should contain 3 projects with hashTag: {} or {}. Found: {}".format(
                 self.projectHashTag_3_Id,
                 self.projectHashTag_4_Id,
                 response.json()["count"],
@@ -1411,7 +1412,7 @@ class ProjectTestCase(TestCase):
         )
 
         response = self.client.get(
-            "/projects/?hashTags={}&hashTags={}&group={}".format(
+            "/projects/?hashTags={}&hashTags={}&projectGroup={}".format(
                 self.projectHashTag_3_Id,
                 self.projectHashTag_4_Id,
                 self.projectGroup_1_Id,
@@ -1422,7 +1423,7 @@ class ProjectTestCase(TestCase):
             200,
             msg="Status code != 200, Error: {}".format(response.json()),
         )
-        print(response.json())
+
         self.assertEqual(
             response.json()["count"],
             2,

--- a/infraohjelmointi_api/views.py
+++ b/infraohjelmointi_api/views.py
@@ -155,6 +155,10 @@ class ProjectFilter(django_filters.FilterSet):
         ),
         coerce=strtobool,
     )
+    projectGroup = django_filters.ModelMultipleChoiceFilter(
+        field_name="projectGroup",
+        queryset=ProjectGroupSerializer.Meta.model.objects.all(),
+    )
 
     class Meta:
         fields = {
@@ -196,11 +200,17 @@ class ProjectViewSet(BaseViewSet):
             projectQs = ProjectGetSerializer.Meta.model.objects.filter(
                 name__icontains=freeSearch
             )
+            projectGroupQs = ProjectGroupSerializer.Meta.model.objects.filter(
+                name__icontains=freeSearch
+            )
             hashTagsSerializer = ProjectHashtagSerializer(
                 hashTagQs, fields=("id", "value"), many=True
             )
             projectsSerializer = ProjectGetSerializer(
                 projectQs, fields=("id", "name"), many=True
+            )
+            projectGroupsSerializer = ProjectGroupSerializer(
+                projectGroupQs, fields=("id", "name"), many=True
             )
 
             return Response(
@@ -210,6 +220,10 @@ class ProjectViewSet(BaseViewSet):
                         for project in projectsSerializer.data
                     ],
                     "hashtags": hashTagsSerializer.data,
+                    "groups": [
+                        {"id": group["id"], "value": group["name"]}
+                        for group in projectGroupsSerializer.data
+                    ],
                 }
             )
         else:

--- a/infraohjelmointi_api/views.py
+++ b/infraohjelmointi_api/views.py
@@ -193,7 +193,7 @@ class ProjectViewSet(BaseViewSet):
     @override
     def list(self, request, *args, **kwargs):
         freeSearch = request.query_params.get("freeSearch", None)
-        if freeSearch:
+        if freeSearch is not None:
             hashTagQs = ProjectHashtagSerializer.Meta.model.objects.filter(
                 value__icontains=freeSearch
             )

--- a/infraohjelmointi_api/views.py
+++ b/infraohjelmointi_api/views.py
@@ -148,16 +148,16 @@ class ConstructionPhaseViewSet(BaseViewSet):
 
 
 class ProjectFilter(django_filters.FilterSet):
+    projectGroup = django_filters.ModelMultipleChoiceFilter(
+        field_name="projectGroup",
+        queryset=ProjectGroupSerializer.Meta.model.objects.all(),
+    )
     programmed = django_filters.TypedMultipleChoiceFilter(
         choices=(
             ("false", "False"),
             ("true", "True"),
         ),
         coerce=strtobool,
-    )
-    projectGroup = django_filters.ModelMultipleChoiceFilter(
-        field_name="projectGroup",
-        queryset=ProjectGroupSerializer.Meta.model.objects.all(),
     )
 
     class Meta:

--- a/infraohjelmointi_api/views.py
+++ b/infraohjelmointi_api/views.py
@@ -205,10 +205,8 @@ class ProjectViewSet(BaseViewSet):
 
             return Response(
                 {
-                    "data": {
-                        "projects": projectsSerializer.data,
-                        "hashtags": hashTagsSerializer.data,
-                    }
+                    "projects": projectsSerializer.data,
+                    "hashtags": hashTagsSerializer.data,
                 }
             )
         else:

--- a/infraohjelmointi_api/views.py
+++ b/infraohjelmointi_api/views.py
@@ -205,7 +205,10 @@ class ProjectViewSet(BaseViewSet):
 
             return Response(
                 {
-                    "projects": projectsSerializer.data,
+                    "projects": [
+                        {"id": project["id"], "value": project["name"]}
+                        for project in projectsSerializer.data
+                    ],
                     "hashtags": hashTagsSerializer.data,
                 }
             )

--- a/infraohjelmointi_api/views.py
+++ b/infraohjelmointi_api/views.py
@@ -148,10 +148,6 @@ class ConstructionPhaseViewSet(BaseViewSet):
 
 
 class ProjectFilter(django_filters.FilterSet):
-
-    # freeSearch = django_filters.CharFilter(
-    #     method="filter_search_string", label="Search"
-    # )
     programmed = django_filters.TypedMultipleChoiceFilter(
         choices=(
             ("false", "False"),
@@ -160,15 +156,11 @@ class ProjectFilter(django_filters.FilterSet):
         coerce=strtobool,
     )
 
-    # def filter_search_string(self, queryset, name, value):
-    #     return queryset.filter(
-    #         Q(name__icontains=value) | Q(hashTags__value__icontains=value)
-    #     ).distinct()
-
     class Meta:
         fields = {
             "hkrId": ["exact"],
             "category": ["exact"],
+            "hashTags": ["exact"],
         }
         model = Project
 


### PR DESCRIPTION
- Changed response for projects endpoint when "freeSearch" query parameter is used
- Created DynamicFieldsModelSerializer Class which allows fields to be retrieved from serializers dynamically
- "freeSearch" query parameter matches string with project name, hashtag name and group name and returns a response
- Added projectGroup as a query parameter to project filtering
- Added test for projectGroup parameter