### PR TITLE
HKISD-171/import responsible persons script email

### DIFF
--- a/infraohjelmointi_api/management/commands/responsiblepersons.py
+++ b/infraohjelmointi_api/management/commands/responsiblepersons.py
@@ -69,6 +69,7 @@ class Command(BaseCommand):
         wb = load_workbook(excelPath, data_only=True, read_only=True)
         rows = list(wb.worksheets[0].rows)
         incorrect_emails = []
+        duplicates = []
 
         for row in rows:
             if len(row) < 2:
@@ -87,24 +88,84 @@ class Command(BaseCommand):
                 incorrect_emails.append((firstname, lastname, email))
                 continue
 
-            person, _ = PersonService.get_or_create_by_name_and_email(
-                firstName=firstname, lastName=lastname, email=email
+            # Get person by email. Create new person if name or email are not found.
+            # In case person was found without an email, we update the person.
+            # In case multiple person with the same name, we do nothing but show these as a result.
+            person_by_email = PersonService.get_by_email(
+                email=email
             )
 
-            if person:
-                logger.info(
-                    "Person added: {} {}, email '{}' ({})".format(
-                        person.firstName, person.lastName, person.email, person.id
+            if person_by_email is None:
+                person = PersonService.get_by_name(
+                    firstName=firstname,
+                    lastName=lastname
+                )
+
+                if isinstance(person, list):
+                    # When multiple names found, PersonService returns a list.
+                    # In this case, do nothing and show the duplicate at the end.
+                    duplicates.append((firstname,lastname,email))
+
+                    logger.warning(
+                        "Duplicate found: {} {}, '{}'".format(
+                            firstname, lastname, email
+                        )
+                    )
+
+                    continue
+
+                if person is None:
+                    # Create new person if not found by email and name
+                    person = PersonService.create_by_name(
+                        firstName=firstname,
+                        lastName=lastname,
+                        email=email
+                    )
+
+                    logger.info(
+                        "Person added: '{}', {} {} ({})".format(
+                            person.email, person.firstName, person.lastName, person.id
+                    )
+                )
+
+                elif not person.email:
+                    # Update missing email address for found name when email is not set
+                    person.email = email
+                    person.save()
+
+                    logger.info(
+                        "Email updated: '{}', {} {} ({})".format(
+                            person.email, person.firstName, person.lastName, person.id
+                        )
+                )
+            else:
+                logger.warning(
+                    "Email found, skip. Found data: [{}, {}, {}, {}]".format(
+                        person_by_email.id,
+                        person_by_email.firstName,
+                        person_by_email.lastName,
+                        person_by_email.email
                     )
                 )
 
         # Print list of incorrect email data
         if len(incorrect_emails) > 0:
-            printable_list = "Error with following data:"
+            printable_list = "Error with following data that were not added:"
 
             for incorrect_person in incorrect_emails:
                 printable_list += "\n{} {}, email: '{}'".format(
                     incorrect_person[0], incorrect_person[1], incorrect_person[2]
                 )
 
-            logger.error(printable_list)
+            logger.warning(printable_list)
+
+        # Print list of duplicates
+        if len(duplicates) > 0:
+            printable_list = "Found name duplicates (firstname, lastname) that were not added:"
+
+            for duplicate in duplicates:
+                printable_list += "\n{} {}, email: '{}".format(
+                    duplicate[0], duplicate[1], duplicate[2]
+                )
+
+            logger.warning(printable_list)

--- a/infraohjelmointi_api/services/PersonService.py
+++ b/infraohjelmointi_api/services/PersonService.py
@@ -21,16 +21,50 @@ class PersonService:
     def get_or_create_by_name(
         firstName: str,
         lastName: str,
+        email: str = None,
     ) -> Person:
-        return Person.objects.get_or_create(firstName=firstName, lastName=lastName)
+        if email == None:
+            return Person.objects.get_or_create(firstName=firstName, lastName=lastName)
+        else:
+            return Person.objects.get_or_create(firstName=firstName, lastName=lastName, email=email)
 
     @staticmethod
-    def get_or_create_by_name_and_email(
+    def get_by_email(
+        email: str
+    ) -> Person:
+        try:
+            return Person.objects.get(email=email)
+        except Person.DoesNotExist:
+            return None
+
+    @staticmethod
+    def get_by_name(
+        firstName: str,
+        lastName: str
+    ) -> Person:
+        try:
+            return Person.objects.get(firstName=firstName, lastName=lastName)
+        except Person.MultipleObjectsReturned:
+            return list(Person.objects.filter(firstName=firstName, lastName=lastName))
+        except Person.DoesNotExist:
+            return None
+
+    @staticmethod
+    def create_by_name(
         firstName: str,
         lastName: str,
-        email: str,
+        email: str
     ) -> Person:
-        return Person.objects.get_or_create(firstName=firstName, lastName=lastName, email=email)
+        return Person.objects.create(firstName=firstName, lastName=lastName, email=email)
+
+    @staticmethod
+    def get_by_email(
+        email: str
+    ) -> Person:
+        try:
+            return Person.objects.get(email=email)
+        except Person.DoesNotExist:
+            return None
 
     @staticmethod
     def get_by_id(

--- a/infraohjelmointi_api/services/PersonService.py
+++ b/infraohjelmointi_api/services/PersonService.py
@@ -58,15 +58,6 @@ class PersonService:
         return Person.objects.create(firstName=firstName, lastName=lastName, email=email)
 
     @staticmethod
-    def get_by_email(
-        email: str
-    ) -> Person:
-        try:
-            return Person.objects.get(email=email)
-        except Person.DoesNotExist:
-            return None
-
-    @staticmethod
     def get_by_id(
         id: str,
     ) -> Person:

--- a/infraohjelmointi_api/services/PersonService.py
+++ b/infraohjelmointi_api/services/PersonService.py
@@ -70,7 +70,10 @@ class PersonService:
     def get_by_id(
         id: str,
     ) -> Person:
-        return Person.objects.get(id=id)
+        try:
+            return Person.objects.get(id=id)
+        except Person.DoesNotExist:
+            return None
 
     @staticmethod
     def get_all_persons() -> list[Person]:

--- a/infraohjelmointi_api/services/PersonService.py
+++ b/infraohjelmointi_api/services/PersonService.py
@@ -77,4 +77,4 @@ class PersonService:
 
     @staticmethod
     def get_all_persons() -> list[Person]:
-        return Person.objects.all()
+        return list(Person.objects.all())

--- a/infraohjelmointi_api/services/PersonService.py
+++ b/infraohjelmointi_api/services/PersonService.py
@@ -25,6 +25,14 @@ class PersonService:
         return Person.objects.get_or_create(firstName=firstName, lastName=lastName)
 
     @staticmethod
+    def get_or_create_by_name_and_email(
+        firstName: str,
+        lastName: str,
+        email: str,
+    ) -> Person:
+        return Person.objects.get_or_create(firstName=firstName, lastName=lastName, email=email)
+
+    @staticmethod
     def get_by_id(
         id: str,
     ) -> Person:

--- a/infraohjelmointi_api/tests/__init__.py
+++ b/infraohjelmointi_api/tests/__init__.py
@@ -1,3 +1,4 @@
 from .test_Projects import ProjectTestCase
 from .test_Notes import NoteTestCase
 from .management.commands.test_managehierarchies import ManageHierarchiesCommandTestCase
+from .management.commands.test_responsiblepersons import ResponsiblePersonsCommandTestCase

--- a/infraohjelmointi_api/tests/management/commands/test_responsiblepersons.py
+++ b/infraohjelmointi_api/tests/management/commands/test_responsiblepersons.py
@@ -1,0 +1,63 @@
+from io import StringIO
+from os import path
+import tempfile
+from unittest.mock import patch
+from django.core.management import call_command
+from django.core.management.base import CommandError
+
+from django.test import TestCase
+import environ
+import pandas as pd
+
+from infraohjelmointi_api.services import PersonService
+
+if path.exists(".env"):
+    environ.Env().read_env(".env")
+
+env = environ.Env()
+
+import logging
+logger = logging.getLogger("infraohjelmointi_api")
+
+class ResponsiblePersonsCommandTestCase(TestCase):
+    # Columns does not have a header row.
+    # Because of that, the first row includes person information
+    mock_data = {
+        'Matt': ["Sarah", "Max", "Peter", "John"],
+        'Smith': ["Example", "Test", "Incorrect-Email", "Empty-Email"],
+        'email1@example.com': ["email2@example.com", "email3@example.com", "email(at)example.com", ""]
+    }
+
+    def test_without_arguments(self):
+        # Script without arguments
+        out = StringIO()
+        call_command("responsiblepersons", stdout=out)
+        self.assertIn("No arguments given.", out.getvalue())
+
+    def test_with_file_argument_without_file(self):
+        # Script with argument without the file name
+        with self.assertRaises(CommandError):
+            call_command("responsiblepersons", "--file")
+
+    def test_with_file_argument_with_incorrect_file(self):
+        # Script with unknown file name
+        out = StringIO()
+
+        call_command("responsiblepersons", "--file", "unknown-file.xlsx", stdout=out)
+        command_output = out.getvalue()
+
+        expected_error_message = "\x1b[31;1mExcel file path is incorrect or missing. Usage: --file path/to/file.xlsx\x1b[0m\n"
+
+        self.assertIn(expected_error_message, command_output)
+
+    def test_populate_db_with_excel(self):
+        # Script with mock data file
+        with tempfile.NamedTemporaryFile(suffix='.xlsx', delete=False) as tmp:
+            mock_df = pd.DataFrame(self.mock_data)
+            mock_df.to_excel(tmp.name, index=False)
+
+        call_command("responsiblepersons", "--file", tmp.name)
+
+        persons = PersonService.get_all_persons()
+
+        self.assertEqual(len(persons), 3, "The count of successfully added person should be three")

--- a/infraohjelmointi_api/tests/test_Person.py
+++ b/infraohjelmointi_api/tests/test_Person.py
@@ -1,0 +1,168 @@
+from os import path
+import uuid
+
+from django.test import TestCase
+import environ
+from overrides import override
+
+from infraohjelmointi_api.models import Person
+from infraohjelmointi_api.services import PersonService
+
+
+if path.exists(".env"):
+    environ.Env().read_env(".env")
+
+env = environ.Env()
+
+import logging
+logger = logging.getLogger("infraohjelmointi_api")
+
+class ResponsiblePersonsCommandTestCase(TestCase):
+    _id = "994e931e-3abd-4b8c-b376-f97d913d1877"
+    _uuid = uuid.UUID(_id)
+    firstname = "John"
+    lastname = "Example"
+    email = "john.example@example.com"
+
+    @classmethod
+    @override
+    def setUpTestData(cls):
+        Person.objects.create(id=cls._uuid, firstName=cls.firstname, lastName=cls.lastname, email=cls.email)
+
+    def test_get_or_create_by_last_name(self):
+        lastname = "Smith"
+        
+        # Create new person by lastname
+        person, created = PersonService.get_or_create_by_last_name(lastName=lastname)
+        self.assertTrue(created, "Created should be False when creating a new person by lastname")
+        self.assertEqual(person.lastName, lastname, "The last name of the person should match the query")
+
+        # Get existing person by lastname
+        person, created = PersonService.get_or_create_by_last_name(lastName=self.lastname)
+        self.assertFalse(created, "Created should be False when retrieving an existing person by lastname")
+        self.assertEqual(person.lastName, self.lastname, "The last name of the person should match the query")
+
+    def test_get_or_create_by_first_name(self):
+        firstname = "Eva"
+        
+        # Create new person by firstname
+        person, created = PersonService.get_or_create_by_first_name(firstName=firstname)
+        self.assertTrue(created, "Created should be False when creating a new person by firstname")
+        self.assertEqual(person.firstName, firstname, "The first name of the person should match the query")
+
+        # Get existing person by firstname
+        person, created = PersonService.get_or_create_by_first_name(firstName=self.firstname)
+        self.assertFalse(created, "Created should be False when retrieving an existing person by firstname")
+        self.assertEqual(person.firstName, self.firstname, "The last name of the person should match the query")
+
+    def test_get_or_create_by_name(self):
+        firstname1 = "Matt"
+        firstname2 = "Sarah"
+        lastname1 = "Kalevala"
+        lastname2 = "Vainamoinen"
+        email = "matt.kalevala@example.com"
+
+        # Create new person without email
+        person, created = PersonService.get_or_create_by_name(firstName=firstname1, lastName=lastname1)
+        self.assertTrue(created, "Created should be False when creating a new person by first and lastname")
+        self.assertEqual(person.firstName, firstname1, "The first name of the person should match the query")
+        self.assertEqual(person.lastName, lastname1, "The first name of the person should match the query")
+
+        # Create new person including email
+        person, created = PersonService.get_or_create_by_name(firstName=firstname2, lastName=lastname2, email=email)
+        self.assertTrue(created, "Created should be False when creating a new person by first, lastname, and email")
+        self.assertEqual(person.firstName, firstname2, "The first name of the person should match the query")
+        self.assertEqual(person.lastName, lastname2, "The first name of the person should match the query")
+        self.assertEqual(person.email, email, "The email of the person should match the query")
+
+        # Get existing person by name and email
+        person, created = PersonService.get_or_create_by_name(firstName=self.firstname, lastName=self.lastname, email=self.email)
+        self.assertFalse(created, "Created should be False when retrieving an existing person by firstname")
+        self.assertEqual(person.firstName, self.firstname, "The last name of the person should match the query")
+        self.assertEqual(person.lastName, self.lastname, "The last name of the person should match the query")
+        self.assertEqual(person.email, self.email, "The email of the person should match the query")
+
+    def test_get_by_email(self):
+        emailnotfound = "email@notfound.com"
+
+        # Get Person with email
+        person, _ = PersonService.get_by_email(email=self.email)
+        self.assertEqual(person.email, self.email, "The email of the person should match the query")
+
+        # Search Person with no results
+        person, _ = PersonService.get_by_email(email=emailnotfound)
+        self.assertEqual(person, None, "The Person object should not be found when searching with unknown email")
+
+    def test_get_by_name(self):
+        # Get person
+        person = PersonService.get_by_name(firstName=self.firstname, lastName=self.lastname)
+        self.assertEqual(person.firstName, self.firstname, "The last name of the person should match the query")
+        self.assertEqual(person.lastName, self.lastname, "The last name of the person should match the query")
+
+        # Create duplicate Person with the same name
+        Person.objects.create(firstName=self.firstname, lastName=self.lastname)
+        persons = PersonService.get_by_name(firstName=self.firstname, lastName=self.lastname)
+        self.assertEqual(isinstance(persons, list), True, "Returned Person should be a list of multiple Persons")
+        self.assertEqual(len(persons), 2, "Returned persons list length should be 2")
+
+        for person in persons:
+            self.assertEqual(person.firstName, self.firstname, "The last name of the person should match the query")
+            self.assertEqual(person.lastName, self.lastname, "The last name of the person should match the query")
+
+        # Person does not exists
+        person = PersonService.get_by_name(firstName="Patric", lastName="Notfound")
+        self.assertEqual(person, None, "The Person object should not be found when searching with unknown email")
+
+    def test_create_by_name(self):
+        firstname = "Mark"
+        lastname = "Nieminen"
+        email = "mark.nieminen@example.com"
+
+        # Create a new person
+        try:
+            person = PersonService.create_by_name(firstName=firstname, lastName=lastname, email=email)
+        except Exception as e:
+            print(e)
+
+        # self.assertFalse(created, "Created should be False when creating a new person by first, lastname, and email")
+        self.assertEqual(person.firstName, firstname, "The first name of the person should match the query")
+        self.assertEqual(person.lastName, lastname, "The first name of the person should match the query")
+        self.assertEqual(person.email, email, "The email of the person should match the query")
+
+    def test_get_by_email(self):
+        email = "email.not@found.fi"
+        
+        # Get person by email
+        person = PersonService.get_by_email(email=self.email)
+        self.assertEqual(person.firstName, self.firstname, "The last name of the person should match the query")
+        self.assertEqual(person.lastName, self.lastname, "The last name of the person should match the query")
+        self.assertEqual(person.email, self.email, "The email of the person should match the query")
+
+        # Person not found
+        person = PersonService.get_by_email(email=email)
+        self.assertEqual(person, None, "The Person object should not be found when searching with unknown email")
+
+    def test_get_by_id(self):
+        idnotfound = "07ba0e37-61fd-4408-8f9b-6ff3ac4f333a"
+
+        # Get person by UUID
+        person = PersonService.get_by_id(id=self._id)
+        self.assertEqual(person.id, self._uuid, "The UUID of the person should match the query")
+        self.assertEqual(person.firstName, self.firstname, "The last name of the person should match the query")
+        self.assertEqual(person.lastName, self.lastname, "The last name of the person should match the query")
+        self.assertEqual(person.email, self.email, "The email of the person should match the query")
+
+        # Person not found
+        person = PersonService.get_by_id(id=idnotfound)
+        self.assertEqual(person, None, "The Person object should not be found when searching with unknown email")
+
+    def test_get_all_persons(self):
+        _ = PersonService.create_by_name(firstName="Test1", lastName="Example1", email="test.example1@test.com")
+        _ = PersonService.create_by_name(firstName="Test2", lastName="Example2", email="test.example2@test.com")
+        _ = PersonService.create_by_name(firstName="Test3", lastName="Example3", email="test.example3@test.com")
+
+        # Total count of person is four
+        persons = PersonService.get_all_persons()
+        self.assertEqual(isinstance(persons, list), True, "Returned data should be a list of multiple Persons")
+        self.assertEqual(len(persons), 4, "Returned list of multiple Person should be exactly 10")
+

--- a/infraohjelmointi_api/tests/test_Person.py
+++ b/infraohjelmointi_api/tests/test_Person.py
@@ -34,7 +34,7 @@ class ResponsiblePersonsCommandTestCase(TestCase):
         
         # Create new person by lastname
         person, created = PersonService.get_or_create_by_last_name(lastName=lastname)
-        self.assertTrue(created, "Created should be False when creating a new person by lastname")
+        self.assertTrue(created, "Created should be True when creating a new person by lastname")
         self.assertEqual(person.lastName, lastname, "The last name of the person should match the query")
 
         # Get existing person by lastname
@@ -47,13 +47,13 @@ class ResponsiblePersonsCommandTestCase(TestCase):
         
         # Create new person by firstname
         person, created = PersonService.get_or_create_by_first_name(firstName=firstname)
-        self.assertTrue(created, "Created should be False when creating a new person by firstname")
+        self.assertTrue(created, "Created should be True when creating a new person by firstname")
         self.assertEqual(person.firstName, firstname, "The first name of the person should match the query")
 
         # Get existing person by firstname
         person, created = PersonService.get_or_create_by_first_name(firstName=self.firstname)
         self.assertFalse(created, "Created should be False when retrieving an existing person by firstname")
-        self.assertEqual(person.firstName, self.firstname, "The last name of the person should match the query")
+        self.assertEqual(person.firstName, self.firstname, "The first name of the person should match the query")
 
     def test_get_or_create_by_name(self):
         firstname1 = "Matt"
@@ -62,23 +62,23 @@ class ResponsiblePersonsCommandTestCase(TestCase):
         lastname2 = "Vainamoinen"
         email = "matt.kalevala@example.com"
 
-        # Create new person without email
+        # Create new person without email. Creating a new person without email is allowed.
         person, created = PersonService.get_or_create_by_name(firstName=firstname1, lastName=lastname1)
-        self.assertTrue(created, "Created should be False when creating a new person by first and lastname")
+        self.assertTrue(created, "Created should be True when creating a new person by first and lastname")
         self.assertEqual(person.firstName, firstname1, "The first name of the person should match the query")
-        self.assertEqual(person.lastName, lastname1, "The first name of the person should match the query")
+        self.assertEqual(person.lastName, lastname1, "The last name of the person should match the query")
 
         # Create new person including email
         person, created = PersonService.get_or_create_by_name(firstName=firstname2, lastName=lastname2, email=email)
-        self.assertTrue(created, "Created should be False when creating a new person by first, lastname, and email")
+        self.assertTrue(created, "Created should be True when creating a new person by first, lastname, and email")
         self.assertEqual(person.firstName, firstname2, "The first name of the person should match the query")
-        self.assertEqual(person.lastName, lastname2, "The first name of the person should match the query")
+        self.assertEqual(person.lastName, lastname2, "The last name of the person should match the query")
         self.assertEqual(person.email, email, "The email of the person should match the query")
 
         # Get existing person by name and email
         person, created = PersonService.get_or_create_by_name(firstName=self.firstname, lastName=self.lastname, email=self.email)
         self.assertFalse(created, "Created should be False when retrieving an existing person by firstname")
-        self.assertEqual(person.firstName, self.firstname, "The last name of the person should match the query")
+        self.assertEqual(person.firstName, self.firstname, "The first name of the person should match the query")
         self.assertEqual(person.lastName, self.lastname, "The last name of the person should match the query")
         self.assertEqual(person.email, self.email, "The email of the person should match the query")
 
@@ -96,7 +96,7 @@ class ResponsiblePersonsCommandTestCase(TestCase):
     def test_get_by_name(self):
         # Get person
         person = PersonService.get_by_name(firstName=self.firstname, lastName=self.lastname)
-        self.assertEqual(person.firstName, self.firstname, "The last name of the person should match the query")
+        self.assertEqual(person.firstName, self.firstname, "The first name of the person should match the query")
         self.assertEqual(person.lastName, self.lastname, "The last name of the person should match the query")
 
         # Create duplicate Person with the same name
@@ -106,7 +106,7 @@ class ResponsiblePersonsCommandTestCase(TestCase):
         self.assertEqual(len(persons), 2, "Returned persons list length should be 2")
 
         for person in persons:
-            self.assertEqual(person.firstName, self.firstname, "The last name of the person should match the query")
+            self.assertEqual(person.firstName, self.firstname, "The first name of the person should match the query")
             self.assertEqual(person.lastName, self.lastname, "The last name of the person should match the query")
 
         # Person does not exists
@@ -126,7 +126,7 @@ class ResponsiblePersonsCommandTestCase(TestCase):
 
         # self.assertFalse(created, "Created should be False when creating a new person by first, lastname, and email")
         self.assertEqual(person.firstName, firstname, "The first name of the person should match the query")
-        self.assertEqual(person.lastName, lastname, "The first name of the person should match the query")
+        self.assertEqual(person.lastName, lastname, "The last name of the person should match the query")
         self.assertEqual(person.email, email, "The email of the person should match the query")
 
     def test_get_by_email(self):
@@ -134,7 +134,7 @@ class ResponsiblePersonsCommandTestCase(TestCase):
         
         # Get person by email
         person = PersonService.get_by_email(email=self.email)
-        self.assertEqual(person.firstName, self.firstname, "The last name of the person should match the query")
+        self.assertEqual(person.firstName, self.firstname, "The first name of the person should match the query")
         self.assertEqual(person.lastName, self.lastname, "The last name of the person should match the query")
         self.assertEqual(person.email, self.email, "The email of the person should match the query")
 
@@ -148,7 +148,7 @@ class ResponsiblePersonsCommandTestCase(TestCase):
         # Get person by UUID
         person = PersonService.get_by_id(id=self._id)
         self.assertEqual(person.id, self._uuid, "The UUID of the person should match the query")
-        self.assertEqual(person.firstName, self.firstname, "The last name of the person should match the query")
+        self.assertEqual(person.firstName, self.firstname, "The first name of the person should match the query")
         self.assertEqual(person.lastName, self.lastname, "The last name of the person should match the query")
         self.assertEqual(person.email, self.email, "The email of the person should match the query")
 
@@ -164,5 +164,5 @@ class ResponsiblePersonsCommandTestCase(TestCase):
         # Total count of person is four
         persons = PersonService.get_all_persons()
         self.assertEqual(isinstance(persons, list), True, "Returned data should be a list of multiple Persons")
-        self.assertEqual(len(persons), 4, "Returned list of multiple Person should be exactly 10")
+        self.assertEqual(len(persons), 4, "Returned list of multiple Person should be exactly 4")
 


### PR DESCRIPTION
KaPu app requires email addresses for responsible persons. The script, that was used to import new responsible persons, did not have the feature to include emails.

With this change, the imported excel requires three columns: first name, last name, and email.

If the email address is incorrect (is checked if the string does not have symbol '@') or empty, the data will not be added. Also, all data that was not added, will be shown at the end of the run.

```
/app $ python manage.py responsiblepersons --file .uusi/name_import.xlsx 
2024-09-16 10:28:19,500 INFO /app/infraohjelmointi_api/management/commands/responsiblepersons.py:95 Person added: Touko Testi1, email 'abc@a.fi' (00b9f68b-dbbb-4ff1-94e7-91128d0908ae)
2024-09-16 10:28:19,501 INFO /app/infraohjelmointi_api/management/commands/responsiblepersons.py:95 Person added: Kalle Testi4, email 'cde@e.fi' (b52e2bd5-c7b3-4dae-adfb-f74165e11ec7)
2024-09-16 10:28:19,501 ERROR /app/infraohjelmointi_api/management/commands/responsiblepersons.py:110 Error with following data:
Katri Testi2, email: 'abc'
Pekka Testi3, email: 'None'
Done.
```