### PR TITLE
HKISD-28: fix project card finance save

### DIFF
--- a/infraohjelmointi_api/services/ProjectFinancialService.py
+++ b/infraohjelmointi_api/services/ProjectFinancialService.py
@@ -98,7 +98,7 @@ class ProjectFinancialService:
             start_year + 9: "preliminaryCurrentYearPlus9",
             start_year + 10: "preliminaryCurrentYearPlus10",
         }
-    
+
     @staticmethod
     def convert_financial_field_to_year(field_name: str, start_year: int):
         number = None

--- a/infraohjelmointi_api/services/ProjectFinancialService.py
+++ b/infraohjelmointi_api/services/ProjectFinancialService.py
@@ -98,22 +98,15 @@ class ProjectFinancialService:
             start_year + 9: "preliminaryCurrentYearPlus9",
             start_year + 10: "preliminaryCurrentYearPlus10",
         }
-
+    
     @staticmethod
-    def get_financial_field_to_year_mapping(start_year: int):
-        return {
-            "budgetProposalCurrentYearPlus0": start_year,
-            "budgetProposalCurrentYearPlus1": start_year + 1,
-            "budgetProposalCurrentYearPlus2": start_year + 2,
-            "preliminaryCurrentYearPlus3": start_year + 3,
-            "preliminaryCurrentYearPlus4": start_year + 4,
-            "preliminaryCurrentYearPlus5": start_year + 5,
-            "preliminaryCurrentYearPlus6": start_year + 6,
-            "preliminaryCurrentYearPlus7": start_year + 7,
-            "preliminaryCurrentYearPlus8": start_year + 8,
-            "preliminaryCurrentYearPlus9": start_year + 9,
-            "preliminaryCurrentYearPlus10": start_year + 10,
-        }
+    def convert_financial_field_to_year(field_name: str, start_year: int):
+        number = None
+        if field_name.startswith("budgetProposalCurrentYearPlus"):
+            number = int(field_name.replace("budgetProposalCurrentYearPlus", ""))
+        elif field_name.startswith("preliminaryCurrentYearPlus"):
+            number = int(field_name.replace("preliminaryCurrentYearPlus", ""))
+        return start_year + number
 
     @staticmethod
     def instance_exists(project_id: str, year: int, forFrameView: bool = False) -> bool:

--- a/infraohjelmointi_api/views/ProjectViewSet.py
+++ b/infraohjelmointi_api/views/ProjectViewSet.py
@@ -999,12 +999,12 @@ class ProjectViewSet(BaseViewSet):
                             # skip the year field in finances
                             if field == "year":
                                 continue
-                            financeYear = ProjectFinancialService.convert_financial_field_to_year(field, year)
+                            finance_year = ProjectFinancialService.convert_financial_field_to_year(field, year)
                             (
                                 projectFinancialObject,
                                 created,
                             ) = ProjectFinancialService.get_or_create(
-                                year=financeYear,
+                                year=finance_year,
                                 project_id=Project(id=financeData["project"]).id,
                                 forFrameView=forcedToFrame,
                             )

--- a/infraohjelmointi_api/views/ProjectViewSet.py
+++ b/infraohjelmointi_api/views/ProjectViewSet.py
@@ -152,8 +152,8 @@ class ProjectViewSet(BaseViewSet):
             data=request.data, project=updated_project
         )
         return Response(projectSerializer.data)
-    
-    def get_finance_instances(self, finances, project, forcedToFrame, year):
+
+    def get_finance_instances(self, finances, project, forced_to_frame, year):
         finance_instances = []
         for field in finances.keys():
                 if hasattr(project, "lock"):
@@ -174,12 +174,12 @@ class ProjectViewSet(BaseViewSet):
                     project=project,
                     value=finances[field],
                     year=finance_year,
-                    forFrameView=forcedToFrame,
+                    forFrameView=forced_to_frame,
                 )
 
                 finance_instances.append(finance_instance)
                 if (
-                    forcedToFrame == False
+                    forced_to_frame == False
                     and not ProjectFinancialService.instance_exists(
                         project_id=project.id,
                         year=finance_year,

--- a/infraohjelmointi_api/views/ProjectViewSet.py
+++ b/infraohjelmointi_api/views/ProjectViewSet.py
@@ -137,7 +137,7 @@ class ProjectViewSet(BaseViewSet):
                         code="project_locked",
                     )
                 if not finances[field]:
-                    logger.info("No budget set for key: {}", field)
+                    logger.info("No budget set for key: {}".format(field))
                     continue
 
                 financeYear = ProjectFinancialService.convert_financial_field_to_year(field, year)

--- a/infraohjelmointi_api/views/ProjectViewSet.py
+++ b/infraohjelmointi_api/views/ProjectViewSet.py
@@ -140,8 +140,6 @@ class ProjectViewSet(BaseViewSet):
                     logger.info("No budget set for key: {}", field)
                     continue
 
-                logger.info(finances[field])
-
                 financeYear = ProjectFinancialService.convert_financial_field_to_year(field, year)
                 financeInstance = ProjectFinancial(
                     project=project,


### PR DESCRIPTION
- There was a bug in saving the finances for a project, where if the finance year was outside startyear + 10 years, it gave a key error and the saving failed
- Code is now refactored so that finances can be saved to any year from the start year (start of timeline in UI) instead of just 10 years from it.
- UI PR about the same issue: https://github.com/City-of-Helsinki/infraohjelmointi-ui/pull/154