### PR TITLE
Fix: frameBudget overlap alert

### DIFF
--- a/infraohjelmointi_api/serializers/FinancialSumSerializer.py
+++ b/infraohjelmointi_api/serializers/FinancialSumSerializer.py
@@ -1,4 +1,5 @@
 from datetime import date
+import logging
 from infraohjelmointi_api.models import (
     Project,
     ClassFinancial,
@@ -29,6 +30,8 @@ from django.db.models import (
     Subquery,
 )
 from django.db.models.functions import Coalesce
+
+logger = logging.getLogger("infraohjelmointi_api")
 
 
 class FinancialSumSerializer(serializers.ModelSerializer):
@@ -179,10 +182,7 @@ class FinancialSumSerializer(serializers.ModelSerializer):
             "isFrameBudgetOverlap": False
             if _type == "ProjectLocation"
             else childClassQueryResult["subChildrenOverlapCount"] > 0
-            or (
-                financeInstance != None
-                and (childClassQueryResult["childSums"] > financeInstance.frameBudget)
-            ),
+            ,
         }
 
     # try caching this whole result for a class

--- a/infraohjelmointi_api/serializers/FinancialSumSerializer.py
+++ b/infraohjelmointi_api/serializers/FinancialSumSerializer.py
@@ -1,5 +1,4 @@
 from datetime import date
-import logging
 from infraohjelmointi_api.models import (
     Project,
     ClassFinancial,
@@ -30,8 +29,6 @@ from django.db.models import (
     Subquery,
 )
 from django.db.models.functions import Coalesce
-
-logger = logging.getLogger("infraohjelmointi_api")
 
 
 class FinancialSumSerializer(serializers.ModelSerializer):


### PR DESCRIPTION
- Fixed frameBudget overlap alert
- Now frameBudget alert icon should only pop up if the sum of frame budgets of classes/locations directly under the class is bigger than the frame budget
- Ticket: [https://futurice.atlassian.net/browse/HKISD-8](https://futurice.atlassian.net/browse/HKISD-8)