### PR TITLE
Fixed ProjectGroup field name, districtRelation -> locationRelation

### DIFF
--- a/infraohjelmointi_api/management/commands/util/hierarchy.py
+++ b/infraohjelmointi_api/management/commands/util/hierarchy.py
@@ -652,7 +652,7 @@ def buildHierarchiesAndProjects(
 
             project_group = ProjectGroupService.get_or_create(
                 name=name,
-                districtRelation=location,
+                locationRelation=location,
                 classRelation=class_stack[-1],
             )[0]
 
@@ -664,7 +664,7 @@ def buildHierarchiesAndProjects(
                     row=row,
                     name=name,
                     project_class=class_stack[-1],
-                    project_location=project_group.districtRelation,
+                    project_location=project_group.locationRelation,
                     project_group=project_group,
                 )
         # for coordinator data

--- a/infraohjelmointi_api/services/ProjectGroupService.py
+++ b/infraohjelmointi_api/services/ProjectGroupService.py
@@ -5,11 +5,11 @@ class ProjectGroupService:
     @staticmethod
     def get_or_create(
         name: str,
-        districtRelation: ProjectLocation,
+        locationRelation: ProjectLocation,
         classRelation: ProjectClass,
     ) -> ProjectGroup:
         return ProjectGroup.objects.get_or_create(
             name=name,
-            districtRelation=districtRelation,
+            locationRelation=locationRelation,
             classRelation=classRelation,
         )


### PR DESCRIPTION
Renamed districtRelation to locationRelation in ProjectGroupService and all its references in management commands