### PR TITLE
Story/io 369/finance events and calculations optimizations

### DIFF
--- a/infraohjelmointi_api/serializers/FinancialSumSerializer.py
+++ b/infraohjelmointi_api/serializers/FinancialSumSerializer.py
@@ -6,8 +6,7 @@ from infraohjelmointi_api.models import (
     LocationFinancial,
     ProjectLocation,
 )
-
-
+from django.core.cache import cache
 from infraohjelmointi_api.services import (
     ProjectService,
     ClassFinancialService,
@@ -38,6 +37,7 @@ class FinancialSumSerializer(serializers.ModelSerializer):
         Returns the frameBudget, budgetChange and isFrameBudgetOverlap for a given year and class/location instance.\n
         isFrameBudgetOverlap donates if child classes have a frameBudget sum that exceeds the current class frameBudget.
         """
+
         for_coordinator = self.context.get("for_coordinator", False)
         _type = instance._meta.model.__name__
 
@@ -147,6 +147,8 @@ class FinancialSumSerializer(serializers.ModelSerializer):
             ),
         }
 
+    # try caching this whole result for a class
+    # can change based on frameview, and year
     def get_finance_sums(self, instance):
         """
         Calculates financial sums for 10 years given a group | location | class instance.
@@ -154,157 +156,190 @@ class FinancialSumSerializer(serializers.ModelSerializer):
         _type = instance._meta.model.__name__
         year = int(self.context.get("finance_year", date.today().year))
         forcedToFrame = self.context.get("forcedToFrame", False)
-        relatedProjects = self.get_related_projects(instance=instance, _type=_type)
-        summedFinances = relatedProjects.aggregate(
-            year0_plannedBudget=Sum(
-                "finances__value",
-                default=0,
-                filter=Q(finances__forFrameView=forcedToFrame) & Q(finances__year=year),
-            ),
-            year1_plannedBudget=Sum(
-                "finances__value",
-                default=0,
-                filter=Q(finances__forFrameView=forcedToFrame)
-                & Q(finances__year=year + 1),
-            ),
-            year2_plannedBudget=Sum(
-                "finances__value",
-                default=0,
-                filter=Q(finances__forFrameView=forcedToFrame)
-                & Q(finances__year=year + 2),
-            ),
-            year3_plannedBudget=Sum(
-                "finances__value",
-                default=0,
-                filter=Q(finances__forFrameView=forcedToFrame)
-                & Q(finances__year=year + 3),
-            ),
-            year4_plannedBudget=Sum(
-                "finances__value",
-                default=0,
-                filter=Q(finances__forFrameView=forcedToFrame)
-                & Q(finances__year=year + 4),
-            ),
-            year5_plannedBudget=Sum(
-                "finances__value",
-                default=0,
-                filter=Q(finances__forFrameView=forcedToFrame)
-                & Q(finances__year=year + 5),
-            ),
-            year6_plannedBudget=Sum(
-                "finances__value",
-                default=0,
-                filter=Q(finances__forFrameView=forcedToFrame)
-                & Q(finances__year=year + 6),
-            ),
-            year7_plannedBudget=Sum(
-                "finances__value",
-                default=0,
-                filter=Q(finances__forFrameView=forcedToFrame)
-                & Q(finances__year=year + 7),
-            ),
-            year8_plannedBudget=Sum(
-                "finances__value",
-                default=0,
-                filter=Q(finances__forFrameView=forcedToFrame)
-                & Q(finances__year=year + 8),
-            ),
-            year9_plannedBudget=Sum(
-                "finances__value",
-                default=0,
-                filter=Q(finances__forFrameView=forcedToFrame)
-                & Q(finances__year=year + 9),
-            ),
-            year10_plannedBudget=Sum(
-                "finances__value",
-                default=0,
-                filter=Q(finances__forFrameView=forcedToFrame)
-                & Q(finances__year=year + 10),
-            ),
-            budgetOverrunAmount=Sum("budgetOverrunAmount", default=0),
-        )
-        if _type == "ProjectGroup":
-            summedFinances["projectBudgets"] = relatedProjects.aggregate(
-                projectBudgets=Sum("costForecast", default=0)
-            )["projectBudgets"]
-        summedFinances["year"] = year
-        summedFinances["year0"] = {
-            **self.get_frameBudget_and_budgetChange(
-                instance=instance,
-                year=year,
-            ),
-            "plannedBudget": int(summedFinances.pop("year0_plannedBudget")),
-        }
-        summedFinances["year1"] = {
-            **self.get_frameBudget_and_budgetChange(
-                instance=instance,
-                year=year + 1,
-            ),
-            "plannedBudget": int(summedFinances.pop("year1_plannedBudget")),
-        }
-        summedFinances["year2"] = {
-            **self.get_frameBudget_and_budgetChange(
-                instance=instance,
-                year=year + 2,
-            ),
-            "plannedBudget": int(summedFinances.pop("year2_plannedBudget")),
-        }
-        summedFinances["year3"] = {
-            **self.get_frameBudget_and_budgetChange(
-                instance=instance,
-                year=year + 3,
-            ),
-            "plannedBudget": int(summedFinances.pop("year3_plannedBudget")),
-        }
-        summedFinances["year4"] = {
-            **self.get_frameBudget_and_budgetChange(
-                instance=instance,
-                year=year + 4,
-            ),
-            "plannedBudget": int(summedFinances.pop("year4_plannedBudget")),
-        }
-        summedFinances["year5"] = {
-            **self.get_frameBudget_and_budgetChange(
-                instance=instance,
-                year=year + 5,
-            ),
-            "plannedBudget": int(summedFinances.pop("year5_plannedBudget")),
-        }
-        summedFinances["year6"] = {
-            **self.get_frameBudget_and_budgetChange(
-                instance=instance,
-                year=year + 6,
-            ),
-            "plannedBudget": int(summedFinances.pop("year6_plannedBudget")),
-        }
-        summedFinances["year7"] = {
-            **self.get_frameBudget_and_budgetChange(
-                instance=instance,
-                year=year + 7,
-            ),
-            "plannedBudget": int(summedFinances.pop("year7_plannedBudget")),
-        }
-        summedFinances["year8"] = {
-            **self.get_frameBudget_and_budgetChange(
-                instance=instance,
-                year=year + 8,
-            ),
-            "plannedBudget": int(summedFinances.pop("year8_plannedBudget")),
-        }
-        summedFinances["year9"] = {
-            **self.get_frameBudget_and_budgetChange(
-                instance=instance,
-                year=year + 9,
-            ),
-            "plannedBudget": int(summedFinances.pop("year9_plannedBudget")),
-        }
-        summedFinances["year10"] = {
-            **self.get_frameBudget_and_budgetChange(
-                instance=instance,
-                year=year + 10,
-            ),
-            "plannedBudget": int(summedFinances.pop("year10_plannedBudget")),
-        }
+
+        relationEffectedCached: list = cache.get("relationEffected", None)
+        if (
+            relationEffectedCached != None
+            and (instance in relationEffectedCached)
+            or (
+                relationEffectedCached == None
+                and cache.get(
+                    str(instance.id) + "/{}/{}".format(forcedToFrame, year), None
+                )
+                == None
+            )
+        ):
+            # this instance needs new financial sums to be calculated
+
+            relatedProjects = self.get_related_projects(instance=instance, _type=_type)
+
+            summedFinances = relatedProjects.aggregate(
+                year0_plannedBudget=Sum(
+                    "finances__value",
+                    default=0,
+                    filter=Q(finances__forFrameView=forcedToFrame)
+                    & Q(finances__year=year),
+                ),
+                year1_plannedBudget=Sum(
+                    "finances__value",
+                    default=0,
+                    filter=Q(finances__forFrameView=forcedToFrame)
+                    & Q(finances__year=year + 1),
+                ),
+                year2_plannedBudget=Sum(
+                    "finances__value",
+                    default=0,
+                    filter=Q(finances__forFrameView=forcedToFrame)
+                    & Q(finances__year=year + 2),
+                ),
+                year3_plannedBudget=Sum(
+                    "finances__value",
+                    default=0,
+                    filter=Q(finances__forFrameView=forcedToFrame)
+                    & Q(finances__year=year + 3),
+                ),
+                year4_plannedBudget=Sum(
+                    "finances__value",
+                    default=0,
+                    filter=Q(finances__forFrameView=forcedToFrame)
+                    & Q(finances__year=year + 4),
+                ),
+                year5_plannedBudget=Sum(
+                    "finances__value",
+                    default=0,
+                    filter=Q(finances__forFrameView=forcedToFrame)
+                    & Q(finances__year=year + 5),
+                ),
+                year6_plannedBudget=Sum(
+                    "finances__value",
+                    default=0,
+                    filter=Q(finances__forFrameView=forcedToFrame)
+                    & Q(finances__year=year + 6),
+                ),
+                year7_plannedBudget=Sum(
+                    "finances__value",
+                    default=0,
+                    filter=Q(finances__forFrameView=forcedToFrame)
+                    & Q(finances__year=year + 7),
+                ),
+                year8_plannedBudget=Sum(
+                    "finances__value",
+                    default=0,
+                    filter=Q(finances__forFrameView=forcedToFrame)
+                    & Q(finances__year=year + 8),
+                ),
+                year9_plannedBudget=Sum(
+                    "finances__value",
+                    default=0,
+                    filter=Q(finances__forFrameView=forcedToFrame)
+                    & Q(finances__year=year + 9),
+                ),
+                year10_plannedBudget=Sum(
+                    "finances__value",
+                    default=0,
+                    filter=Q(finances__forFrameView=forcedToFrame)
+                    & Q(finances__year=year + 10),
+                ),
+                budgetOverrunAmount=Sum("budgetOverrunAmount", default=0),
+            )
+            if _type == "ProjectGroup":
+                summedFinances["projectBudgets"] = relatedProjects.aggregate(
+                    projectBudgets=Sum("costForecast", default=0)
+                )["projectBudgets"]
+
+            summedFinances["year"] = year
+            summedFinances["year0"] = {
+                **self.get_frameBudget_and_budgetChange(
+                    instance=instance,
+                    year=year,
+                ),
+                "plannedBudget": int(summedFinances.pop("year0_plannedBudget")),
+            }
+            summedFinances["year1"] = {
+                **self.get_frameBudget_and_budgetChange(
+                    instance=instance,
+                    year=year + 1,
+                ),
+                "plannedBudget": int(summedFinances.pop("year1_plannedBudget")),
+            }
+            summedFinances["year2"] = {
+                **self.get_frameBudget_and_budgetChange(
+                    instance=instance,
+                    year=year + 2,
+                ),
+                "plannedBudget": int(summedFinances.pop("year2_plannedBudget")),
+            }
+            summedFinances["year3"] = {
+                **self.get_frameBudget_and_budgetChange(
+                    instance=instance,
+                    year=year + 3,
+                ),
+                "plannedBudget": int(summedFinances.pop("year3_plannedBudget")),
+            }
+            summedFinances["year4"] = {
+                **self.get_frameBudget_and_budgetChange(
+                    instance=instance,
+                    year=year + 4,
+                ),
+                "plannedBudget": int(summedFinances.pop("year4_plannedBudget")),
+            }
+            summedFinances["year5"] = {
+                **self.get_frameBudget_and_budgetChange(
+                    instance=instance,
+                    year=year + 5,
+                ),
+                "plannedBudget": int(summedFinances.pop("year5_plannedBudget")),
+            }
+            summedFinances["year6"] = {
+                **self.get_frameBudget_and_budgetChange(
+                    instance=instance,
+                    year=year + 6,
+                ),
+                "plannedBudget": int(summedFinances.pop("year6_plannedBudget")),
+            }
+            summedFinances["year7"] = {
+                **self.get_frameBudget_and_budgetChange(
+                    instance=instance,
+                    year=year + 7,
+                ),
+                "plannedBudget": int(summedFinances.pop("year7_plannedBudget")),
+            }
+            summedFinances["year8"] = {
+                **self.get_frameBudget_and_budgetChange(
+                    instance=instance,
+                    year=year + 8,
+                ),
+                "plannedBudget": int(summedFinances.pop("year8_plannedBudget")),
+            }
+            summedFinances["year9"] = {
+                **self.get_frameBudget_and_budgetChange(
+                    instance=instance,
+                    year=year + 9,
+                ),
+                "plannedBudget": int(summedFinances.pop("year9_plannedBudget")),
+            }
+            summedFinances["year10"] = {
+                **self.get_frameBudget_and_budgetChange(
+                    instance=instance,
+                    year=year + 10,
+                ),
+                "plannedBudget": int(summedFinances.pop("year10_plannedBudget")),
+            }
+
+            cache.set(
+                str(instance.id) + "/{}/{}".format(forcedToFrame, year),
+                summedFinances,
+                60 * 60 * 2,
+            )
+            # delete this instance from relationEffected
+            if relationEffectedCached != None and instance in relationEffectedCached:
+                relationEffectedCached.remove(instance)
+            cache.set("relationEffected", relationEffectedCached)
+
+        else:
+            summedFinances = cache.get(
+                str(instance.id) + "/{}/{}".format(forcedToFrame, year)
+            )
 
         return summedFinances
 

--- a/infraohjelmointi_api/serializers/FinancialSumSerializer.py
+++ b/infraohjelmointi_api/serializers/FinancialSumSerializer.py
@@ -170,7 +170,6 @@ class FinancialSumSerializer(serializers.ModelSerializer):
             )
         ):
             # this instance needs new financial sums to be calculated
