### PR TITLE
HKISD-159 add eri suurpiirejä location option

### DIFF
--- a/infraohjelmointi_api/management/commands/locationimporter.py
+++ b/infraohjelmointi_api/management/commands/locationimporter.py
@@ -24,9 +24,13 @@ class Command(BaseCommand):
             "--eri-kaupunginosia",
             action="store_true",
         )
+        parser.add_argument(
+            "--eri-suurpiirejä",
+            action="store_true",
+        )
 
     def handle(self, *args, **options):
-        if not options["file"] and not options["eri_kaupunginosia"]:
+        if not options["file"] and not options["eri_kaupunginosia"] and not options["eri_suurpiirejä"]:
             self.stdout.write(
                 self.style.ERROR(
                     "No arguments given. "
@@ -36,6 +40,10 @@ class Command(BaseCommand):
             return
         if options["eri_kaupunginosia"] is True:
             self.add_eri_kaupunginosia_location_option()
+            return
+        
+        if options["eri_suurpiirejä"] is True:
+            self.add_eri_suurpiirejä_location_option()
             return
         
         if not os.path.isfile(options["file"]):
@@ -78,3 +86,14 @@ class Command(BaseCommand):
             self.stdout.write(
                 self.style.NOTICE(division.name + " division was added under " + district.name + " district")
             )
+
+    def add_eri_suurpiirejä_location_option(self):
+        division = ProjectDistrictService.get_or_create(
+            name='Eri suurpiirejä',
+            path='Eri suurpiirejä',
+            parent=None,
+            level="district",
+            )[0]
+        self.stdout.write(
+            self.style.NOTICE(division.name + " district was added")
+        )


### PR DESCRIPTION
- added a script to add "Eri suurpiirejä location option
- UI PR: https://github.com/City-of-Helsinki/infraohjelmointi-ui/pull/278
- to test:
in the ap docker container first run
`python manage.py locationimporter --eri-suurpiirejä`
and then
`python manage.py locationimporter --eri-kaupunginosia`
Check from the UI that the district menu on a project card has "Eri suurpiirejä" option and when that is selected, division menu has only one option and it's "Eri kaupunginosia"