### PR TITLE
Set correct string as path when importing files on the first time

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,8 +1,11 @@
 static-files
 
 # Ignore Excel import files. Do not upload new excel files
-*.xlsx*
+*.xlsx
 *.zip
+
+# Ignore Zone Identifier files
+*:Zone.Identifier
 
 # Created by https://www.toptal.com/developers/gitignore/api/python,django,macos,vscode
 # Edit at https://www.toptal.com/developers/gitignore?templates=python,django,macos,vscode

--- a/infraohjelmointi_api/management/commands/util/hierarchy.py
+++ b/infraohjelmointi_api/management/commands/util/hierarchy.py
@@ -409,8 +409,9 @@ def proceedWithDistrict(
     district = name.split(" ")[0].strip()
     path = district
     # exceptional case for Östersundom which can be Östersundomin
-    if name.lower() == OSTERSUNDOM:
+    if district.lower() in [OSTERSUNDOM, "östersundomin"]:
         district = OSTERSUNDOMIN_SUURPIIRI
+        path = OSTERSUNDOM.capitalize()
     elif SUURPIIRI in name.lower():
         district = name.strip()
     else:


### PR DESCRIPTION
- Previously when hierarchy was imported, it created ProjectLocation table with incorrect path values.
  - When "Östersundomin suurpiiri" was imported, it set "Östersundomin" as the path. Correct path would be "Östersundom".