### PR TITLE
feat: IO-387 add rights for viewers to fetch project objects

### DIFF
--- a/infraohjelmointi_api/permissions.py
+++ b/infraohjelmointi_api/permissions.py
@@ -152,7 +152,12 @@ class IsViewer(permissions.BasePermission):
         return False
 
     def has_object_permission(self, request, view, obj):
-        # Viewer cannot edit anything or get an object instance
+        # Viewer can only access project object, to be able to see the project card
+        _type = obj._meta.model.__name__
+
+        if view.action in [*DJANGO_BASE_READ_ONLY_ACTIONS] and _type == "Project":
+            return True
+        
         return False
 
 class IsCoordinator(permissions.BasePermission):


### PR DESCRIPTION
- Users with viewer roles are allowed to see project cards now so they needed access to fetch the project object
- ticket: [https://helsinkisolutionoffice.atlassian.net/browse/IO-387](https://helsinkisolutionoffice.atlassian.net/browse/IO-387)
- Instruction for testing can be found from the UI PR: [https://github.com/City-of-Helsinki/infraohjelmointi-ui/pull/255](https://github.com/City-of-Helsinki/infraohjelmointi-ui/pull/255)