### PR TITLE
fix: HKISD-149 set project ID to None if SAP cost for project group

### DIFF
--- a/infraohjelmointi_api/services/SapApiService.py
+++ b/infraohjelmointi_api/services/SapApiService.py
@@ -258,7 +258,7 @@ class SapApiService:
                     )
         if project_group_id is not None:
             group_sap_cost, _ = SapCostService.get_or_create(
-                project_id="",
+                project_id=None,
                 group_id=project_group_id,
                 year=current_year,
             )

--- a/infraohjelmointi_api/services/SapCostService.py
+++ b/infraohjelmointi_api/services/SapCostService.py
@@ -27,7 +27,7 @@ class SapCostService:
         return SapCost.objects.filter(year=year)
 
     @staticmethod
-    def get_or_create(project_id: str, group_id: str, year: int) -> SapCost:
+    def get_or_create(project_id: str|None, group_id: str|None, year: int) -> SapCost:
         return SapCost.objects.get_or_create(
             project_id=project_id, project_group_id=group_id, year=year
         )


### PR DESCRIPTION
Fixes the ValueError issue when trying to create or get a SapCost data without project ID UUID.