### PR TITLE
HKISD-57: temporary fix for the cache

### DIFF
--- a/infraohjelmointi_api/serializers/FinancialSumSerializer.py
+++ b/infraohjelmointi_api/serializers/FinancialSumSerializer.py
@@ -363,7 +363,7 @@ class FinancialSumSerializer(serializers.ModelSerializer):
                 cache.set(
                     str(instance.id) + "/{}/{}".format(forcedToFrame, year),
                     summedFinances,
-                    60 * 60 * 24,
+                    60 * 60 * 2,
                 )
 
             # delete this instance from relationEffected if it exists there since it has been updated now


### PR DESCRIPTION
https://futurice.atlassian.net/browse/HKISD-57

When a project is moved to a new class, the numbers aren't summed correctly as you can see in the image below:
<img width="500" alt="image" src="https://github.com/City-of-Helsinki/infraohjelmointi-api/assets/59826954/1c77fbd7-76d5-45d9-84d5-ab44652b72e8">

This happens because there is a problem with updating the cache. We could temporarily change the cache length to two hours so that the numbers would update quicker and the users wouldn't have to wait for one day before seeing the new values. We need to prioritize other features at the moment so we will get back to this issue later.