### PR TITLE
Update README how to populate projectDistrict_id column

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,6 +147,13 @@ Fix known issues from database:
   infraohjelmointi_api_db=# \i fix-database.sql
   ```
 
+Update projects' missing `projectDistrict_id` data with `infraohjelmointi_api_projectdistrict.id`.
+
+  ```bash
+  $ psql $DATABASE_URL
+  infraohjelmointi_api_db=# \i update-districts.sql
+  ```
+
 ### Other Optional File Imports
 
 Import project location options:


### PR DESCRIPTION
- Update README about how to populate `infraohjelmointi_api_project.projectDistrict_id` column after #106 release
  - With this projects will get Suurpiiri data on project cards.