### PR TITLE
build: set specific version for the ubi9-python image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi9/python-311:latest
+FROM registry.access.redhat.com/ubi9/python-311:1-77.1726664316
 
 WORKDIR /app
 


### PR DESCRIPTION
Set specific version for the Python image. The issue about version tag `:latest` was raised by SonarCloud check.