### PR TITLE
Hkisd 124/fix note adding permissions for project manager

### DIFF
--- a/infraohjelmointi_api/permissions.py
+++ b/infraohjelmointi_api/permissions.py
@@ -262,8 +262,6 @@ class IsProjectManager(permissions.BasePermission):
         if view.action in [
             *DJANGO_BASE_UPDATE_ONLY_ACTIONS,
             *DJANGO_BASE_READ_ONLY_ACTIONS,
-            *DJANGO_BASE_DELETE_ONLY_ACTIONS,
-            *DJANGO_BASE_CREATE_ONLY_ACTIONS,
             *PROJECT_NOTE_ALL_ACTIONS] and _type in [
             "Project", "Note"
         ]:

--- a/infraohjelmointi_api/permissions.py
+++ b/infraohjelmointi_api/permissions.py
@@ -59,9 +59,11 @@ PROJECT_LOCATION_ALL_ACTIONS = [
 #### Project Notes custom actions ####
 PROJECT_NOTE_COORDINATOR_GET_ACTIONS = ["get_note_history", "get_note_history_by_user", "get_project_notes",]
 PROJECT_NOTE_PLANNING_GET_ACTIONS = ["get_note_history", "get_note_history_by_user", "get_project_notes",]
+PROJECT_NOTE_BASIC_ACTIONS = ["list", "retrieve", "create"]
 PROJECT_NOTE_ALL_GET_ACTIONS = [
     *PROJECT_NOTE_PLANNING_GET_ACTIONS,
     *PROJECT_NOTE_COORDINATOR_GET_ACTIONS,
+    *PROJECT_NOTE_BASIC_ACTIONS,
 ]
 PROJECT_NOTE_ALL_ACTIONS = [*PROJECT_NOTE_ALL_GET_ACTIONS]
 
@@ -228,7 +230,7 @@ class IsProjectManager(permissions.BasePermission):
             return True
 
     def has_permission(self, request, view):
-        # has edit permissions for projects only
+        # has edit permissions for projects and notes
         # and read permissions
         if (
             request.user.is_authenticated
@@ -257,10 +259,15 @@ class IsProjectManager(permissions.BasePermission):
         # and only specific project fields
         _type = obj._meta.model.__name__
 
-        if view.action in [*DJANGO_BASE_UPDATE_ONLY_ACTIONS, *DJANGO_BASE_READ_ONLY_ACTIONS] and _type in [
-            "Project",
+        if view.action in [
+            *DJANGO_BASE_UPDATE_ONLY_ACTIONS,
+            *DJANGO_BASE_READ_ONLY_ACTIONS,
+            *DJANGO_BASE_DELETE_ONLY_ACTIONS,
+            *DJANGO_BASE_CREATE_ONLY_ACTIONS,
+            *PROJECT_NOTE_ALL_ACTIONS] and _type in [
+            "Project", "Note"
         ]:
-            if any(
+            if _type == "Project" and any(
                 [
                     item
                     for item in request.data.keys()
@@ -297,6 +304,9 @@ class IsProjectManager(permissions.BasePermission):
                 ]
             ]):
                 return False
+            
+            if _type == "Note":
+                return True
             
             return True
 

--- a/infraohjelmointi_api/permissions.py
+++ b/infraohjelmointi_api/permissions.py
@@ -59,13 +59,12 @@ PROJECT_LOCATION_ALL_ACTIONS = [
 #### Project Notes custom actions ####
 PROJECT_NOTE_COORDINATOR_GET_ACTIONS = ["get_note_history", "get_note_history_by_user", "get_project_notes",]
 PROJECT_NOTE_PLANNING_GET_ACTIONS = ["get_note_history", "get_note_history_by_user", "get_project_notes",]
-PROJECT_NOTE_BASIC_ACTIONS = ["list", "retrieve", "create"]
+PROJECT_NOTE_BASIC_ACTIONS = ["create"]
 PROJECT_NOTE_ALL_GET_ACTIONS = [
     *PROJECT_NOTE_PLANNING_GET_ACTIONS,
     *PROJECT_NOTE_COORDINATOR_GET_ACTIONS,
-    *PROJECT_NOTE_BASIC_ACTIONS,
 ]
-PROJECT_NOTE_ALL_ACTIONS = [*PROJECT_NOTE_ALL_GET_ACTIONS]
+PROJECT_NOTE_ALL_ACTIONS = [*PROJECT_NOTE_ALL_GET_ACTIONS, *PROJECT_NOTE_BASIC_ACTIONS,]
 
 #### PROJECT Finances custom actions ####
 PROJECT_FINANCES_PLANNING_GET_ACTIONS = ["get_project_finances_by_year"]

--- a/infraohjelmointi_api/permissions.py
+++ b/infraohjelmointi_api/permissions.py
@@ -291,8 +291,6 @@ class IsProjectManager(permissions.BasePermission):
                         "spentCost", # * Käytetty Ei (No) # spentCost
                         "budgetOverrunYear", # ylistysoikeus vuosi Ei (No) # budgetOverrunYear
                         "budgetOverrunAmount", # * Ylitysoikeus Ei (No) # budgetOverrunAmount
-                        "personPlanning", # * Vastuuhenkilö Ei (No) # personPlanning
-                        "personConstruction", # * Rakennuttamisen vastuuhenkilö Ei (No) # personConstruction
                         "personProgramming", # * Ohjelmoija Ei (No) # personProgramming
                         "responsibleZone", # * Alueen vastuujaon mukaan Ei (No) # responsibleZone
                         "projectLocation", # value can be district/division/subDivision
@@ -302,11 +300,9 @@ class IsProjectManager(permissions.BasePermission):
                 ]
             ]):
                 return False
-            
+
             if _type == "Note":
                 return True
-            
-            return True
 
         return True
     


### PR DESCRIPTION
This PR will add project managers permissions also to create new notes for projects. Project manager is allowed to do any actions to notes: read, create, modify and delete. 
Also removed personPlanning and personConstruction from the list of restrictions to project managers. 