### PR TITLE
After file import show budgets on UI from 2024 forward

### DIFF
--- a/infraohjelmointi_api/management/commands/util/BudgetFileHandler.py
+++ b/infraohjelmointi_api/management/commands/util/BudgetFileHandler.py
@@ -148,7 +148,6 @@ class BudgetFileHandler(IExcelFileHandler):
         preliminaryCurrentYearPlus9 = row[28].value
 
         budget_list = [
-            0,
             budgetProposalCurrentYearPlus0 or 0,
             budgetProposalCurrentYearPlus1 or 0,
             budgetProposalCurrentYearPlus2 or 0,


### PR DESCRIPTION
Previously importer did not add budget numbers under column 2023 because it was planned like that. With this PR this is now removed.