-
             relatedProjects = self.get_related_projects(instance=instance, _type=_type)
 
             summedFinances = relatedProjects.aggregate(
@@ -325,11 +324,12 @@ class FinancialSumSerializer(serializers.ModelSerializer):
                 ),
                 "plannedBudget": int(summedFinances.pop("year10_plannedBudget")),
             }
-
+            # caching calculations for 24 hours
+            # will get updated according to relations which change
             cache.set(
                 str(instance.id) + "/{}/{}".format(forcedToFrame, year),
                 summedFinances,
-                60 * 60 * 2,
+                60 * 60 * 24,
             )
             # delete this instance from relationEffected
             if relationEffectedCached != None and instance in relationEffectedCached:

--- a/infraohjelmointi_api/signals.py
+++ b/infraohjelmointi_api/signals.py
@@ -106,14 +106,14 @@ def get_financial_sums(
             project=project
         )
 
-        # set cache for 2 hours
+        # set cache for 24 hours
         cache.set(
             "relationEffected",
             [
                 *projectRelations["coordination"].values(),
                 *projectRelations["planning"].values(),
             ],
-            60 * 60 * 2,
+            60 * 60 * 24,
         )
         logger.debug("Setting levels effected by ProjectFinancial change to cache")
         for viewType, instances in projectRelations.items():

