### PR TITLE
Update dockerfile to redhat image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,25 +1,28 @@
-FROM alpine:3.18
+FROM registry.access.redhat.com/ubi9/python-311:latest
 
 WORKDIR /app
 
 ENV STATIC_ROOT /srv/app/static
 COPY . .
 
-RUN TZ="Europe/Helsinki" apk add --update nano libffi-dev gcc \
-    musl-dev python3-dev python3  py3-pip py3-pandas uwsgi \
-    postgresql-client netcat-openbsd gettext libpq-dev unzip \
-    bash grep busybox-suid dcron libcap && \
-    ln -s /usr/bin/pip3 /usr/local/bin/pip && \
-    ln -s /usr/bin/python3 /usr/local/bin/python && \
-    # install python project modules
+USER root
+
+RUN TZ="Europe/Helsinki" \
+    yum -y update && \
+    yum install -y gcc libffi-devel python3-devel libpq-devel unzip bash gettext cronie && \
+    yum install -y https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-aarch64/pgdg-redhat-repo-latest.noarch.rpm && \
+    yum -y install postgresql13 && \
+    yum clean all && \
+    rm -rf /var/cache/yum && \
     pip install --no-cache-dir -r requirements.txt && \
     mkdir -p /srv/app/static && \
-    DJANGO_SECRET_KEY="only-used-for-collectstatic" DATABASE_URL="sqlite:///" \
-    python manage.py collectstatic --noinput && \
     chmod +x /app/sync-from-sap.sh
 
-# Openshift starts the container process with group zero and random ID
-# we mimic that here with nobody and group zero
+ENV DJANGO_SECRET_KEY="only-used-for-collectstatic" DATABASE_URL="sqlite:///"
+
+RUN python manage.py collectstatic --noinput && \
+    chown -R nobody:nobody /srv/app/static
+
 USER nobody:0
 
 ENTRYPOINT ["./docker-entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,9 +16,8 @@ RUN TZ="Europe/Helsinki" \
     rm -rf /var/cache/yum && \
     pip install --no-cache-dir -r requirements.txt && \
     mkdir -p /srv/app/static && \
-    chmod +x /app/sync-from-sap.sh
-
-RUN python manage.py collectstatic --noinput && \
+    chmod +x /app/sync-from-sap.sh && \
+    python manage.py collectstatic --noinput && \
     chown -R nobody:nobody /srv/app/static
 
 USER nobody:0

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,7 @@ RUN TZ="Europe/Helsinki" \
     mkdir -p /srv/app/static && \
     chmod +x /app/sync-from-sap.sh
 
-ENV DJANGO_SECRET_KEY="only-used-for-collectstatic" DATABASE_URL="sqlite:///"
+ENV DJANGO_SECRET_KEY=${DJANGO_SECRET_KEY}
 
 RUN python manage.py collectstatic --noinput && \
     chown -R nobody:nobody /srv/app/static

--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,6 @@ RUN TZ="Europe/Helsinki" \
     mkdir -p /srv/app/static && \
     chmod +x /app/sync-from-sap.sh
 
-ENV DJANGO_SECRET_KEY=${DJANGO_SECRET_KEY}
-
 RUN python manage.py collectstatic --noinput && \
     chown -R nobody:nobody /srv/app/static
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 django==4.1.3                                  # web framework itself
 djangorestframework==3.14.0                    # creating rest APIs
-psycopg2-binary==2.9.5                         # postgres database adapter
+psycopg2-binary==2.9.6                         # postgres database adapter
 requests>=2.31.0
 django-cors-headers==3.13.0
 django_db_logger==0.1.12
@@ -22,3 +22,5 @@ daphne                                      # application server
 django-helusers                               # Tunnistamo user inegration
 social-auth-app-django
 drf-yasg                                    # API Swagger documentation
+pandas
+numpy


### PR DESCRIPTION
- Switch from Docker Hub image to Red Hat Ecosystem Catalog image to fix issues with blocked image fetches from Docker Hub.

- Rewrite dockerfile

- Change boolean value to string, because docker-compose does not allow boolean value type

How-to test:

Run docker-compose up --build --force-recreate
This force-re-builds the image
If it fails, it might happen because image caches. Cleaning docker builder caches requires deleting all images

docker-compose down - Stop and remove all docker-compose containers (doesn't delete volumes)
