### PR TITLE
Delete project response change

### DIFF
--- a/infraohjelmointi_api/tests/test_Projects.py
+++ b/infraohjelmointi_api/tests/test_Projects.py
@@ -698,8 +698,15 @@ class ProjectTestCase(TestCase):
         response = self.client.delete("/projects/{}/".format(self.project_1_Id))
         self.assertEqual(
             response.status_code,
-            204,
-            msg="Error deleting project with Id {}".format(self.project_1_Id),
+            200,
+            msg="Error deleting project with Id {}, status code: {}".format(
+                self.project_1_Id, response.status_code
+            ),
+        )
+        self.assertEqual(
+            response.json()["id"],
+            self.project_1_Id.__str__(),
+            msg="Response does not contain the deleted project id",
         )
         self.assertEqual(
             Project.objects.filter(id=self.project_1_Id).exists(),
@@ -779,19 +786,6 @@ class ProjectTestCase(TestCase):
         self.assertEqual(
             response.json()[1]["finances"]["budgetProposalCurrentYearPlus0"],
             "2.00",
-        )
-
-    def test_DELETE_project(self):
-        response = self.client.delete("/projects/{}/".format(self.project_1_Id))
-        self.assertEqual(
-            response.status_code,
-            204,
-            msg="Error deleting project with Id {}".format(self.project_1_Id),
-        )
-        self.assertEqual(
-            Project.objects.filter(id=self.project_1_Id).exists(),
-            False,
-            msg="Project with Id {} still exists in DB".format(self.project_1_Id),
         )
 
     def test_notes_project(self):

--- a/infraohjelmointi_api/views.py
+++ b/infraohjelmointi_api/views.py
@@ -312,9 +312,9 @@ class ProjectViewSet(BaseViewSet):
         Overriding destroy action to get the deleted project id as a response
         """
         project = self.get_object()
-        data = project.id
+        project_id = project.id
         project.delete()
-        return Response({"id": data})
+        return Response({"id": project_id})
 
     @transaction.atomic
     @override

--- a/infraohjelmointi_api/views.py
+++ b/infraohjelmointi_api/views.py
@@ -306,6 +306,16 @@ class ProjectViewSet(BaseViewSet):
     filter_backends = [DjangoFilterBackend]
     filterset_class = ProjectFilter
 
+    @override
+    def destroy(self, request, *args, **kwargs):
+        """
+        Overriding destroy action to get the deleted project id as a response
+        """
+        project = self.get_object()
+        data = project.id
+        project.delete()
+        return Response({"id": data})
+
     @transaction.atomic
     @override
     def partial_update(self, request, *args, **kwargs):


### PR DESCRIPTION
- Override the destroy method on ProjectView to change the response of the DELETE request
- Added deleted project id in the DELETE request response on the project endpoint
- Wrote test to check for the id in response
- Removed a duplicate delete project test