--- a/infraohjelmointi_api/signals.py
+++ b/infraohjelmointi_api/signals.py
@@ -13,6 +13,7 @@ from .services import ClassFinancialService, ProjectService, LocationFinancialSe
 from .models import ProjectFinancial
 from django.dispatch import receiver
 from django_eventstream import send_event
+from django.core.cache import cache
 
 logger = logging.getLogger("infraohjelmointi_api")
 
@@ -96,12 +97,25 @@ def get_financial_sums(
         },
     }
     if _type == "ProjectFinancial":
+        # check which projcet relations get effected by this project,
+        # set those relations in cache
+
         project = instance.project
         forFrameView = instance.forFrameView
         projectRelations = ProjectService.get_project_class_location_group_relations(
             project=project
         )
 
+        # set cache for 2 hours
+        cache.set(
+            "relationEffected",
+            [
+                *projectRelations["coordination"].values(),
+                *projectRelations["planning"].values(),
+            ],
+            60 * 60 * 2,
+        )
+        logger.debug("Setting levels effected by ProjectFinancial change to cache")
         for viewType, instances in projectRelations.items():
             if viewType == "planning" and forFrameView == True:
                 continue
@@ -147,6 +161,17 @@ def get_financial_sums(
         classRelations = ClassFinancialService.get_coordinator_class_and_related_class(
             instance=instance
         )
+
+        # set cache for 2 hours
+        cache.set(
+            "relationEffected",
+            [
+                *classRelations["coordination"].values(),
+                *classRelations["planning"].values(),
+            ],
+            60 * 60 * 2,
+        )
+        logger.debug("Setting levels effected by ClassFinancial change to cache")
         for viewType, classValues in classRelations.items():
             for classType, classInstance in classValues.items():
                 if classInstance != None:
@@ -161,6 +186,16 @@ def get_financial_sums(
                 instance=instance
             )
         )
