### PR TITLE
fix: HKISD-184 add configurable TWISTED_MAX_LINE_LENGTH setting

### DIFF
--- a/project/settings.py
+++ b/project/settings.py
@@ -40,6 +40,7 @@ env = environ.Env(
     HELSINKI_TUNNISTUS_AUDIENCE=(str, "infraohjelmointi-api-dev"),
     HELUSERS_BACK_CHANNEL_LOGOUT_ENABLED=(bool, False),
     SOCIAL_AUTH_TUNNISTAMO_SCOPE=(str, "ad_group"),
+    TWISTED_MAX_LINE_LENGTH=(int, 32768),
 )
 
 if path.exists(".env"):
@@ -262,3 +263,20 @@ SWAGGER_SETTINGS = {
     'SUPPORTED_SUBMIT_METHODS': ['get'],
     'USE_SESSION_AUTH': False,
 }
+
+TWISTED_MAX_LINE_LENGTH = env("TWISTED_MAX_LINE_LENGTH")
+
+def overwrite_twisted_max_line_length(max_line_length):
+    """
+    Twisted has a default max line length of 16384.
+    The following is used to override the default length which is necessary
+    for long headers - in the case of helsinki-tunnistus the Authentication
+    header can be rather long if the user has many AD groups.
+    """
+    from twisted.protocols.basic import LineReceiver
+    from twisted.web.http import HTTPChannel
+
+    LineReceiver.MAX_LENGTH = max_line_length
+    HTTPChannel.totalHeadersSize = max_line_length
+
+overwrite_twisted_max_line_length(TWISTED_MAX_LINE_LENGTH)


### PR DESCRIPTION
Twisted (and therefore daphne) defaults to a max line length of 16384. This is not enough due to a relatively long Authentication header created by helsinki-tunnistus for certain AD users that have many AD groups. It is possible to change this config directly in twisted during runtime, but it is not configurable in daphne itself.

--
This is a cherry-pick from develop branch. Dev/test build pipelines are not working, and Platta doesn't know when those will be fixed, so as this change is needed urgently to main, this cherry-pick was made. 