### PR TITLE
HKISD-41: change hierarchy import and queries

### DIFF
--- a/fix-database.sql
+++ b/fix-database.sql
@@ -1,9 +1,11 @@
 --Set correct location numbers
+
 UPDATE infraohjelmointi_api_projectlocation SET name = '2. Kluuvi' WHERE name = '3. Kluuvi';
 UPDATE infraohjelmointi_api_projectlocation SET name = '38. Malmi' WHERE name = '37. Malmi';
 UPDATE infraohjelmointi_api_projectlocation SET name = '37. Pukinmäki' WHERE name = '38. Pukinmäki';
 
 --Correct typos
+
 UPDATE infraohjelmointi_api_projectclass SET name = REPLACE(name, 'Liikunta-Alueet', 'Liikunta-alueet') WHERE name LIKE '%Liikunta-Alueet%';
 UPDATE infraohjelmointi_api_projectclass SET path = REPLACE(path, 'Liikunta-Alueet', 'Liikunta-alueet') WHERE path LIKE '%Liikunta-Alueet%';
 UPDATE infraohjelmointi_api_projectclass SET name = REPLACE(name, 'Ranta-Alueiden', 'Ranta-alueiden') WHERE name LIKE '%Ranta-Alueiden%';
@@ -18,15 +20,6 @@ UPDATE infraohjelmointi_api_projectclass SET name = REPLACE(name, 'umen vastaano
 UPDATE infraohjelmointi_api_projectclass SET path = REPLACE(path, 'umen vastaanottopaikat', 'umenvastaanottopaikat') WHERE path LIKE '%umen vastaanottopaikat%';
 
 --Add missing 'suurpiiri' text for locations (name -column)
+
 UPDATE infraohjelmointi_api_projectlocation SET name = CONCAT(name, ' suurpiiri') WHERE name IN ('Eteläinen', 'Läntinen', 'Kaakkoinen', 'Keskinen', 'Pohjoinen', 'Koillinen', 'Itäinen') AND NOT name LIKE '%suurpiiri%';
 UPDATE infraohjelmointi_api_projectlocation SET name = 'Östersundomin suurpiiri' WHERE name = 'Östersundom';
-
---Add missing 'suurpiiri' text for locations (path -column)
-UPDATE infraohjelmointi_api_projectlocation SET path = REPLACE(path, 'Koillinen', 'Koillinen suurpiiri') WHERE path LIKE '%Koillinen%' AND NOT path LIKE '%suurpiiri%';
-UPDATE infraohjelmointi_api_projectlocation SET path = REPLACE(path, 'Eteläinen', 'Eteläinen suurpiiri') WHERE path LIKE '%Eteläinen%' AND NOT path LIKE '%suurpiiri%';
-UPDATE infraohjelmointi_api_projectlocation SET path = REPLACE(path, 'Läntinen', 'Läntinen suurpiiri') WHERE path LIKE '%Läntinen%' AND NOT path LIKE '%suurpiiri%';
-UPDATE infraohjelmointi_api_projectlocation SET path = REPLACE(path, 'Keskinen', 'Keskinen suurpiiri') WHERE path LIKE '%Keskinen%' AND NOT path LIKE '%suurpiiri%';
-UPDATE infraohjelmointi_api_projectlocation SET path = REPLACE(path, 'Pohjoinen', 'Pohjoinen suurpiiri') WHERE path LIKE '%Pohjoinen%' AND NOT path LIKE '%suurpiiri%';
-UPDATE infraohjelmointi_api_projectlocation SET path = REPLACE(path, 'Kaakkoinen', 'Kaakkoinen suurpiiri') WHERE path LIKE '%Kaakkoinen%' AND NOT path LIKE '%suurpiiri%';
-UPDATE infraohjelmointi_api_projectlocation SET path = REPLACE(path, 'Itäinen', 'Itäinen suurpiiri') WHERE path LIKE '%Itäinen%' AND NOT path LIKE '%suurpiiri%';
-UPDATE infraohjelmointi_api_projectlocation SET path = REPLACE(path, 'Östersundom', 'Östersundomin suurpiiri') WHERE path LIKE '%Östersundom%' AND NOT path LIKE '%suurpiiri%';

--- a/infraohjelmointi_api/management/commands/util/BudgetFileHandler.py
+++ b/infraohjelmointi_api/management/commands/util/BudgetFileHandler.py
@@ -148,7 +148,6 @@ class BudgetFileHandler(IExcelFileHandler):
         preliminaryCurrentYearPlus9 = row[28].value
 
         budget_list = [
-            0,
             budgetProposalCurrentYearPlus0 or 0,
             budgetProposalCurrentYearPlus1 or 0,
             budgetProposalCurrentYearPlus2 or 0,
@@ -291,4 +290,4 @@ class BudgetFileHandler(IExcelFileHandler):
                 content=notes,
                 project=project,
                 byPerson=None,
-            )
+            )#

--- a/infraohjelmointi_api/management/commands/util/BudgetFileHandler.py
+++ b/infraohjelmointi_api/management/commands/util/BudgetFileHandler.py
@@ -290,4 +290,4 @@ class BudgetFileHandler(IExcelFileHandler):
                 content=notes,
                 project=project,
                 byPerson=None,
-            )#
+            )

