### PR TITLE
Save finance value correctly if set zero

### DIFF
--- a/infraohjelmointi_api/views/ProjectViewSet.py
+++ b/infraohjelmointi_api/views/ProjectViewSet.py
@@ -165,7 +165,7 @@ class ProjectViewSet(BaseViewSet):
                         },
                         code="project_locked",
                     )
-                if not finances[field]:
+                if finances[field] == None:
                     logger.info("No budget set for key: {}".format(field))
                     continue
 


### PR DESCRIPTION
When project's finance value was set to zero, code understood INT value "0" as False and did not save the value correctly to database.

> In Python, the integer 0 is always False, while every other number, including negative numbers, are True. In fact, under the hood, booleans inherit from integers.
https://www.learnpython.dev/02-introduction-to-python/090-boolean-logic/10-truthiness/#numbers