### PR TITLE
HKISD-229: fix bug when planning start in future

### DIFF
--- a/infraohjelmointi_api/services/SapApiService.py
+++ b/infraohjelmointi_api/services/SapApiService.py
@@ -381,7 +381,7 @@ class SapApiService:
         else:
             return response.json()["d"]["results"]
     
-    def __validate_costs_and_commitments(costs_and_commitments: list) -> bool:
+    def __validate_costs_and_commitments(self, costs_and_commitments: list) -> bool:
         if 'all_sap_data' in costs_and_commitments and 'current_year' in costs_and_commitments:
             return True
         

--- a/infraohjelmointi_api/services/SapApiService.py
+++ b/infraohjelmointi_api/services/SapApiService.py
@@ -77,7 +77,7 @@ class SapApiService:
                     self.get_project_costs_and_commitments_from_sap(sap_id)
                 )
 
-                if 'all_sap_data' in sap_costs_and_commitments and 'current_year' in sap_costs_and_commitments:
+                if self.__validate_costs_and_commitments(sap_costs_and_commitments) :
                     costs_by_sap_id_all[sap_id] = sap_costs_and_commitments["all_sap_data"]
                     costs_by_sap_id_current_year[sap_id] = sap_costs_and_commitments["current_year"]
 
@@ -106,9 +106,6 @@ class SapApiService:
                         projects_grouped_by_sap_id=projects_grouped_by_sap_id,
                         current_year=current_year,
                     )
-                else:
-                    logger.error(
-                        f"Skipped SAP data fetch for id {id}")
 
     def get_project_costs_and_commitments_from_sap(
         self,
@@ -383,3 +380,10 @@ class SapApiService:
 
         else:
             return response.json()["d"]["results"]
+    
+    def __validate_costs_and_commitments(costs_and_commitments: list) -> bool:
+        if 'all_sap_data' in costs_and_commitments and 'current_year' in costs_and_commitments:
+            return True
+        
+        else:
+            return False

--- a/infraohjelmointi_api/services/SapApiService.py
+++ b/infraohjelmointi_api/services/SapApiService.py
@@ -77,34 +77,38 @@ class SapApiService:
                     self.get_project_costs_and_commitments_from_sap(sap_id)
                 )
 
-                costs_by_sap_id_all[sap_id] = sap_costs_and_commitments["all_sap_data"]
-                costs_by_sap_id_current_year[sap_id] = sap_costs_and_commitments["current_year"]
+                if 'all_sap_data' in sap_costs_and_commitments and 'current_year' in sap_costs_and_commitments:
+                    costs_by_sap_id_all[sap_id] = sap_costs_and_commitments["all_sap_data"]
+                    costs_by_sap_id_current_year[sap_id] = sap_costs_and_commitments["current_year"]
 
-                handling_time = time.perf_counter() - start_time
-                if sync_group:
-                    logger.debug(
-                        f"Finished fetching data from SAP for project group '{group_id}' in {handling_time}s"
+                    handling_time = time.perf_counter() - start_time
+                    if sync_group:
+                        logger.debug(
+                            f"Finished fetching data from SAP for project group '{group_id}' in {handling_time}s"
+                        )
+                    else:
+                        logger.info(
+                            f"Finished fetching data from SAP for project {project_id_list} in {handling_time}s"
+                        )
+
+                    self.__store_sap_data(
+                        service_class = SapCostService,
+                        group_id=group_id,
+                        costs_by_sap_id=costs_by_sap_id_all,
+                        projects_grouped_by_sap_id=projects_grouped_by_sap_id,
+                        current_year=current_year,
+                    )
+
+                    self.__store_sap_data(
+                        service_class = SapCurrentYearService,
+                        group_id=group_id,
+                        costs_by_sap_id=costs_by_sap_id_current_year,
+                        projects_grouped_by_sap_id=projects_grouped_by_sap_id,
+                        current_year=current_year,
                     )
                 else:
-                    logger.info(
-                        f"Finished fetching data from SAP for project {project_id_list} in {handling_time}s"
-                    )
-
-            self.__store_sap_data(
-                service_class = SapCostService,
-                group_id=group_id,
-                costs_by_sap_id=costs_by_sap_id_all,
-                projects_grouped_by_sap_id=projects_grouped_by_sap_id,
-                current_year=current_year,
-            )
-
-            self.__store_sap_data(
-                service_class = SapCurrentYearService,
-                group_id=group_id,
-                costs_by_sap_id=costs_by_sap_id_current_year,
-                projects_grouped_by_sap_id=projects_grouped_by_sap_id,
-                current_year=current_year,
-            )
+                    logger.error(
+                        f"Skipped SAP data fetch for id {id}")
 
     def get_project_costs_and_commitments_from_sap(
         self,


### PR DESCRIPTION
There is a bug if project has planning start year in the future. Then function get_project_costs_and_commitments_from_sap in returning empty object {}, and that was not handled in the code. 
If planning start year is in the future and empty object is received (line 77), then `'all_sap_data' in sap_costs_and_commitments and 'current_year' in sap_costs_and_commitments` is false, nothing is saved to database.