### PR TITLE
HKISD-149: fix path to python/django

### DIFF
--- a/sync-from-sap.sh
+++ b/sync-from-sap.sh
@@ -5,4 +5,4 @@ set -e
 # needed for crontab
 cd /app
 # full path for python needed fron crontab
-/usr/local/bin/python manage.py sapsynchronizer
+/opt/app-root/bin/python manage.py sapsynchronizer


### PR DESCRIPTION
### Problem
Cronjob in openshift has been failing since either django update or image change.

Error is not in cronjob itself. Cronjob is running the script and that script is running file sapsynchronizer.py. In this file django module was searched from path /usr/local/bin/python, this PR changes it to /opt/app-root/bin/python. 

In /usr/local/bin/python there is no django, which is the reason for error in cronjob: cannot find module django. 
You can check the error by running in the openshift terminal:
` /app/sync-from-sap.sh`

### Testing
In this branch run
` docker-compose up --build --force-recreate`

Then when docker is running check that in /opt/app-root/bin/python there is django by running this command inside the container:
` /opt/app-root/bin/python -m pip list`
You can see Django 4.2 there.

Then you can try to run the script sync.from-sap.sh in the container with:
`/app/sync-from-sap.sh`

### Compare to situation before this PR:
If you run these in dev branch for example, you get error django module is not found:
` docker-compose up --build --force-recreate`
`/app/sync-from-sap.sh`

