### PR TITLE
HKISD-130/fix calculating planned budgets

### DIFF
--- a/infraohjelmointi_api/serializers/FinancialSumSerializer.py
+++ b/infraohjelmointi_api/serializers/FinancialSumSerializer.py
@@ -51,14 +51,14 @@ class FinancialSumSerializer(serializers.ModelSerializer):
         if _type not in ["ProjectClass", "ProjectLocation"] or instance == None:
             return {"frameBudget": 0, "budgetChange": 0, "isFrameBudgetOverlap": False}
 
-        financeInstance = None
+        finance_instance = None
         if instance.finances.filter(year=year).exists():
             if _type == "ProjectClass":
-                financeInstance = ClassFinancialService.get(
+                finance_instance = ClassFinancialService.get(
                     class_id=instance.id, year=year
                 )
             if _type == "ProjectLocation":
-                financeInstance = LocationFinancialService.get(
+                finance_instance = LocationFinancialService.get(
                     location_id=instance.id, year=year
                 )
 
@@ -67,7 +67,7 @@ class FinancialSumSerializer(serializers.ModelSerializer):
         if _type == "ProjectClass":
             # get all childs with frameBudget for each level
 
-            childClasses = (
+            child_classes = (
                 ProjectClass.objects.filter(
                     path__startswith=instance.path,
                     path__gt=instance.path,
@@ -98,10 +98,10 @@ class FinancialSumSerializer(serializers.ModelSerializer):
                 .values("id", "parentRelation", "frameBudget", "parentFrameBudget")
             )
             # get all locations with parentClass as childs and get frameBudgets
-            childLocations = (
+            child_locations = (
                 ProjectLocation.objects.filter(
                     parentClass__in=[
-                        *childClasses.values_list("id", flat=True),
+                        *child_classes.values_list("id", flat=True),
                         instance.id,
                     ],
                     forCoordinatorOnly=True,
@@ -130,22 +130,22 @@ class FinancialSumSerializer(serializers.ModelSerializer):
                 .values("id", "parentRelation", "frameBudget", "parentFrameBudget")
             )
             # Combine all child relations of the current instance into one single queryset
-            allChildRelations = childLocations.union(childClasses)
-            if allChildRelations.exists():
+            all_child_relations = child_locations.union(child_classes)
+            if all_child_relations.exists():
                 grouped = defaultdict(lambda: {'frameBudget': 0})
 
-                for relation in allChildRelations:
+                for relation in all_child_relations:
                     grouped[relation['parentRelation']]['frameBudget'] += relation['frameBudget']
                     if grouped[relation['parentRelation']]['frameBudget'] > relation['parentFrameBudget']:
                         is_frame_budget_overlap = True
                         break
 
         return {
-            "frameBudget": financeInstance.frameBudget
-            if financeInstance != None
+            "frameBudget": finance_instance.frameBudget
+            if finance_instance != None
             else 0,
-            "budgetChange": financeInstance.budgetChange
-            if financeInstance != None
+            "budgetChange": finance_instance.budgetChange
+            if finance_instance != None
             else 0,
             "isFrameBudgetOverlap": False
             if _type == "ProjectLocation"
@@ -159,165 +159,165 @@ class FinancialSumSerializer(serializers.ModelSerializer):
         """
         _type = instance._meta.model.__name__
         year = int(self.context.get("finance_year", date.today().year))
-        forcedToFrame = self.context.get("forcedToFrame", False)
+        forced_to_frame = self.context.get("forcedToFrame", False)
 
-        relatedProjects = self.get_related_projects(instance=instance, _type=_type)
+        related_projects = self.get_related_projects(instance=instance, _type=_type)
 
-        summedFinances = relatedProjects.aggregate(
+        summed_finances = related_projects.aggregate(
             year0_plannedBudget=Sum(
                 "finances__value",
                 default=0,
-                filter=Q(finances__forFrameView=forcedToFrame)
+                filter=Q(finances__forFrameView=forced_to_frame)
                 & Q(finances__year=year),
             ),
             year1_plannedBudget=Sum(
                 "finances__value",
                 default=0,
-                filter=Q(finances__forFrameView=forcedToFrame)
+                filter=Q(finances__forFrameView=forced_to_frame)
                 & Q(finances__year=year + 1),
             ),
             year2_plannedBudget=Sum(
                 "finances__value",
                 default=0,
-                filter=Q(finances__forFrameView=forcedToFrame)
+                filter=Q(finances__forFrameView=forced_to_frame)
                 & Q(finances__year=year + 2),
             ),
             year3_plannedBudget=Sum(
                 "finances__value",
                 default=0,
-                filter=Q(finances__forFrameView=forcedToFrame)
+                filter=Q(finances__forFrameView=forced_to_frame)
                 & Q(finances__year=year + 3),
             ),
             year4_plannedBudget=Sum(
                 "finances__value",
                 default=0,
-                filter=Q(finances__forFrameView=forcedToFrame)
+                filter=Q(finances__forFrameView=forced_to_frame)
                 & Q(finances__year=year + 4),
             ),
             year5_plannedBudget=Sum(
                 "finances__value",
                 default=0,
-                filter=Q(finances__forFrameView=forcedToFrame)
+                filter=Q(finances__forFrameView=forced_to_frame)
                 & Q(finances__year=year + 5),
             ),
             year6_plannedBudget=Sum(
                 "finances__value",
                 default=0,
-                filter=Q(finances__forFrameView=forcedToFrame)
+                filter=Q(finances__forFrameView=forced_to_frame)
                 & Q(finances__year=year + 6),
             ),
             year7_plannedBudget=Sum(
                 "finances__value",
                 default=0,
-                filter=Q(finances__forFrameView=forcedToFrame)
+                filter=Q(finances__forFrameView=forced_to_frame)
                 & Q(finances__year=year + 7),
             ),
             year8_plannedBudget=Sum(
                 "finances__value",
                 default=0,
-                filter=Q(finances__forFrameView=forcedToFrame)
+                filter=Q(finances__forFrameView=forced_to_frame)
                 & Q(finances__year=year + 8),
             ),
             year9_plannedBudget=Sum(
                 "finances__value",
                 default=0,
-                filter=Q(finances__forFrameView=forcedToFrame)
+                filter=Q(finances__forFrameView=forced_to_frame)
                 & Q(finances__year=year + 9),
             ),
             year10_plannedBudget=Sum(
                 "finances__value",
                 default=0,
-                filter=Q(finances__forFrameView=forcedToFrame)
+                filter=Q(finances__forFrameView=forced_to_frame)
                 & Q(finances__year=year + 10),
             ),
             budgetOverrunAmount=Sum("budgetOverrunAmount", default=0),
         )
 
         if _type == "ProjectGroup":
-            summedFinances["projectBudgets"] = relatedProjects.aggregate(
+            summed_finances["projectBudgets"] = related_projects.aggregate(
                 projectBudgets=Sum("costForecast", default=0)
             )["projectBudgets"]
 
-        summedFinances["year"] = year
-        summedFinances["year0"] = {
+        summed_finances["year"] = year
+        summed_finances["year0"] = {
             **self.get_frameBudget_and_budgetChange(
                 instance=instance,
                 year=year,
             ),
-            "plannedBudget": int(summedFinances.pop("year0_plannedBudget")),
+            "plannedBudget": int(summed_finances.pop("year0_plannedBudget")),
         }
-        summedFinances["year1"] = {
+        summed_finances["year1"] = {
             **self.get_frameBudget_and_budgetChange(
                 instance=instance,
                 year=year + 1,
             ),
-            "plannedBudget": int(summedFinances.pop("year1_plannedBudget")),
+            "plannedBudget": int(summed_finances.pop("year1_plannedBudget")),
         }
-        summedFinances["year2"] = {
+        summed_finances["year2"] = {
             **self.get_frameBudget_and_budgetChange(
                 instance=instance,
                 year=year + 2,
             ),
-            "plannedBudget": int(summedFinances.pop("year2_plannedBudget")),
+            "plannedBudget": int(summed_finances.pop("year2_plannedBudget")),
         }
-        summedFinances["year3"] = {
+        summed_finances["year3"] = {
             **self.get_frameBudget_and_budgetChange(
                 instance=instance,
                 year=year + 3,
             ),
-            "plannedBudget": int(summedFinances.pop("year3_plannedBudget")),
+            "plannedBudget": int(summed_finances.pop("year3_plannedBudget")),
         }
-        summedFinances["year4"] = {
+        summed_finances["year4"] = {
             **self.get_frameBudget_and_budgetChange(
                 instance=instance,
                 year=year + 4,
             ),
-            "plannedBudget": int(summedFinances.pop("year4_plannedBudget")),
+            "plannedBudget": int(summed_finances.pop("year4_plannedBudget")),
         }
-        summedFinances["year5"] = {
+        summed_finances["year5"] = {
             **self.get_frameBudget_and_budgetChange(
                 instance=instance,
                 year=year + 5,
             ),
-            "plannedBudget": int(summedFinances.pop("year5_plannedBudget")),
+            "plannedBudget": int(summed_finances.pop("year5_plannedBudget")),
         }
-        summedFinances["year6"] = {
+        summed_finances["year6"] = {
             **self.get_frameBudget_and_budgetChange(
                 instance=instance,
                 year=year + 6,
             ),
-            "plannedBudget": int(summedFinances.pop("year6_plannedBudget")),
+            "plannedBudget": int(summed_finances.pop("year6_plannedBudget")),
         }
-        summedFinances["year7"] = {
+        summed_finances["year7"] = {
             **self.get_frameBudget_and_budgetChange(
                 instance=instance,
                 year=year + 7,
             ),
-            "plannedBudget": int(summedFinances.pop("year7_plannedBudget")),
+            "plannedBudget": int(summed_finances.pop("year7_plannedBudget")),
         }
-        summedFinances["year8"] = {
+        summed_finances["year8"] = {
             **self.get_frameBudget_and_budgetChange(
                 instance=instance,
                 year=year + 8,
             ),
-            "plannedBudget": int(summedFinances.pop("year8_plannedBudget")),
+            "plannedBudget": int(summed_finances.pop("year8_plannedBudget")),
         }
-        summedFinances["year9"] = {
+        summed_finances["year9"] = {
             **self.get_frameBudget_and_budgetChange(
                 instance=instance,
                 year=year + 9,
             ),
-            "plannedBudget": int(summedFinances.pop("year9_plannedBudget")),
+            "plannedBudget": int(summed_finances.pop("year9_plannedBudget")),
         }
-        summedFinances["year10"] = {
+        summed_finances["year10"] = {
             **self.get_frameBudget_and_budgetChange(
                 instance=instance,
                 year=year + 10,
             ),
-            "plannedBudget": int(summedFinances.pop("year10_plannedBudget")),
+            "plannedBudget": int(summed_finances.pop("year10_plannedBudget")),
         }
 
-        return summedFinances
+        return summed_finances
 
     def get_related_projects(self, instance, _type) -> list[Project]:
         """

--- a/infraohjelmointi_api/serializers/FinancialSumSerializer.py
+++ b/infraohjelmointi_api/serializers/FinancialSumSerializer.py
@@ -1,4 +1,3 @@
-import logging
 from collections import defaultdict
 from datetime import date
 from infraohjelmointi_api.models import (
@@ -25,8 +24,6 @@ from django.db.models import (
     Subquery,
 )
 from django.db.models.functions import Coalesce
-
-logger = logging.getLogger("infraohjelmointi_api")
 
 
 class FinancialSumSerializer(serializers.ModelSerializer):
@@ -236,10 +233,6 @@ class FinancialSumSerializer(serializers.ModelSerializer):
             budgetOverrunAmount=Sum("budgetOverrunAmount", default=0),
         )
 
-        if instance.name == "Malmi":
-            logger.info("projektit")
-            logger.info(relatedProjects)
-
         if _type == "ProjectGroup":
             summedFinances["projectBudgets"] = relatedProjects.aggregate(
                 projectBudgets=Sum("costForecast", default=0)
@@ -380,9 +373,9 @@ class FinancialSumSerializer(serializers.ModelSerializer):
                     .filter(
                         (
                             Q(projectClass__name__icontains="suurpiiri")
-                            & (Q(projectClass=instance) 
-                            | Q(projectClass__parent=instance) 
-                            | Q(projectClass__parent__parent=instance))
+                            & Q(
+                                projectClass__parent__coordinatorClass__path__startswith=instance.path
+                            )
                         )
                         | Q(
                             projectClass__coordinatorClass__path__startswith=instance.path


### PR DESCRIPTION
- related projects for project classes in planning view were filtered using path name and projects under Malminkartano-Kannelmäki ended up under Malmi as well, cause in planning view the classes don't have unique numbers in the names -> I changed it to use ids now
- fixed some old sonar cloud issues related to camel case naming