### PR TITLE
HKSID-133 Rounded all costForecasts in db

### DIFF
--- a/update-costForecast.sql
+++ b/update-costForecast.sql
@@ -1,0 +1,4 @@
+-- Round costForecast to whole numbers, in order to then run 0056_alter_project_costforecast.py migration to PositiveIntegerField
+-- This needs to be done prior to migrating, otherwise costForecast already in DB will be deleted
+UPDATE infraohjelmointi_api_project
+SET "costForecast" = ROUND("costForecast");

--- a/update-costForecast.sql
+++ b/update-costForecast.sql
@@ -1,4 +1,5 @@
 -- Round costForecast to whole numbers, in order to then run 0056_alter_project_costforecast.py migration to PositiveIntegerField
 -- This needs to be done prior to migrating, otherwise costForecast already in DB will be deleted
 UPDATE infraohjelmointi_api_project
-SET "costForecast" = ROUND("costForecast");
+SET "costForecast" = ROUND("costForecast")
+WHERE "costForecast" IS NOT NULL;


### PR DESCRIPTION
Updated: Rounded all costForecast numbers to whole numbers.

This is needed to be done prior to running the next PR which is a migration from decimal to int
