### PR TITLE
HKISD-70: Remove not needed old debug message when mapping PW data

### DIFF
--- a/infraohjelmointi_api/services/utils/ProjectWiseDataMapper.py
+++ b/infraohjelmointi_api/services/utils/ProjectWiseDataMapper.py
@@ -277,7 +277,6 @@ class ProjectWiseDataMapper:
                         result[mapped_field["values"][2]] = locations[2]
                 elif field == "personPlanning":
                     planningPersonModel = PersonService.get_by_id(value) if value else None
-                    logger.debug("planningPerson", planningPersonModel)
                     # fullname
                     result[mapped_field["values"][0]] = "{} {}".format(
                         planningPersonModel.lastName, planningPersonModel.firstName


### PR DESCRIPTION
While investigating HKISD-70 on PROD environment, I noticed old debug message that created error messages. Error messages comes when Logger tries to convert Person object to string which it failed to do. 

With this PR the error causing debug line will be removed.

An example of failed Logging error (Person object is empty):
```
--- Logging error ---
Traceback (most recent call last):
  File "/usr/lib/python3.11/logging/__init__.py", line 1110, in emit
    msg = self.format(record)
          ^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/logging/__init__.py", line 953, in format
    return fmt.format(record)
           ^^^^^^^^^^^^^^^^^^
  File "/app/project/customlogging/ColoredFormatter.py", line 27, in format
    return formatter.format(record)
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/logging/__init__.py", line 687, in format
    record.message = record.getMessage()
                     ^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/logging/__init__.py", line 377, in getMessage
    msg = msg % self.args
          ~~~~^~~~~~~~~~~
TypeError: not all arguments converted during string formatting
Call stack:
  <long call stack>
  File "/app/infraohjelmointi_api/services/utils/ProjectWiseDataMapper.py", line 280, in convert_to_pw_data
    logger.debug("planningPerson", planningPersonModel)
Message: 'planningPerson'
Arguments: (None,)
```

The same error comes when Person object is not empty:
```
--- Logging error ---
Traceback (most recent call last):
  File "/usr/lib/python3.11/logging/__init__.py", line 1110, in emit
    msg = self.format(record)
          ^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/logging/__init__.py", line 953, in format
    return fmt.format(record)
           ^^^^^^^^^^^^^^^^^^
  File "/app/project/customlogging/ColoredFormatter.py", line 27, in format
    return formatter.format(record)
           ^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/logging/__init__.py", line 687, in format
    record.message = record.getMessage()
                     ^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/logging/__init__.py", line 377, in getMessage
    msg = msg % self.args
          ~~~~^~~~~~~~~~~
TypeError: not all arguments converted during string formatting
Call stack:
  <long call stack>
  File "/app/infraohjelmointi_api/services/utils/ProjectWiseDataMapper.py", line 280, in convert_to_pw_data
    logger.debug("planningPerson", planningPersonModel)
Message: 'planningPerson'
Arguments: (<Person: Person object (<here is Person object ID>)>,)
```