+
+        cache.set(
+            "relationEffected",
+            [
+                *locationFinancialRelations["coordination"].values(),
+                *locationFinancialRelations["planning"].values(),
+            ],
+            60 * 60 * 2,
+        )
+        logger.debug("Setting levels effected by LocationFinancial change to cache")
         for viewType, instances in locationFinancialRelations.items():
             for instanceType, instance in instances.items():
                 if instance != None:

--- a/infraohjelmointi_api/tests/test_Projects.py
+++ b/infraohjelmointi_api/tests/test_Projects.py
@@ -2455,7 +2455,7 @@ class ProjectTestCase(TestCase):
 
         self.assertEqual(
             "The field budgetProposalCurrentYearPlus0 cannot be modified when the project is locked",
-            response.json()["non_field_errors"][0],
+            response.json()["budgetProposalCurrentYearPlus0"],
         )
 
         data = {"finances": {"budgetProposalCurrentYearPlus1": 200}}
@@ -2471,7 +2471,7 @@ class ProjectTestCase(TestCase):
         )
         self.assertEqual(
             "The field budgetProposalCurrentYearPlus1 cannot be modified when the project is locked",
-            response.json()["non_field_errors"][0],
+            response.json()["budgetProposalCurrentYearPlus1"],
         )
 
         data = {"finances": {"budgetProposalCurrentYearPlus2": 200}}
@@ -2487,7 +2487,7 @@ class ProjectTestCase(TestCase):
         )
         self.assertEqual(
             "The field budgetProposalCurrentYearPlus2 cannot be modified when the project is locked",
-            response.json()["non_field_errors"][0],
+            response.json()["budgetProposalCurrentYearPlus2"],
         )
 
         data = {"finances": {"preliminaryCurrentYearPlus3": 200}}
@@ -2503,7 +2503,7 @@ class ProjectTestCase(TestCase):
         )
         self.assertEqual(
             "The field preliminaryCurrentYearPlus3 cannot be modified when the project is locked",
-            response.json()["non_field_errors"][0],
+            response.json()["preliminaryCurrentYearPlus3"],
         )
 
         data = {"finances": {"preliminaryCurrentYearPlus4": 200}}
@@ -2519,7 +2519,7 @@ class ProjectTestCase(TestCase):
         )
         self.assertEqual(
             "The field preliminaryCurrentYearPlus4 cannot be modified when the project is locked",
-            response.json()["non_field_errors"][0],
+            response.json()["preliminaryCurrentYearPlus4"],
         )
 
         data = {"finances": {"preliminaryCurrentYearPlus5": 200}}
