### PR TITLE
HKISD-179/fetch updated projects successfully

### DIFF
--- a/infraohjelmointi_api/views/api/ApiProjectsViewSet.py
+++ b/infraohjelmointi_api/views/api/ApiProjectsViewSet.py
@@ -64,6 +64,8 @@ class ApiProjectsViewSet(BaseViewSet):
         queryset = self.queryset
         if project_class_id is not None:
             queryset = queryset.filter(projectClass__id=uuid.UUID(project_class_id))
+        else:
+            queryset = Project.objects.all()
         self.queryset = queryset
         serializer = self.get_serializer(self.queryset, many=True)
         return Response(serializer.data)


### PR DESCRIPTION
Previously updated projects were not listed when fetching all projects using the API `/projects` endpoint. The API fetched the information only once, and used the same result for other `/projects` endpoint fetches.

This issue is visible only for the this specific endpoint. Other endpoints such as `/projects/<id>` (to fetch specific project object) returned updated values.

The fix forces to get all project objects.