--- a/infraohjelmointi_api/management/commands/util/hierarchy.py
+++ b/infraohjelmointi_api/management/commands/util/hierarchy.py
@@ -35,6 +35,9 @@ color_map = {
     "FFF2DCDB": "OTHER CLASSIFICATION SUBCLASS",
 }
 
+SUURPIIRI = "suurpiiri"
+OSTERSUNDOM = "östersundom"
+OSTERSUNDOMIN_SUURPIIRI = "Östersundomin suurpiiri"
 
 def getColor(wb, color_object) -> str:
     try:
@@ -203,7 +206,7 @@ def buildHierarchies(
                 )
                 pv_class_stack.append(pv_class)
                 # if subslcass is also a district
-                if "suurpiiri" in pv_name.lower() or "östersundom" in pv_name.lower():
+                if SUURPIIRI in pv_name.lower() or OSTERSUNDOM in pv_name.lower():
                     related_to_district = proceedWithDistrict(
                         name=pv_name,
                         parent_class=pv_class_stack[-1],
@@ -404,11 +407,12 @@ def proceedWithDistrict(
     related_to: ProjectLocation = None,
 ) -> ProjectLocation:
     district = name.split(" ")[0].strip()
+    path = district
     # exceptional case for Östersundom which can be Östersundomin
-    if "östersundom" in name.lower():
-        district = "Östersundom"
-    elif "suurpiiri" in name.lower():
-        district = name.split(" ")[0].strip()
+    if name.lower() == OSTERSUNDOM:
+        district = OSTERSUNDOMIN_SUURPIIRI
+    elif SUURPIIRI in name.lower():
+        district = name.strip()
     else:
         district = sanitizeString(data=name.strip())
     print_with_bg_color(
@@ -428,7 +432,7 @@ def proceedWithDistrict(
         name=district,
         parentClass=parent_class,
         parent=None,
-        path=district,
+        path=path,
         forCoordinatorOnly=for_coordinator_only,
         relatedTo=related_to,
     )[0]
@@ -559,19 +563,24 @@ def buildHierarchiesAndProjects(
             )
 
             # if subslcass is also a district
-            if "suurpiiri" in name.lower():
+            if SUURPIIRI in name.lower():
                 location_stack.clear()  # remove all
-                district = name.split(" ")[0].strip()
-                # exceptional case for Östersundom which can be Östersundomin
+                district = name.strip()
+                path = district.split(" ")[0].strip()
+                # exceptional case for Östersundom which can be Östersundomin suurpiiri
                 district = (
-                    "Östersundom" if "östersundom" in district.lower() else district
+                    OSTERSUNDOMIN_SUURPIIRI if district.lower() == OSTERSUNDOM else district
                 )
+                path = (
+                    OSTERSUNDOM.capitalize() if "Östersundomin" in path else path
+                )
+
                 location_stack.append(
                     ProjectLocationService.get_or_create(
                         name=district,
                         parentClass=class_stack[-1],
                         parent=None,
-                        path=district,
+                        path=path,
                         forCoordinatorOnly=for_coordinator_only,
                     )[0]
                 )
@@ -579,17 +588,21 @@ def buildHierarchiesAndProjects(
             location_stack.clear()  # remove all
             type = "DISTRICT"
             indention = 3
-            district = (
+            district = name
+            path = (
                 name.split(" ")[0].strip() if "suurpiiri" in name.lower() else name
+            )
+            path = (
+                OSTERSUNDOM.capitalize() if "Östersundomin" in path else path
             )
 
             # exceptional case for Östersundom which can be Östersundomin
-            district = "Östersundom" if "östersundom" in district.lower() else district
+            district = OSTERSUNDOMIN_SUURPIIRI if district.lower() == OSTERSUNDOM else district
             location_stack.append(
                 ProjectLocationService.get_or_create(
                     name=district,
                     parent=None,
-                    path=district,
+                    path=path,
                     parentClass=class_stack[-1],
                     forCoordinatorOnly=for_coordinator_only,
                 )[0]
@@ -709,7 +722,7 @@ def buildHierarchiesAndProjects(
             cell_color,
         )
 
-        if type == "SUB CLASS" and "suurpiiri" in name:
+        if type == "SUB CLASS" and SUURPIIRI in name:
             print_with_bg_color(
                 "{}'{}' will be used as '{}' ({}) too at line {}. Its class path is '{}', and location path is '{}'.".format(
                     " " * indention,


### PR DESCRIPTION
- Remove "suurpiiri" string from _projectlocation_ table _path_ column
  - Helps adding data to _project_ and _projectgroup_ tables _projectDistrict_id_ and _location_id_ columns 

To test locally:
- rebuild API from zero (docker-compose down --volumes && docker-compose up)
- import excels (hierarchy and projects)
- import project location options with manage.py (locationimporter)
- run update-districts.sql on PSQL to populate projectDistrict_id and location_id columns 
- ! check that local environment is similar as prod location
- run fix-database.sql on PSQL
- import excels which adds missing locations on hierarchy

To check:
- Hierarchies and projects look normal
  - no duplicates and some names includes word "suurpiiri"
- Hierarchy includes new empty locations
- When project card is opened, it shows information on Suurpiiri fields

Fixes:
- duplicates on hierarchy
- update-districts.sql would work correctly