@@ -2535,7 +2535,7 @@ class ProjectTestCase(TestCase):
         )
         self.assertEqual(
             "The field preliminaryCurrentYearPlus5 cannot be modified when the project is locked",
-            response.json()["non_field_errors"][0],
+            response.json()["preliminaryCurrentYearPlus5"],
         )
 
         data = {"finances": {"preliminaryCurrentYearPlus6": 200}}
@@ -2551,7 +2551,7 @@ class ProjectTestCase(TestCase):
         )
         self.assertEqual(
             "The field preliminaryCurrentYearPlus6 cannot be modified when the project is locked",
-            response.json()["non_field_errors"][0],
+            response.json()["preliminaryCurrentYearPlus6"],
         )
 
         data = {"finances": {"preliminaryCurrentYearPlus7": 200}}
@@ -2567,7 +2567,7 @@ class ProjectTestCase(TestCase):
         )
         self.assertEqual(
             "The field preliminaryCurrentYearPlus7 cannot be modified when the project is locked",
-            response.json()["non_field_errors"][0],
+            response.json()["preliminaryCurrentYearPlus7"],
         )
 
         data = {"finances": {"preliminaryCurrentYearPlus8": 200}}
@@ -2583,7 +2583,7 @@ class ProjectTestCase(TestCase):
         )
         self.assertEqual(
             "The field preliminaryCurrentYearPlus8 cannot be modified when the project is locked",
-            response.json()["non_field_errors"][0],
+            response.json()["preliminaryCurrentYearPlus8"],
         )
 
         data = {"finances": {"preliminaryCurrentYearPlus9": 200}}
@@ -2599,7 +2599,7 @@ class ProjectTestCase(TestCase):
         )
         self.assertEqual(
             "The field preliminaryCurrentYearPlus9 cannot be modified when the project is locked",
-            response.json()["non_field_errors"][0],
+            response.json()["preliminaryCurrentYearPlus9"],
         )
 
         data = {"finances": {"preliminaryCurrentYearPlus10": 200}}
@@ -2615,7 +2615,7 @@ class ProjectTestCase(TestCase):
         )
         self.assertEqual(
             "The field preliminaryCurrentYearPlus10 cannot be modified when the project is locked",
-            response.json()["non_field_errors"][0],
+            response.json()["preliminaryCurrentYearPlus10"],
         )
 
     def test_locking_project_twice(self):

--- a/infraohjelmointi_api/validators/ProjectFinancialValidators/LockedFieldsValidator.py
+++ b/infraohjelmointi_api/validators/ProjectFinancialValidators/LockedFieldsValidator.py
@@ -28,7 +28,12 @@ class LockedFieldsValidator:
             for field in lockedFields:
                 if allFields.get(field, None) is not None:
                     raise ValidationError(
-                        "The field {} cannot be modified when the project is locked".format(
-                            yearToFieldMapping[projectFinancialInstance.year]
-                        )
+                        detail={
+                            yearToFieldMapping[
+                                projectFinancialInstance.year
+                            ]: "The field {} cannot be modified when the project is locked".format(
+                                yearToFieldMapping[projectFinancialInstance.year]
+                            )
+                        },
+                        code="project_locked",
                     )

--- a/infraohjelmointi_api/views/ConstructionPhaseDetailViewSet.py
+++ b/infraohjelmointi_api/views/ConstructionPhaseDetailViewSet.py
@@ -2,6 +2,8 @@ from .BaseViewSet import BaseViewSet
 from infraohjelmointi_api.serializers.ConstructionPhaseDetailSerializer import (
     ConstructionPhaseDetailSerializer,
 )
+from django.utils.decorators import method_decorator
+from django.views.decorators.cache import cache_page
 
 
 class ConstructionPhaseDetailViewSet(BaseViewSet):
@@ -10,3 +12,7 @@ class ConstructionPhaseDetailViewSet(BaseViewSet):
     """
 
     serializer_class = ConstructionPhaseDetailSerializer
+
+    @method_decorator(cache_page(60 * 60 * 24))
+    def list(self, request, *args, **kwargs):
+        return super().list(request, *args, **kwargs)

--- a/infraohjelmointi_api/views/ConstructionPhaseViewSet.py
+++ b/infraohjelmointi_api/views/ConstructionPhaseViewSet.py
@@ -2,6 +2,8 @@ from .BaseViewSet import BaseViewSet
 from infraohjelmointi_api.serializers.ConstructionPhaseSerializer import (
     ConstructionPhaseSerializer,
 )
+from django.utils.decorators import method_decorator
+from django.views.decorators.cache import cache_page
 
 
 class ConstructionPhaseViewSet(BaseViewSet):
@@ -10,3 +12,7 @@ class ConstructionPhaseViewSet(BaseViewSet):
     """
 
     serializer_class = ConstructionPhaseSerializer
