### PR TITLE
HKISD-81: Add codes for classes and hierarchies on coord view if set on hierarchy import file.

### DIFF
--- a/infraohjelmointi_api/management/commands/util/hierarchy.py
+++ b/infraohjelmointi_api/management/commands/util/hierarchy.py
@@ -342,7 +342,7 @@ def sanitizeString(data: str = None):
         data = (
             # remove first spaces between numbers and then remove all numbers from name
             re.sub(
-                "^[\d.-]+\s[0,100]", "", re.sub("(?<=\d) (?=\d)", "", str(data))
+                "^[\d.-]+\s\d{1,2}", "", re.sub("(?<=\d) (?=\d)", "", str(data))
             )
             .strip()
         )
@@ -353,7 +353,7 @@ def sanitizeString(data: str = None):
 
 
 def proceedWithClass(
-    code: str,
+    code: str | None,
     name: str,
     cell_color: str,
     row_number: int,

--- a/infraohjelmointi_api/management/commands/util/hierarchy.py
+++ b/infraohjelmointi_api/management/commands/util/hierarchy.py
@@ -342,9 +342,8 @@ def sanitizeString(data: str = None):
         data = (
             # remove first spaces between numbers and then remove all numbers from name
             re.sub(
-                "^[\d.-]+\s[0,100]", "", re.sub("(?<=\d) (?=\d)", "", str(data).lower())
+                "^[\d.-]+\s[0,100]", "", re.sub("(?<=\d) (?=\d)", "", str(data))
             )
-            .capitalize()
             .strip()
         )
         if "-" in data and "liikunta" not in data:
@@ -371,9 +370,7 @@ def proceedWithClass(
     if parent == None:
         # Main Classes need different formatting
         name = "{} {}".format(
-            re.sub(
-                "(?<=\d) (?=\d)", "", str(code).lower()
-            ),  # remove spaces between numbers
+            str(code).lower(),
             name,
         ).strip()
     else:
@@ -478,9 +475,12 @@ def buildHierarchiesAndProjects(
     # if main class give
     if main_class:
         # remove spaces between numbers
-        main_class = re.sub("(?<=\d) (?=\d)", "", str(main_class).lower())
+        main_class = str(main_class).lower()
+        main_class_array = main_class.split(" ")[0,1]
 
-        class_code = main_class.split(" ")[0]
+        # code structure is "8 01" including space
+        class_code = "{} {}".format(main_class_array[0], main_class_array[1]).strip()
+
         # capitalize the alpha part
         main_class = re.sub("^[\d.-]+\s*", "", main_class).strip().capitalize()
         if "-" in main_class and "liikunta" not in main_class:
@@ -514,12 +514,10 @@ def buildHierarchiesAndProjects(
         cell_color = getColor(wb, cell.fill.start_color)
         cell_color_hex = hex(int(cell_color, 16))
 
+        class_code_array = str(row[name_column_index - 1 if name_column_index > 0 else 0].value).split(" ")[0:2]
+
         class_code = (
-            re.sub(
-                "(?<=\d) (?=\d)",
-                "",
-                row[name_column_index - 1 if name_column_index > 0 else 0].value,
-            ).split(" ")[0]
+            "{} {}".format(class_code_array[0], class_code_array[1])
             if cell_color_hex == MAIN_CLASS_COLOR
             else str(row[name_column_index - 1].value).strip()
             if for_coordinator_only and row[name_column_index - 1].value


### PR DESCRIPTION
https://futurice.atlassian.net/browse/HKISD-81

On coordinator field under class **803 01** few subclasses and districts were missing codes A, B, C, ...

![image](https://github.com/City-of-Helsinki/infraohjelmointi-api/assets/14055798/6df99bde-ec1d-4624-a204-832016ad3d7b)

This change adds codes on names when the project is set up first time locally while importing hierarchy excel file. The change affects only the names.

The excel file is update on the secret vault.