### PR TITLE
Story/io 281/planning view projects endpoint

### DIFF
--- a/infraohjelmointi_api/tests/test_Projects.py
+++ b/infraohjelmointi_api/tests/test_Projects.py
@@ -991,7 +991,7 @@ class ProjectTestCase(TestCase):
             msg="visibilityEnd format in POST request != format in response",
         )
 
-    def test_endpoint_filter_project(self):
+    def test_search_results_endpoint_project(self):
         projectGroup_1 = ProjectGroup.objects.create(
             id=self.projectGroup_1_Id, name="Test Group 1 rain"
         )
@@ -1172,7 +1172,7 @@ class ProjectTestCase(TestCase):
         )
 
         response = self.client.get(
-            "/projects/?prYearMin={}".format(2025),
+            "/projects/search-results/?prYearMin={}".format(2025),
         )
         self.assertEqual(
             response.status_code,
@@ -1188,7 +1188,7 @@ class ProjectTestCase(TestCase):
         )
 
         response = self.client.get(
-            "/projects/?prYearMin={}".format(2030),
+            "/projects/search-results/?prYearMin={}".format(2030),
         )
         self.assertEqual(
             response.status_code,
@@ -1204,7 +1204,7 @@ class ProjectTestCase(TestCase):
         )
 
         response = self.client.get(
-            "/projects/?prYearMax={}".format(2024),
+            "/projects/search-results/?prYearMax={}".format(2024),
         )
         self.assertEqual(
             response.status_code,
@@ -1220,7 +1220,7 @@ class ProjectTestCase(TestCase):
         )
 
         response = self.client.get(
-            "/projects/?prYearMin={}&prYearMax={}".format(2030, 2032),
+            "/projects/search-results/?prYearMin={}&prYearMax={}".format(2030, 2032),
         )
         self.assertEqual(
             response.status_code,
@@ -1236,7 +1236,7 @@ class ProjectTestCase(TestCase):
         )
 
         response = self.client.get(
-            "/projects/?prYearMin={}&prYearMax={}".format(2030, 2032),
+            "/projects/search-results/?prYearMin={}&prYearMax={}".format(2030, 2032),
         )
         self.assertEqual(
             response.status_code,
@@ -1252,7 +1252,7 @@ class ProjectTestCase(TestCase):
         )
 
         response = self.client.get(
-            "/projects/?prYearMin={}&prYearMax={}".format(2028, 2029),
+            "/projects/search-results/?prYearMin={}&prYearMax={}".format(2028, 2029),
         )
         self.assertEqual(
             response.status_code,
@@ -1268,7 +1268,7 @@ class ProjectTestCase(TestCase):
         )
 
         response = self.client.get(
-            "/projects/?hkrId={}".format(2222),
+            "/projects/search-results/?hkrId={}".format(2222),
         )
         self.assertEqual(
             response.status_code,
@@ -1283,7 +1283,7 @@ class ProjectTestCase(TestCase):
             ),
         )
         response = self.client.get(
-            "/projects/?freeSearch={}".format("jira"),
+            "/projects/search-results/?freeSearch={}".format("jira"),
         )
         self.assertEqual(
             response.status_code,
@@ -1306,7 +1306,7 @@ class ProjectTestCase(TestCase):
             msg="Filtered result should contain 0 groups with the string 'jira' appearing in value field",
         )
         response = self.client.get(
-            "/projects/?freeSearch={}".format("park"),
+            "/projects/search-results/?freeSearch={}".format("park"),
         )
         self.assertEqual(
             response.status_code,
@@ -1329,7 +1329,7 @@ class ProjectTestCase(TestCase):
             msg="Filtered result should contain 1 group with the string 'park' appearing in name field",
         )
         response = self.client.get(
-            "/projects/?freeSearch={}".format("Parking"),
+            "/projects/search-results/?freeSearch={}".format("Parking"),
         )
         self.assertEqual(
             response.status_code,
@@ -1348,7 +1348,7 @@ class ProjectTestCase(TestCase):
         )
 
         response = self.client.get(
-            "/projects/?programmed={}".format("false"),
+            "/projects/search-results/?programmed={}".format("false"),
         )
         self.assertEqual(
             response.status_code,
@@ -1363,7 +1363,9 @@ class ProjectTestCase(TestCase):
             ),
         )
         response = self.client.get(
-            "/projects/?programmed={}&programmed={}".format("false", "true"),
+            "/projects/search-results/?programmed={}&programmed={}".format(
+                "false", "true"
+            ),
         )
         self.assertEqual(
             response.status_code,
@@ -1376,7 +1378,7 @@ class ProjectTestCase(TestCase):
             msg="Filtered result should contain all projects existing in the DB",
         )
         response = self.client.get(
-            "/projects/?programmed={}&hkrId={}".format("false", "3333"),
+            "/projects/search-results/?programmed={}&hkrId={}".format("false", "3333"),
         )
         self.assertEqual(
             response.status_code,
@@ -1391,7 +1393,9 @@ class ProjectTestCase(TestCase):
             ),
         )
         response = self.client.get(
-            "/projects/?masterClass={}".format(self.projectMasterClass_2_Id),
+            "/projects/search-results/?masterClass={}".format(
+                self.projectMasterClass_2_Id
+            ),
         )
         self.assertEqual(
             response.status_code,
@@ -1414,7 +1418,7 @@ class ProjectTestCase(TestCase):
             ),
         )
         response = self.client.get(
-            "/projects/?subClass={}&masterClass={}".format(
+            "/projects/search-results/?subClass={}&masterClass={}".format(
                 self.projectSubClass_2_Id, self.projectMasterClass_3_Id
             ),
         )
@@ -1438,7 +1442,7 @@ class ProjectTestCase(TestCase):
             msg="Filtered result should contain 0 classes",
         )
         response = self.client.get(
-            "/projects/?subClass={}".format(self.projectSubClass_1_Id),
+            "/projects/search-results/?subClass={}".format(self.projectSubClass_1_Id),
         )
         self.assertEqual(
             response.status_code,
@@ -1462,7 +1466,7 @@ class ProjectTestCase(TestCase):
             ),
         )
         response = self.client.get(
-            "/projects/?subClass={}&subClass={}".format(
+            "/projects/search-results/?subClass={}&subClass={}".format(
                 self.projectSubClass_1_Id, self.projectSubClass_2_Id
             ),
         )
@@ -1491,7 +1495,7 @@ class ProjectTestCase(TestCase):
         )
 
         response = self.client.get(
-            "/projects/?subClass={}&category={}".format(
+            "/projects/search-results/?subClass={}&category={}".format(
                 self.projectSubClass_2_Id, self.projectCategory_3_Id
             ),
         )
@@ -1518,7 +1522,7 @@ class ProjectTestCase(TestCase):
             ),
         )
         response = self.client.get(
-            "/projects/?class={}".format(self.projectClass_2_Id),
+            "/projects/search-results/?class={}".format(self.projectClass_2_Id),
         )
         self.assertEqual(
             response.status_code,
@@ -1545,7 +1549,7 @@ class ProjectTestCase(TestCase):
         )
 
         response = self.client.get(
-            "/projects/?district={}".format(self.projectDistrict_2_Id),
+            "/projects/search-results/?district={}".format(self.projectDistrict_2_Id),
         )
         self.assertEqual(
             response.status_code,
@@ -1573,7 +1577,7 @@ class ProjectTestCase(TestCase):
             ),
         )
         response = self.client.get(
-            "/projects/?district={}&hashtag={}".format(
+            "/projects/search-results/?district={}&hashtag={}".format(
                 self.projectDistrict_3_Id, self.projectHashTag_3_Id
             ),
         )
@@ -1603,7 +1607,7 @@ class ProjectTestCase(TestCase):
             ),
         )
         response = self.client.get(
-            "/projects/?district={}&district={}".format(
+            "/projects/search-results/?district={}&district={}".format(
                 self.projectDistrict_2_Id, self.projectDistrict_3_Id
             ),
         )
@@ -1635,7 +1639,7 @@ class ProjectTestCase(TestCase):
             ),
         )
         response = self.client.get(
-            "/projects/?district={}&programmed={}".format(
+            "/projects/search-results/?district={}&programmed={}".format(
                 self.projectDistrict_3_Id, "false"
             ),
         )
@@ -1663,7 +1667,7 @@ class ProjectTestCase(TestCase):
             ),
         )
         response = self.client.get(
-            "/projects/?masterClass={}&subClass={}".format(
+            "/projects/search-results/?masterClass={}&subClass={}".format(
                 self.projectMasterClass_2_Id, self.projectSubClass_2_Id
             ),
         )
@@ -1689,7 +1693,7 @@ class ProjectTestCase(TestCase):
             ),
         )
         response = self.client.get(
-            "/projects/?programmed={}&category={}".format(
+            "/projects/search-results/?programmed={}&category={}".format(
                 "true", self.projectCategory_3_Id
             ),
         )
@@ -1707,7 +1711,7 @@ class ProjectTestCase(TestCase):
             ),
         )
         response = self.client.get(
-            "/projects/?masterClass={}&masterClass={}&subClass={}&subClass={}".format(
+            "/projects/search-results/?masterClass={}&masterClass={}&subClass={}&subClass={}".format(
                 self.projectMasterClass_2_Id,
                 self.projectMasterClass_3_Id,
                 self.projectSubClass_1_Id,
@@ -1739,7 +1743,7 @@ class ProjectTestCase(TestCase):
             ),
         )
         response = self.client.get(
-            "/projects/?hashtag={}".format(self.projectHashTag_3_Id),
+            "/projects/search-results/?hashtag={}".format(self.projectHashTag_3_Id),
         )
         self.assertEqual(
             response.status_code,
@@ -1757,7 +1761,7 @@ class ProjectTestCase(TestCase):
         )
 
         response = self.client.get(
-            "/projects/?hashtag={}&hashtag={}".format(
+            "/projects/search-results/?hashtag={}&hashtag={}".format(
                 self.projectHashTag_3_Id, self.projectHashTag_4_Id
             ),
         )
@@ -1777,7 +1781,7 @@ class ProjectTestCase(TestCase):
         )
 
         response = self.client.get(
-            "/projects/?hashtag={}&hashtag={}&group={}".format(
+            "/projects/search-results/?hashtag={}&hashtag={}&group={}".format(
                 self.projectHashTag_3_Id,
                 self.projectHashTag_4_Id,
                 self.projectGroup_1_Id,
@@ -1808,7 +1812,7 @@ class ProjectTestCase(TestCase):
             ),
         )
         response = self.client.get(
-            "/projects/?group={}&group={}".format(
+            "/projects/search-results/?group={}&group={}".format(
                 self.projectGroup_2_Id,
                 self.projectGroup_1_Id,
             ),
@@ -1839,7 +1843,7 @@ class ProjectTestCase(TestCase):
         )
 
         response = self.client.get(
-            "/projects/?group={}&group={}&subClass={}&district={}".format(
+            "/projects/search-results/?group={}&group={}&subClass={}&district={}".format(
                 self.projectGroup_2_Id,
                 self.projectGroup_1_Id,
                 self.projectSubClass_1_Id,
@@ -1891,7 +1895,7 @@ class ProjectTestCase(TestCase):
         )
 
         response = self.client.get(
-            "/projects/?personPlanning={}".format(self.person_4_Id),
+            "/projects/search-results/?personPlanning={}".format(self.person_4_Id),
         )
         self.assertEqual(
             response.status_code,
@@ -1909,7 +1913,7 @@ class ProjectTestCase(TestCase):
         )
 
         response = self.client.get(
-            "/projects/?project={}&project={}".format(
+            "/projects/search-results/?project={}&project={}".format(
                 self.project_3_Id, self.project_4_Id
             ),
         )
@@ -1928,7 +1932,7 @@ class ProjectTestCase(TestCase):
         )
 
         response = self.client.get(
-            "/projects/?project={}&project={}&projectName={}".format(
+            "/projects/search-results/?project={}&project={}&projectName={}".format(
                 self.project_3_Id, self.project_4_Id, "park"
             ),
         )
@@ -1948,7 +1952,7 @@ class ProjectTestCase(TestCase):
         )
 
         response = self.client.get(
-            "/projects/?inGroup={}".format("false"),
+            "/projects/search-results/?inGroup={}".format("false"),
         )
         self.assertEqual(
             response.status_code,

--- a/infraohjelmointi_api/views.py
+++ b/infraohjelmointi_api/views.py
@@ -529,7 +529,7 @@ class ProjectViewSet(BaseViewSet):
         projectGroups = self.request.query_params.getlist("group", [])
         inGroup = self.request.query_params.get("inGroup", None)
         projectName = self.request.query_params.get("projectName", None)
-        # TODO: Write test for this
+
         direct = self.request.query_params.get("direct", False)
 
         try:
@@ -732,7 +732,6 @@ class ProjectViewSet(BaseViewSet):
             if model_class.__name__ == "ProjectLocation":
                 return qs.filter(projectLocation__in=search_ids)
             elif model_class.__name__ == "ProjectClass":
-                # TODO: write test for this case
                 return qs.filter(
                     projectClass__in=search_ids, projectLocation__isnull=True
                 )

--- a/infraohjelmointi_api/views.py
+++ b/infraohjelmointi_api/views.py
@@ -775,6 +775,7 @@ class ProjectViewSet(BaseViewSet):
             if model_class.__name__ == "ProjectLocation":
                 return qs.filter(projectLocation__in=search_ids)
             elif model_class.__name__ == "ProjectClass":
+                # TODO: write test for this case
                 return qs.filter(
                     projectClass__in=search_ids, projectLocation__isnull=True
                 )

--- a/infraohjelmointi_api/views.py
+++ b/infraohjelmointi_api/views.py
@@ -337,10 +337,11 @@ class ProjectViewSet(BaseViewSet):
         financeYear = request.query_params.get("year", None)
         limit = request.query_params.get("limit", None)
         if limit is None:
-            limit = queryset.count()
+            limit = queryset.count() if queryset.count() > 0 else 1
 
         if financeYear is not None and not financeYear.isnumeric():
             raise ParseError(detail={"limit": "Invalid value"}, code="invalid")
+
         # pagination
         paginator = PageNumberPagination()
         paginator.page_size = limit
@@ -774,7 +775,9 @@ class ProjectViewSet(BaseViewSet):
             if model_class.__name__ == "ProjectLocation":
                 return qs.filter(projectLocation__in=search_ids)
             elif model_class.__name__ == "ProjectClass":
-                return qs.filter(projectClass__in=search_ids)
+                return qs.filter(
+                    projectClass__in=search_ids, projectLocation__isnull=True
+                )
         paths = (
             model_class.objects.filter(
                 id__in=search_ids,

--- a/infraohjelmointi_api/views.py
+++ b/infraohjelmointi_api/views.py
@@ -530,6 +530,8 @@ class ProjectViewSet(BaseViewSet):
         inGroup = self.request.query_params.get("inGroup", None)
         projectName = self.request.query_params.get("projectName", None)
 
+        # This query param gives the projects which are directly under any given location or class if set to True
+        # Else the queryset will also contain the projects containing the child locations/districts
         direct = self.request.query_params.get("direct", False)
 
         try:

--- a/infraohjelmointi_api/views.py
+++ b/infraohjelmointi_api/views.py
@@ -322,6 +322,32 @@ class ProjectViewSet(BaseViewSet):
         }
         return Response(response)
 
+    @action(
+        methods=["get"],
+        detail=False,
+        url_path=r"planning-view",
+    )
+    def get_projects_for_planning_view(self, request):
+        """
+        Custom action to get projects by financial year
+        Usage: /projects/planning-view/
+        """
+        # apply filtering
+        queryset = self.filter_queryset(self.get_queryset())
+        financeYear = request.query_params.get("year", None)
+        if financeYear is not None and not financeYear.isnumeric():
+            raise ParseError(detail={"limit": "Invalid value"}, code="invalid")
+        # pagination
+        page = self.paginate_queryset(queryset)
+        if page is not None:
+            serializer = self.get_serializer(
+                page, many=True, context={"finance_year": financeYear}
+            )
+            return self.get_paginated_response(serializer.data)
+
+        serializer = self.get_serializer(queryset, many=True)
+        return Response(serializer.data)
+
     @override
     def get_serializer_class(self):
         """

--- a/infraohjelmointi_api/views.py
+++ b/infraohjelmointi_api/views.py
@@ -325,74 +325,26 @@ class ProjectViewSet(BaseViewSet):
     @action(
         methods=["get"],
         detail=False,
-        url_path=r"planning-view",
+        url_path=r"search-results",
     )
-    def get_projects_for_planning_view(self, request):
+    def get_search_resuls(self, request):
         """
         Custom action to get projects by financial year
-        Usage: /projects/planning-view/
+        Usage: /projects/search-results/?<filter-params>
         """
-        # apply filtering
-        queryset = self.filter_queryset(self.get_queryset())
-        financeYear = request.query_params.get("year", None)
-        limit = request.query_params.get("limit", None)
-        if limit is None:
-            limit = queryset.count() if queryset.count() > 0 else 1
 
-        if financeYear is not None and not financeYear.isnumeric():
-            raise ParseError(detail={"limit": "Invalid value"}, code="invalid")
-
-        # pagination
-        paginator = PageNumberPagination()
-        paginator.page_size = limit
-        page = paginator.paginate_queryset(queryset, request)
-        if page is not None:
-            serializer = self.get_serializer(
-                page, many=True, context={"finance_year": financeYear}
-            )
-            return paginator.get_paginated_response(serializer.data)
-
-        serializer = self.get_serializer(
-            queryset, many=True, context={"finance_year": financeYear}
-        )
-        return Response(serializer.data)
-
-    @override
-    def get_serializer_class(self):
-        """
-        Overriden ModelViewSet class method to get appropriate serializer depending on the request action
-        """
-        if self.action == "list":
-            return ProjectGetSerializer
-        if self.action == "retrieve":
-            return ProjectGetSerializer
-        return ProjectCreateSerializer
-
-    @override
-    def list(self, request, *args, **kwargs):
         response = {}
         freeSearch = request.query_params.get("freeSearch", None)
         projectGroup = request.query_params.getlist("group", [])
         masterClass = self.request.query_params.getlist("masterClass", [])
         _class = self.request.query_params.getlist("class", [])
         subClass = self.request.query_params.getlist("subClass", [])
-
         district = self.request.query_params.getlist("district", [])
         division = self.request.query_params.getlist("division", [])
         subDivision = self.request.query_params.getlist("subDivision", [])
-
-        hkrId = request.query_params.get("hkrId", None)
-        category = request.query_params.get("category", None)
         hashTags = request.query_params.getlist("hashtag", [])
-        phase = request.query_params.get("phase", None)
-        personPlanning = request.query_params.get("personPlanning", None)
-        programmed = request.query_params.getlist("programmed", [])
-        projects = self.request.query_params.getlist("project", [])
-        inGroup = self.request.query_params.get("inGroup", None)
-        projectName = self.request.query_params.get("projectName", None)
         order = self.request.query_params.get("order", None)
         limit = self.request.query_params.get("limit", "10")
-
         if freeSearch is not None:
             if freeSearch == "":
                 return Response(
@@ -435,125 +387,130 @@ class ProjectViewSet(BaseViewSet):
                     ],
                 }
             )
-        elif (
-            len(projects) > 0
-            or len(projectGroup) > 0
-            or len(masterClass) > 0
-            or len(_class) > 0
-            or len(subClass) > 0
-            or len(district) > 0
-            or len(division) > 0
-            or len(subDivision) > 0
-            or len(hashTags) > 0
-            or len(programmed) > 0
-            or hkrId is not None
-            or category is not None
-            or phase is not None
-            or personPlanning is not None
-            or (inGroup is not None and inGroup in ["true", "True", "false", "False"])
-            or projectName is not None
-            or order is not None
-        ):
-            if not limit.isnumeric():
-                raise ParseError(detail={"limit": "Invalid value"}, code="invalid")
-            if limit not in ["10", "20", "30"]:
-                raise ValidationError(
-                    detail={"limit": "Value out of range"}, code="out_of_range"
-                )
 
-            limit = int(limit)
-            # already filtered queryset
-            queryset = self.filter_queryset(self.get_queryset())
-            groups = []
-            projectClasses = []
-            projectLocations = []
-            combinedQuerysets = []
-
-            if order is None:
-                order = "new"
-
-            if len(projectGroup) > 0:
-                groups = ProjectGroup.objects.filter(
-                    id__in=queryset.values_list("projectGroup", flat=True).distinct()
-                ).select_related("classRelation")
-
-            if len(masterClass) > 0 or len(_class) > 0 or len(subClass) > 0:
-                projectClasses = ProjectClass.objects.filter(
-                    id__in=queryset.values_list("projectClass", flat=True).distinct(),
-                    forCoordinatorOnly=False,
-                )
-            if len(district) > 0 or len(division) > 0 or len(subDivision) > 0:
-                projectLocations = ProjectLocation.objects.filter(
-                    id__in=queryset.values_list(
-                        "projectLocation", flat=True
-                    ).distinct(),
-                    forCoordinatorOnly=False,
-                )
-
-            if order == "new":
-                combinedQuerysets = sorted(
-                    chain(groups, projectClasses, projectLocations, queryset),
-                    key=lambda obj: obj.createdDate,
-                    reverse=True,
-                )
-            elif order == "old":
-                combinedQuerysets = sorted(
-                    chain(groups, projectClasses, projectLocations, queryset),
-                    key=lambda obj: obj.createdDate,
-                    reverse=False,
-                )
-            elif order == "project":
-                combinedQuerysets = list(
-                    chain(queryset, projectClasses, projectLocations, groups)
-                )
-            elif order == "group":
-                combinedQuerysets = list(
-                    chain(groups, queryset, projectClasses, projectLocations)
-                )
-            elif order == "phase":
-                queryset = queryset.annotate(
-                    relevancy=Count(Case(When(phase__value="proposal", then=1)))
-                ).order_by("-relevancy")
-                combinedQuerysets = list(
-                    chain(
-                        queryset,
-                        groups,
-                        projectClasses,
-                        projectLocations,
-                    )
-                )
-            else:
-                return Response(
-                    data={"message": "Invalid value for order"},
-                    status=status.HTTP_400_BAD_REQUEST,
-                )
-
-            searchPaginator = PageNumberPagination()
-            searchPaginator.page_size = limit
-            result = searchPaginator.paginate_queryset(combinedQuerysets, request)
-            serializer = searchResultSerializer(
-                result, many=True, context={"hashtags_include": hashTags}
+        if not limit.isnumeric():
+            raise ParseError(detail={"limit": "Invalid value"}, code="invalid")
+        if limit not in ["10", "20", "30"]:
+            raise ValidationError(
+                detail={"limit": "Value out of range"}, code="out_of_range"
             )
-            response = {
-                "next": searchPaginator.get_next_link(),
-                "previous": searchPaginator.get_previous_link(),
-                "count": searchPaginator.page.paginator.count,
-                "results": serializer.data,
-            }
 
-            return Response(response)
+        limit = int(limit)
+        # already filtered queryset
+        queryset = self.filter_queryset(self.get_queryset())
+        groups = []
+        projectClasses = []
+        projectLocations = []
+        combinedQuerysets = []
 
+        if order is None:
+            order = "new"
+
+        if len(projectGroup) > 0:
+            groups = ProjectGroup.objects.filter(
+                id__in=queryset.values_list("projectGroup", flat=True).distinct()
+            ).select_related("classRelation")
+
+        if len(masterClass) > 0 or len(_class) > 0 or len(subClass) > 0:
+            projectClasses = ProjectClass.objects.filter(
+                id__in=queryset.values_list("projectClass", flat=True).distinct(),
+                forCoordinatorOnly=False,
+            )
+        if len(district) > 0 or len(division) > 0 or len(subDivision) > 0:
+            projectLocations = ProjectLocation.objects.filter(
+                id__in=queryset.values_list("projectLocation", flat=True).distinct(),
+                forCoordinatorOnly=False,
+            )
+
+        if order == "new":
+            combinedQuerysets = sorted(
+                chain(groups, projectClasses, projectLocations, queryset),
+                key=lambda obj: obj.createdDate,
+                reverse=True,
+            )
+        elif order == "old":
+            combinedQuerysets = sorted(
+                chain(groups, projectClasses, projectLocations, queryset),
+                key=lambda obj: obj.createdDate,
+                reverse=False,
+            )
+        elif order == "project":
+            combinedQuerysets = list(
+                chain(queryset, projectClasses, projectLocations, groups)
+            )
+        elif order == "group":
+            combinedQuerysets = list(
+                chain(groups, queryset, projectClasses, projectLocations)
+            )
+        elif order == "phase":
+            queryset = queryset.annotate(
+                relevancy=Count(Case(When(phase__value="proposal", then=1)))
+            ).order_by("-relevancy")
+            combinedQuerysets = list(
+                chain(
+                    queryset,
+                    groups,
+                    projectClasses,
+                    projectLocations,
+                )
+            )
         else:
-            # with filter
-            queryset = self.filter_queryset(self.get_queryset())
-            # pagination
-            page = self.paginate_queryset(queryset)
-            if page is not None:
-                serializer = self.get_serializer(page, many=True)
-                return self.get_paginated_response(serializer.data)
+            return Response(
+                data={"message": "Invalid value for order"},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
 
-            serializer = self.get_serializer(queryset, many=True)
-            return Response(serializer.data)
+        searchPaginator = PageNumberPagination()
+        searchPaginator.page_size = limit
+        result = searchPaginator.paginate_queryset(combinedQuerysets, request)
+        serializer = searchResultSerializer(
+            result, many=True, context={"hashtags_include": hashTags}
+        )
+        response = {
+            "next": searchPaginator.get_next_link(),
+            "previous": searchPaginator.get_previous_link(),
+            "count": searchPaginator.page.paginator.count,
+            "results": serializer.data,
+        }
+
+        return Response(response)
+
+    @override
+    def get_serializer_class(self):
+        """
+        Overriden ModelViewSet class method to get appropriate serializer depending on the request action
+        """
+        if self.action == "list":
+            return ProjectGetSerializer
+        if self.action == "retrieve":
+            return ProjectGetSerializer
+        return ProjectCreateSerializer
+
+    @override
+    def list(self, request, *args, **kwargs):
+        queryset = self.filter_queryset(self.get_queryset())
+        financeYear = request.query_params.get("year", None)
+        limit = request.query_params.get("limit", None)
+        if limit is None:
+            limit = queryset.count() if queryset.count() > 0 else 1
+
+        if financeYear is not None and not financeYear.isnumeric():
+            raise ParseError(detail={"limit": "Invalid value"}, code="invalid")
+
+        # pagination
+        paginator = PageNumberPagination()
+        paginator.page_size = limit
+        page = paginator.paginate_queryset(queryset, request)
+        if page is not None:
+            serializer = self.get_serializer(
+                page, many=True, context={"finance_year": financeYear}
+            )
+            return paginator.get_paginated_response(serializer.data)
+
+        serializer = self.get_serializer(
+            queryset, many=True, context={"finance_year": financeYear}
+        )
+        return Response(serializer.data)
 
     @override
     def get_queryset(self):

--- a/infraohjelmointi_api/views.py
+++ b/infraohjelmointi_api/views.py
@@ -335,7 +335,7 @@ class ProjectViewSet(BaseViewSet):
         # apply filtering
         queryset = self.filter_queryset(self.get_queryset())
         financeYear = request.query_params.get("year", None)
-        limit = request.query_params.get("limit", "10")
+        limit = request.query_params.get("limit", "20")
 
         if limit is not None and not limit.isnumeric():
             raise ParseError(detail={"limit": "Invalid value"}, code="invalid")

--- a/infraohjelmointi_api/views.py
+++ b/infraohjelmointi_api/views.py
@@ -335,10 +335,9 @@ class ProjectViewSet(BaseViewSet):
         # apply filtering
         queryset = self.filter_queryset(self.get_queryset())
         financeYear = request.query_params.get("year", None)
-        limit = request.query_params.get("limit", "20")
-
-        if limit is not None and not limit.isnumeric():
-            raise ParseError(detail={"limit": "Invalid value"}, code="invalid")
+        limit = request.query_params.get("limit", None)
+        if limit is None:
+            limit = queryset.count()
 
         if financeYear is not None and not financeYear.isnumeric():
             raise ParseError(detail={"limit": "Invalid value"}, code="invalid")


### PR DESCRIPTION
- Move search results to its own endpoint
- Added direct, limit, and  year query parameter to projects endpoint
- direct url query param makes sure projects filtered by location/class only contain projects directly under that class/location
- limit param used to control the number of projects in response
- year param returns projects with the provided year financial data