+
+    @method_decorator(cache_page(60 * 60 * 24))
+    def list(self, request, *args, **kwargs):
+        return super().list(request, *args, **kwargs)

--- a/infraohjelmointi_api/views/PlanningPhaseViewSet.py
+++ b/infraohjelmointi_api/views/PlanningPhaseViewSet.py
@@ -2,6 +2,8 @@ from .BaseViewSet import BaseViewSet
 from infraohjelmointi_api.serializers.PlanningPhaseSerializer import (
     PlanningPhaseSerializer,
 )
+from django.utils.decorators import method_decorator
+from django.views.decorators.cache import cache_page
 
 
 class PlanningPhaseViewSet(BaseViewSet):
@@ -10,3 +12,7 @@ class PlanningPhaseViewSet(BaseViewSet):
     """
 
     serializer_class = PlanningPhaseSerializer
+
+    @method_decorator(cache_page(60 * 60 * 24))
+    def list(self, request, *args, **kwargs):
+        return super().list(request, *args, **kwargs)

--- a/infraohjelmointi_api/views/ProjectAreaViewSet.py
+++ b/infraohjelmointi_api/views/ProjectAreaViewSet.py
@@ -1,5 +1,7 @@
 from .BaseViewSet import BaseViewSet
 from infraohjelmointi_api.serializers.ProjectAreaSerializer import ProjectAreaSerializer
+from django.utils.decorators import method_decorator
+from django.views.decorators.cache import cache_page
 
 
 class ProjectAreaViewSet(BaseViewSet):
@@ -8,3 +10,7 @@ class ProjectAreaViewSet(BaseViewSet):
     """
 
     serializer_class = ProjectAreaSerializer
+
+    @method_decorator(cache_page(60 * 60 * 24))
+    def list(self, request, *args, **kwargs):
+        return super().list(request, *args, **kwargs)

--- a/infraohjelmointi_api/views/ProjectCategoryViewSet.py
+++ b/infraohjelmointi_api/views/ProjectCategoryViewSet.py
@@ -2,6 +2,8 @@ from .BaseViewSet import BaseViewSet
 from infraohjelmointi_api.serializers.ProjectCategorySerializer import (
     ProjectCategorySerializer,
 )
+from django.utils.decorators import method_decorator
+from django.views.decorators.cache import cache_page
 
 
 class ProjectCategoryViewSet(BaseViewSet):
@@ -10,3 +12,7 @@ class ProjectCategoryViewSet(BaseViewSet):
     """
 
     serializer_class = ProjectCategorySerializer
+
+    @method_decorator(cache_page(60 * 60 * 24))
+    def list(self, request, *args, **kwargs):
+        return super().list(request, *args, **kwargs)

--- a/infraohjelmointi_api/views/ProjectClassViewSet.py
+++ b/infraohjelmointi_api/views/ProjectClassViewSet.py
@@ -56,6 +56,7 @@ class ProjectClassViewSet(BaseClassLocationViewSet):
             JSON
                 List of ProjectClass instances with financial sums for projects under each class
         """
+
         year = request.query_params.get("year", date.today().year)
         forcedToFrame = request.query_params.get("forcedToFrame", False)
         if forcedToFrame in ["False", "false"]:
@@ -79,6 +80,7 @@ class ProjectClassViewSet(BaseClassLocationViewSet):
                 "forcedToFrame": forcedToFrame,
             },
         )
