### PR TITLE
Project group delete request response changes and more

### DIFF
--- a/infraohjelmointi_api/serializers.py
+++ b/infraohjelmointi_api/serializers.py
@@ -305,7 +305,7 @@ class SearchResultSerializer(serializers.Serializer):
         else:
             path = str(classInstance.id)
 
-        if 'suurpiiri' in classInstance.name.lower():
+        if "suurpiiri" in classInstance.name.lower():
             return path
 
         if locationInstance is None:
@@ -376,18 +376,29 @@ class ProjectGroupSerializer(DynamicFieldsModelSerializer, FinancialSumSerialize
         """
 
         if projectIds is not None and len(projectIds) > 0:
+            # Get existing group instance if there is any
+            # In case of a PATCH or POST request to a group
+            # None if POST request for a new group
             group = getattr(self, "instance", None)
             for projectId in projectIds:
                 project = get_object_or_404(Project, pk=projectId)
                 if (
-                    group is not None
-                    and project.projectGroup is not None
-                    and project.projectGroup.id != group.id
-                ) or (group is None and project.projectGroup is not None):
+                    (
+                        # PATCH request to existing group
+                        # Check if a project is in a group which is not same as the group being patched
+                        # Means a project is being assigned to this group which belongs to another group already
+                        group is not None
+                        and project.projectGroup is not None
+                        and project.projectGroup.id != group.id
+                    )
+                    or
+                    # POST request for new group
+                    # A project in the request already belongs to another group
+                    (group is None and project.projectGroup is not None)
+                ):
                     raise ValidationError(
-                        detail="Project: {} with id: {} already belongs to the group: {} with id: {}".format(
+                        detail="Project: {} cannot be assigned to this group. It already belongs to group: {} with groupId: {}".format(
                             project.name,
-                            projectId,
                             project.projectGroup.name,
                             project.projectGroup_id,
                         ),

--- a/infraohjelmointi_api/tests/test_ProjectGroups.py
+++ b/infraohjelmointi_api/tests/test_ProjectGroups.py
@@ -159,9 +159,8 @@ class projectGroupTestCase(TestCase):
         errorMessage = response.json()["errors"][0]["detail"]
         self.assertEqual(
             errorMessage,
-            "Project: {} with id: {} already belongs to the group: {} with id: {}".format(
+            "Project: {} cannot be assigned to this group. It already belongs to group: {} with groupId: {}".format(
                 self.project.name,
-                self.projectId,
                 Project.objects.get(id=self.projectId).projectGroup.name,
                 Project.objects.get(id=self.projectId).projectGroup_id,
             ),

--- a/infraohjelmointi_api/tests/test_ProjectGroups.py
+++ b/infraohjelmointi_api/tests/test_ProjectGroups.py
@@ -205,7 +205,12 @@ class projectGroupTestCase(TestCase):
         )
         self.assertEqual(
             response.status_code,
-            204,
+            200,
+            msg="Error deleting projectGroup with Id {}".format(self.projectGroup_1_Id),
+        )
+        self.assertEqual(
+            response.json()["id"],
+            self.projectGroup_1_Id.__str__(),
             msg="Error deleting projectGroup with Id {}".format(self.projectGroup_1_Id),
         )
         self.assertEqual(

--- a/infraohjelmointi_api/views.py
+++ b/infraohjelmointi_api/views.py
@@ -151,6 +151,16 @@ class ProjectGroupViewSet(BaseViewSet):
 
         return Response(serializer.data)
 
+    @override
+    def destroy(self, request, *args, **kwargs):
+        """
+        Overriding destroy action to get the deleted group id as a response
+        """
+        group = self.get_object()
+        data = group.id
+        group.delete()
+        return Response({"id": data})
+
     permission_classes = []
     serializer_class = ProjectGroupSerializer
 


### PR DESCRIPTION
Fixed delete request response to have the id of the deleted group
Fixed a logical error in project group validation which would throw an error if a group was patched with a project which exists on the group itself.
Override update function of ProjectGroupSerializer to remove projects which are not in the patch request