### PR TITLE
HKISD-48: Delete caching for summed finances

### DIFF
--- a/infraohjelmointi_api/serializers/FinancialSumSerializer.py
+++ b/infraohjelmointi_api/serializers/FinancialSumSerializer.py
@@ -357,13 +357,6 @@ class FinancialSumSerializer(serializers.ModelSerializer):
                 ),
                 "plannedBudget": int(summedFinances.pop("year10_plannedBudget")),
             }
-            # caching calculations for 24 hours
-            # will get updated according to relations which change
-            cache.set(
-                str(instance.id) + "/{}/{}".format(forcedToFrame, year),
-                summedFinances,
-                60 * 60 * 24,
-            )
 
             # delete this instance from relationEffected if it exists there since it has been updated now
             if (


### PR DESCRIPTION
https://futurice.atlassian.net/browse/HKISD-48

When user deleted a project, numbers were not updated because they were cached in the backend for 24 hours.