+
         return Response(serializer.data)
 
     @action(

--- a/infraohjelmointi_api/views/ProjectPhaseViewSet.py
+++ b/infraohjelmointi_api/views/ProjectPhaseViewSet.py
@@ -2,6 +2,8 @@ from .BaseViewSet import BaseViewSet
 from infraohjelmointi_api.serializers.ProjectPhaseSerializer import (
     ProjectPhaseSerializer,
 )
+from django.utils.decorators import method_decorator
+from django.views.decorators.cache import cache_page
 
 
 class ProjectPhaseViewSet(BaseViewSet):
@@ -10,3 +12,7 @@ class ProjectPhaseViewSet(BaseViewSet):
     """
 
     serializer_class = ProjectPhaseSerializer
+
+    @method_decorator(cache_page(60 * 60 * 24))
+    def list(self, request, *args, **kwargs):
+        return super().list(request, *args, **kwargs)

--- a/infraohjelmointi_api/views/ProjectPriorityViewSet.py
+++ b/infraohjelmointi_api/views/ProjectPriorityViewSet.py
@@ -2,6 +2,8 @@ from .BaseViewSet import BaseViewSet
 from infraohjelmointi_api.serializers.ProjectPrioritySerializer import (
     ProjectPrioritySerializer,
 )
+from django.utils.decorators import method_decorator
+from django.views.decorators.cache import cache_page
 
 
 class ProjectPriorityViewSet(BaseViewSet):
@@ -10,3 +12,7 @@ class ProjectPriorityViewSet(BaseViewSet):
     """
 
     serializer_class = ProjectPrioritySerializer
+
+    @method_decorator(cache_page(60 * 60 * 24))
+    def list(self, request, *args, **kwargs):
+        return super().list(request, *args, **kwargs)

--- a/infraohjelmointi_api/views/ProjectQualityLevelViewSet.py
+++ b/infraohjelmointi_api/views/ProjectQualityLevelViewSet.py
@@ -2,6 +2,8 @@ from .BaseViewSet import BaseViewSet
 from infraohjelmointi_api.serializers.ProjectQualityLevelSerializer import (
     ProjectQualityLevelSerializer,
 )
+from django.utils.decorators import method_decorator
+from django.views.decorators.cache import cache_page
 
 
 class ProjectQualityLevelViewSet(BaseViewSet):
@@ -10,3 +12,7 @@ class ProjectQualityLevelViewSet(BaseViewSet):
     """
 
     serializer_class = ProjectQualityLevelSerializer
+
+    @method_decorator(cache_page(60 * 60 * 24))
+    def list(self, request, *args, **kwargs):
+        return super().list(request, *args, **kwargs)

--- a/infraohjelmointi_api/views/ProjectResponsibleZoneViewSet.py
+++ b/infraohjelmointi_api/views/ProjectResponsibleZoneViewSet.py
@@ -3,6 +3,8 @@ from .BaseViewSet import BaseViewSet
 from infraohjelmointi_api.serializers.ProjectResponsibleZoneSerializer import (
     ProjectResponsibleZoneSerializer,
 )
+from django.utils.decorators import method_decorator
+from django.views.decorators.cache import cache_page
 
 
 class ProjectResponsibleZoneViewSet(BaseViewSet):
@@ -11,3 +13,7 @@ class ProjectResponsibleZoneViewSet(BaseViewSet):
     """
 
     serializer_class = ProjectResponsibleZoneSerializer
+
+    @method_decorator(cache_page(60 * 60 * 24))
+    def list(self, request, *args, **kwargs):
+        return super().list(request, *args, **kwargs)

--- a/infraohjelmointi_api/views/ProjectRiskViewSet.py
+++ b/infraohjelmointi_api/views/ProjectRiskViewSet.py
@@ -1,5 +1,7 @@
 from .BaseViewSet import BaseViewSet
 from infraohjelmointi_api.serializers.ProjectRiskSerializer import ProjectRiskSerializer
+from django.utils.decorators import method_decorator
+from django.views.decorators.cache import cache_page
 
 
 class ProjectRiskViewSet(BaseViewSet):
@@ -8,3 +10,7 @@ class ProjectRiskViewSet(BaseViewSet):
     """
 
     serializer_class = ProjectRiskSerializer
+
+    @method_decorator(cache_page(60 * 60 * 24))
+    def list(self, request, *args, **kwargs):
+        return super().list(request, *args, **kwargs)

--- a/infraohjelmointi_api/views/ProjectTypeViewSet.py
+++ b/infraohjelmointi_api/views/ProjectTypeViewSet.py
@@ -1,5 +1,7 @@
 from .BaseViewSet import BaseViewSet
 from infraohjelmointi_api.serializers.ProjectTypeSerializer import ProjectTypeSerializer
+from django.utils.decorators import method_decorator
+from django.views.decorators.cache import cache_page
 
 
 class ProjectTypeViewSet(BaseViewSet):
@@ -8,3 +10,7 @@ class ProjectTypeViewSet(BaseViewSet):
     """
 
     serializer_class = ProjectTypeSerializer
+
+    @method_decorator(cache_page(60 * 60 * 24))
+    def list(self, request, *args, **kwargs):
+        return super().list(request, *args, **kwargs)

--- a/infraohjelmointi_api/views/ProjectViewSet.py
+++ b/infraohjelmointi_api/views/ProjectViewSet.py
@@ -129,23 +129,22 @@ class ProjectViewSet(BaseViewSet):
             )
             financeInstances = []
             for field in finances.keys():
