### PR TITLE
fix: add configurable TWISTED_MAX_LINE_LENGTH setting

### DIFF
--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -18,5 +18,5 @@ fi
 if [[ "$DEV_SERVER" = "True" ]]; then
     python /app/manage.py runserver 0.0.0.0:8000
 else
-    daphne -b 0.0.0.0 -p 8000 --http-request-header-size 32768 project.asgi:application
+    daphne -b 0.0.0.0 -p 8000 project.asgi:application
 fi

--- a/project/settings.py
+++ b/project/settings.py
@@ -40,6 +40,7 @@ env = environ.Env(
     HELSINKI_TUNNISTUS_AUDIENCE=(str, "infraohjelmointi-api-dev"),
     HELUSERS_BACK_CHANNEL_LOGOUT_ENABLED=(bool, False),
     SOCIAL_AUTH_TUNNISTAMO_SCOPE=(str, "ad_group"),
+    TWISTED_MAX_LINE_LENGTH=(int, 32768),
 )
 
 if path.exists(".env"):
@@ -262,3 +263,20 @@ SWAGGER_SETTINGS = {
     'SUPPORTED_SUBMIT_METHODS': ['get'],
     'USE_SESSION_AUTH': False,
 }
+
+TWISTED_MAX_LINE_LENGTH = env("TWISTED_MAX_LINE_LENGTH")
+
+def overwrite_twisted_max_line_length(max_line_length):
+    """
+    Twisted has a default max line length of 16384.
+    The following is used to override the default length which is necessary
+    for long headers - in the case of helsinki-tunnistus the Authentication
+    header can be rather long if the user has many AD groups.
+    """
+    from twisted.protocols.basic import LineReceiver
+    from twisted.web.http import HTTPChannel
+
+    LineReceiver.MAX_LENGTH = max_line_length
+    HTTPChannel.totalHeadersSize = max_line_length
+
+overwrite_twisted_max_line_length(TWISTED_MAX_LINE_LENGTH)


### PR DESCRIPTION
Twisted (and therefore daphne) defaults to a max line length of 16384. This is not enough due to a relatively long Authentication header created by helsinki-tunnistus for certain AD users that have many AD groups. It is possible to change this config directly in twisted during runtime, but it is not configurable in daphne itself.