-                (
-                    financeInstance,
-                    created,
-                ) = ProjectFinancialService.get_or_create(
+                if hasattr(project, "lock"):
+                    raise ValidationError(
+                        detail={
+                            field: "The field {} cannot be modified when the project is locked".format(
+                                field
+                            )
+                        },
+                        code="project_locked",
+                    )
+                financeInstance = ProjectFinancial(
+                    project=project,
+                    value=finances[field],
                     year=fieldToYearMapping[field],
-                    project_id=project.id,
                     forFrameView=forcedToFrame,
                 )
-                ProjectFinancialSerializer(
-                    financeInstance,
-                    data={"value": finances[field]},
-                    partial=True,
-                    many=False,
-                    context={"finance_year": year},
-                ).is_valid(raise_exception=True)
 
-                financeInstance.value = finances[field]
                 financeInstances.append(financeInstance)
                 if (
                     forcedToFrame == False

--- a/infraohjelmointi_api/views/ProjectViewSet.py
+++ b/infraohjelmointi_api/views/ProjectViewSet.py
@@ -166,11 +166,15 @@ class ProjectViewSet(BaseViewSet):
                 updatedFinanceInstance = ProjectFinancialService.update_or_create_bulk(
                     project_financials=financeInstances
                 )[0]
+                # adding finance_year here so that on save the instance that gets to the post_save signal has this value on finance_update
+                updatedFinanceInstance.finance_year = year
                 post_save.send(
                     ProjectFinancial, instance=updatedFinanceInstance, created=False
                 )
         # adding forcedToFrame here so that on save the instance that gets to the post_save signal has this value
         project.forcedToFrame = forcedToFrame
+        # adding finance_year here so that on save the instance that gets to the post_save signal has this value
+        project.finance_year = year
         projectSerializer = self.get_serializer(
             project,
             data=request.data,

--- a/infraohjelmointi_api/views/ProjectViewSet.py
+++ b/infraohjelmointi_api/views/ProjectViewSet.py
@@ -16,6 +16,7 @@ from infraohjelmointi_api.models import (
     ProjectGroup,
     ProjectClass,
     ProjectLocation,
+    ProjectFinancial,
 )
 from infraohjelmointi_api.services import (
     ProjectWiseService,
@@ -36,6 +37,7 @@ import uuid
 from rest_framework import status
 from itertools import chain
 from django.db.models import Count, Case, When, Q
+from django.db.models.signals import post_save
 
 
 class ProjectFilter(django_filters.FilterSet):
@@ -125,24 +127,49 @@ class ProjectViewSet(BaseViewSet):
                     start_year=year
                 )
             )
+            financeInstances = []
             for field in finances.keys():
                 (
-                    projectFinancialObject,
+                    financeInstance,
                     created,
                 ) = ProjectFinancialService.get_or_create(
                     year=fieldToYearMapping[field],
                     project_id=project.id,
                     forFrameView=forcedToFrame,
                 )
-                financeSerializer = ProjectFinancialSerializer(
-                    projectFinancialObject,
+                ProjectFinancialSerializer(
+                    financeInstance,
                     data={"value": finances[field]},
                     partial=True,
                     many=False,
                     context={"finance_year": year},
+                ).is_valid(raise_exception=True)
+
+                financeInstance.value = finances[field]
+                financeInstances.append(financeInstance)
+                if (
+                    forcedToFrame == False
+                    and not ProjectFinancialService.instance_exists(
+                        project_id=project.id,
+                        year=fieldToYearMapping[field],
+                        forFrameView=True,
+                    )
+                ):
+                    frameViewFinanceObject = ProjectFinancial(
+                        project=project,
+                        year=fieldToYearMapping[field],
+                        value=finances[field],
+                        forFrameView=True,
+                    )
+                    financeInstances.append(frameViewFinanceObject)
+
+            if len(financeInstances) > 0:
+                updatedFinanceInstance = ProjectFinancialService.update_or_create_bulk(
+                    project_financials=financeInstances
+                )[0]
+                post_save.send(
+                    ProjectFinancial, instance=updatedFinanceInstance, created=False
                 )
-                financeSerializer.is_valid(raise_exception=True)
-                financeSerializer.save()
         # adding forcedToFrame here so that on save the instance that gets to the post_save signal has this value
         project.forcedToFrame = forcedToFrame
         projectSerializer = self.get_serializer(

--- a/project/settings.py
+++ b/project/settings.py
@@ -244,6 +244,6 @@ CACHES = {
     "default": {
         "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
         "TIMEOUT": 60 * 60 * 2,  # 2 hour timeout default
-        "OPTIONS": {"MAX_ENTRIES": 3000},
+        "OPTIONS": {"MAX_ENTRIES": 6000},
     }
 }

--- a/project/settings.py
+++ b/project/settings.py
@@ -236,3 +236,14 @@ LOGGING = {
         # },
     },
 }
+
+
+# Caching framework defaults
+
+CACHES = {
+    "default": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "TIMEOUT": 60 * 60 * 2,  # 2 hour timeout default
+        "OPTIONS": {"MAX_ENTRIES": 3000},
+    }
+}


### PR DESCRIPTION
- Optimised finance calculations by caching them in local memory for 24 hours
- Added functionality to reset changed calculations in the cache through signals
- Enabled caching on endpoints with values which don't often change
- Changed frameBudget calculations by moving some of them to Pandas to account for location levels under classes
- Fixed an issue where finance change in future or past levels would give back wrong information in finance-update event
- Fixed issue for multiple finance update events being sent to the FE on timeline move
- Fixed tests to pass

