### PR TITLE
HKISD-255: add script to fetch sap data for certain year

### DIFF
--- a/infraohjelmointi_api/management/commands/fetchsapdatabyyear.py
+++ b/infraohjelmointi_api/management/commands/fetchsapdatabyyear.py
@@ -33,8 +33,6 @@ class Command(BaseCommand):
         # Validate that the year is an integer and within a reasonable range
         try:
             year_int = int(year)
-        
-            # Additional year range check (2000 to current year+1)
             current_year = datetime.now().year
             if year_int < 2000 or year_int > current_year + 1:
                 raise ValueError("Year out of valid range.")
@@ -43,5 +41,4 @@ class Command(BaseCommand):
             self.stdout.write(self.style.ERROR(f"Invalid year argument: {year}. Error: {e}"))
             return
         
-        # If the year is valid, proceed with the SAP API service call
         SapApiService().sync_all_projects_from_sap(forFinancialStatement=True, sap_year=year)

--- a/infraohjelmointi_api/management/commands/fetchsapdatabyyear.py
+++ b/infraohjelmointi_api/management/commands/fetchsapdatabyyear.py
@@ -6,7 +6,7 @@ from ...services import SapApiService
 
 
 class Command(BaseCommand):
-    help = "Synchronize SAP costs after financial statement is locked. " + "\nUsage: python manage.py fetchsapdatabyyear"
+    help = "Synchronize SAP costs after financial statement is locked. " + "\nUsage: python manage.py fetchsapdatabyyear --year <year>"
 
     def add_arguments(self, parser):
         """

--- a/infraohjelmointi_api/management/commands/fetchsapdatabyyear.py
+++ b/infraohjelmointi_api/management/commands/fetchsapdatabyyear.py
@@ -1,0 +1,47 @@
+from datetime import datetime
+from django.core.management.base import BaseCommand, CommandError
+
+from django.db import transaction
+from ...services import SapApiService
+
+
+class Command(BaseCommand):
+    help = "Synchronize SAP costs after financial statement is locked. " + "\nUsage: python manage.py fetchsapdatabyyear"
+
+    def add_arguments(self, parser):
+        """
+        Add the following arguments to the command
+        """
+
+        parser.add_argument(
+            "--year",
+            type=int,
+            help="Year to sync",
+        )
+
+    @transaction.atomic
+    def handle(self, *args, **options):
+        year = options["year"]
+        if not options["year"]:
+            self.stdout.write(
+                self.style.ERROR(
+                    "No arguments given. "
+                    + "\nUsage: python manage.py fetchsapdatabyyear --year <year>"
+                )
+            )
+            return
+        # Validate that the year is an integer and within a reasonable range
+        try:
+            year_int = int(year)
+        
+            # Additional year range check (2000 to current year+1)
+            current_year = datetime.now().year
+            if year_int < 2000 or year_int > current_year + 1:
+                raise ValueError("Year out of valid range.")
+        
+        except ValueError as e:
+            self.stdout.write(self.style.ERROR(f"Invalid year argument: {year}. Error: {e}"))
+            return
+        
+        # If the year is valid, proceed with the SAP API service call
+        SapApiService().sync_all_projects_from_sap(forFinancialStatement=True, sap_year=year)

--- a/infraohjelmointi_api/management/commands/fetchsapdatabyyear.py
+++ b/infraohjelmointi_api/management/commands/fetchsapdatabyyear.py
@@ -41,4 +41,4 @@ class Command(BaseCommand):
             self.stdout.write(self.style.ERROR(f"Invalid year argument: {year}. Error: {e}"))
             return
         
-        SapApiService().sync_all_projects_from_sap(forFinancialStatement=True, sap_year=year)
+        SapApiService().sync_all_projects_from_sap(for_financial_statement=True, sap_year=year)

--- a/infraohjelmointi_api/management/commands/sapsynchronizer.py
+++ b/infraohjelmointi_api/management/commands/sapsynchronizer.py
@@ -14,4 +14,4 @@ class Command(BaseCommand):
 
     @transaction.atomic
     def handle(self, *args, **options):
-        SapApiService().sync_all_projects_from_sap(forFinancialStatement=False)
+        SapApiService().sync_all_projects_from_sap(for_financial_statement=False)

--- a/infraohjelmointi_api/management/commands/sapsynchronizer.py
+++ b/infraohjelmointi_api/management/commands/sapsynchronizer.py
@@ -5,7 +5,7 @@ from ...services import SapApiService
 
 
 class Command(BaseCommand):
-    help = "Syncrhonize SAP costs. " + "\nUsage: python manage.py sapsynchronizer"
+    help = "Synchronize SAP costs. " + "\nUsage: python manage.py sapsynchronizer"
 
     def add_arguments(self, parser):
         """
@@ -14,4 +14,4 @@ class Command(BaseCommand):
 
     @transaction.atomic
     def handle(self, *args, **options):
-        SapApiService().sync_all_projects_from_sap()
+        SapApiService().sync_all_projects_from_sap(forFinancialStatement=False)

--- a/infraohjelmointi_api/services/SapApiService.py
+++ b/infraohjelmointi_api/services/SapApiService.py
@@ -37,9 +37,11 @@ class SapApiService:
         self.sap_api_costs_endpoint = env("SAP_COSTS_ENDPOINT")
         self.sap_api_commitments_endpoint = env("SAP_COMMITMENTS_ENDPOINT")
 
-    def sync_all_projects_from_sap(self) -> None:
+    def sync_all_projects_from_sap(self, forFinancialStatement: bool, sap_year=datetime.now().year) -> None:
         """Method to synchronise projects from SAP.\n
         Given projects must have sapProject otherwise project will not be syncrhonized.
+        Will get forFinancialStatement as True if called for fetching sap data for certain year only, 
+        then also this certain year is given as parameter.
         """
 
         logger.debug("Synchronizing all projects in DB with SAP")
@@ -47,7 +49,6 @@ class SapApiService:
 
         # group projects by sapProject, all projects belong to same group
         projects_grouped_by_groups = self.__group_projects_by_sap_id(projects=projects)
-        current_year = datetime.now().year
 
         # make only one call either for ungroupped project are all groupped projects
         for group_id in projects_grouped_by_groups.keys():
@@ -73,41 +74,72 @@ class SapApiService:
 
                 # fetch costs and commitments from SAP
                 start_time = time.perf_counter()
-                sap_costs_and_commitments = (
-                    self.get_project_costs_and_commitments_from_sap(sap_id)
-                )
+                sap_costs_and_commitments = {}
+                
+                # all sap data is fetched only if function is called from sapsynchronizer.py
+                if not forFinancialStatement:
+                    sap_costs_and_commitments["all_sap_data"] = (
+                        self.get_all_project_costs_and_commitments_from_sap(sap_id)
+                    )
+                
+                sap_costs_and_commitments["current_year"] = (
+                    self.get_costs_and_commitments_by_year(sap_id, sap_year)
+                ) 
 
-                if self.__validate_costs_and_commitments(sap_costs_and_commitments) :
+                handling_time = time.perf_counter() - start_time
+                if sync_group:
+                    logger.debug(
+                        f"Finished fetching data from SAP for project group '{group_id}' in {handling_time}s"
+                    )
+                else:
+                    logger.info(
+                        f"Finished fetching data from SAP for project {project_id_list} in {handling_time}s"
+                    )   
+
+                if self.__validate_costs_and_commitments(sap_costs_and_commitments):
                     costs_by_sap_id_all[sap_id] = sap_costs_and_commitments["all_sap_data"]
-                    costs_by_sap_id_current_year[sap_id] = sap_costs_and_commitments["current_year"]
-
-                    handling_time = time.perf_counter() - start_time
-                    if sync_group:
-                        logger.debug(
-                            f"Finished fetching data from SAP for project group '{group_id}' in {handling_time}s"
-                        )
-                    else:
-                        logger.info(
-                            f"Finished fetching data from SAP for project {project_id_list} in {handling_time}s"
-                        )
 
                     self.__store_sap_data(
                         service_class = SapCostService,
                         group_id=group_id,
                         costs_by_sap_id=costs_by_sap_id_all,
                         projects_grouped_by_sap_id=projects_grouped_by_sap_id,
-                        current_year=current_year,
+                        current_year=sap_year,
                     )
+                
+                costs_by_sap_id_current_year[sap_id] = sap_costs_and_commitments["current_year"]
+                self.__store_sap_data(
+                    service_class = SapCurrentYearService,
+                    group_id=group_id,
+                    costs_by_sap_id=costs_by_sap_id_current_year,
+                    projects_grouped_by_sap_id=projects_grouped_by_sap_id,
+                    current_year=sap_year,
+                )
 
-                    self.__store_sap_data(
-                        service_class = SapCurrentYearService,
-                        group_id=group_id,
-                        costs_by_sap_id=costs_by_sap_id_current_year,
-                        projects_grouped_by_sap_id=projects_grouped_by_sap_id,
-                        current_year=current_year,
-                    )
+    def get_costs_and_commitments_by_year(self, id: str, year) -> dict:
+        """Method to fetch costs and commitments from SAP for given year"""
+        logger.debug(f"Fetching SAP costs and commitments for year {year}")
 
-    def get_project_costs_and_commitments_from_sap(
+        # Time frame for sap fetch is from 1.1.{year} to 1.1.{year+1}
+        budat_start = datetime.now().replace(year=year, month=1, day=1, hour=0, minute=0, second=0)
+        budat_end = datetime.now().replace(year=year+1, month=1, day=1, hour=0, minute=0, second=0)
+        start_year = year
+
+        # Timeframe for fetching certain year's sap data is from 1.1.{start_year} to 1.1.{start_year+1}
+        logger.debug("Starting to fetch costs and commitments for SAP id {id} from {start_year} to {budat_end}")
+        json_response_current_year = self.__fetch_costs_and_commitments_from_sap(budat_start, budat_end, start_year, id, all_sap_commitments=False)
+
+        grouped_costs_and_commitments_current_year = self.__group_costs_and_commitments( 
+        sap_costs_and_commitments=json_response_current_year,
+        sap_id=id,
+        )
+
+        sap_costs_and_commitments = []
+        sap_costs_and_commitments = grouped_costs_and_commitments_current_year
+
+        return sap_costs_and_commitments
+
+    def get_all_project_costs_and_commitments_from_sap(
         self,
         id: str,
         budat_start: datetime = datetime.now().replace(
@@ -134,26 +166,16 @@ class SapApiService:
                 sap_start_year = project.planningStartYear
 
         if sap_start_year:
-            start_year = datetime.now().year
+            # Timeframe for fetching all sap data is from 1.1.{planning_start_year_in_project} to 1.1.{currentyear+1}
             logger.debug("Starting to fetch all costs for SAP id {id} from {sap_start_year} to {budat_end}, and all commitments from {sap_start_year} to {budat_end} +5 years")
             json_response_all = self.__fetch_costs_and_commitments_from_sap(budat_start, budat_end, sap_start_year, id, all_sap_commitments=True)
-            logger.debug("Starting to fetch current year's costs and commitments for SAP id {id} from {start_year} to {budat_end}")
-            json_response_current_year = self.__fetch_costs_and_commitments_from_sap(budat_start, budat_end, start_year, id, all_sap_commitments=False)
 
             grouped_costs_and_commitments_all = self.__group_costs_and_commitments(
                 sap_costs_and_commitments=json_response_all,
                 sap_id=id,
             )
-
-            grouped_costs_and_commitments_current_year = self.__group_costs_and_commitments(
-                sap_costs_and_commitments=json_response_current_year,
-                sap_id=id,
-            )
-
-            sap_costs_and_commitments = {
-                "all_sap_data": grouped_costs_and_commitments_all,
-                "current_year": grouped_costs_and_commitments_current_year
-            }
+            sap_costs_and_commitments = []
+            sap_costs_and_commitments= grouped_costs_and_commitments_all
 
             return sap_costs_and_commitments
         

--- a/infraohjelmointi_api/services/SapApiService.py
+++ b/infraohjelmointi_api/services/SapApiService.py
@@ -37,10 +37,10 @@ class SapApiService:
         self.sap_api_costs_endpoint = env("SAP_COSTS_ENDPOINT")
         self.sap_api_commitments_endpoint = env("SAP_COMMITMENTS_ENDPOINT")
 
-    def sync_all_projects_from_sap(self, forFinancialStatement: bool, sap_year=datetime.now().year) -> None:
+    def sync_all_projects_from_sap(self, for_financial_statement: bool, sap_year=datetime.now().year) -> None:
         """Method to synchronise projects from SAP.\n
         Given projects must have sapProject otherwise project will not be syncrhonized.
-        Will get forFinancialStatement as True if called for fetching sap data for certain year only, 
+        Will get for_financial_statement as True if called for fetching sap data for certain year only, 
         then also this certain year is given as parameter.
         """
 
@@ -78,7 +78,7 @@ class SapApiService:
                 
                 # all sap data is not fetched, if function is called for getting sap data for certain year, 
                 # f.g. for financial statement
-                if not forFinancialStatement:
+                if not for_financial_statement:
                     sap_costs_and_commitments["all_sap_data"] = (
                         self.get_all_project_costs_and_commitments_from_sap(sap_id)
                     )
@@ -151,7 +151,7 @@ class SapApiService:
         ),
     ) -> dict:
         """Method to fetch costs and commitments from SAP with given SAP project id"""
-        logger.debug(f"in get_project_costs_and_commitments_from_sap")
+        logger.debug("in get_project_costs_and_commitments_from_sap")
 
         # Fetch projects by SAP ID and get earliest planning start year
         projects = ProjectService.get_by_sap_id(id)
@@ -415,7 +415,7 @@ class SapApiService:
         else:
             return response.json()["d"]["results"]
     
-    def __validate_costs_and_commitments(self, costs_and_commitments: list) -> bool:
+    def __validate_costs_and_commitments(self, costs_and_commitments) -> bool:
         if 'all_sap_data' in costs_and_commitments and 'current_year' in costs_and_commitments:
             return True
         

--- a/infraohjelmointi_api/services/SapApiService.py
+++ b/infraohjelmointi_api/services/SapApiService.py
@@ -63,14 +63,7 @@ class SapApiService:
 
                 project_id_list = [p.id for p in projects_within_group]
 
-                if sync_group:
-                    logger.debug(
-                        f"Synchronizing given project group '{group_id}' with SAP Id '{sap_id}' from SAP"
-                    )
-                else:
-                    logger.debug(
-                        f"Synchronizing given project(s) '{project_id_list}' with SAP Id '{sap_id}' from SAP"
-                    )
+                self.__start_and_finish_log_print(sync_group, group_id, sap_id, project_id_list, is_start=True)
 
                 # fetch costs and commitments from SAP
                 start_time = time.perf_counter()
@@ -88,14 +81,8 @@ class SapApiService:
                 ) 
 
                 handling_time = time.perf_counter() - start_time
-                if sync_group:
-                    logger.debug(
-                        f"Finished fetching data from SAP for project group '{group_id}' in {handling_time}s"
-                    )
-                else:
-                    logger.info(
-                        f"Finished fetching data from SAP for project {project_id_list} in {handling_time}s"
-                    )   
+
+                self.__start_and_finish_log_print(sync_group, group_id, sap_id, project_id_list, is_start=False, handling_time=handling_time)  
 
                 if self.__validate_costs_and_commitments(sap_costs_and_commitments):
                     costs_by_sap_id_all[sap_id] = sap_costs_and_commitments["all_sap_data"]
@@ -421,3 +408,23 @@ class SapApiService:
         
         else:
             return False
+        
+    def __start_and_finish_log_print(self, sync_group, group_id, sap_id, project_id_list, is_start, handling_time=None):
+        if (is_start):
+            if sync_group:
+                logger.debug(
+                    f"Synchronizing given project group '{group_id}' with SAP Id '{sap_id}' from SAP"
+                )
+            else:
+                logger.debug(
+                    f"Synchronizing given project(s) '{project_id_list}' with SAP Id '{sap_id}' from SAP"
+                )
+        else:
+            if sync_group:
+                logger.debug(
+                    f"Finished fetching data from SAP for project group '{group_id}' in {handling_time}s"
+                )
+            else:
+                logger.info(
+                    f"Finished fetching data from SAP for project {project_id_list} in {handling_time}s"
+                )

--- a/infraohjelmointi_api/services/SapApiService.py
+++ b/infraohjelmointi_api/services/SapApiService.py
@@ -76,7 +76,8 @@ class SapApiService:
                 start_time = time.perf_counter()
                 sap_costs_and_commitments = {}
                 
-                # all sap data is fetched only if function is called from sapsynchronizer.py
+                # all sap data is not fetched, if function is called for getting sap data for certain year, 
+                # f.g. for financial statement
                 if not forFinancialStatement:
                     sap_costs_and_commitments["all_sap_data"] = (
                         self.get_all_project_costs_and_commitments_from_sap(sap_id)
@@ -126,7 +127,7 @@ class SapApiService:
         start_year = year
 
         # Timeframe for fetching certain year's sap data is from 1.1.{start_year} to 1.1.{start_year+1}
-        logger.debug("Starting to fetch costs and commitments for SAP id {id} from {start_year} to {budat_end}")
+        logger.debug(f"Starting to fetch costs and commitments for SAP id {id} from {budat_start} to {budat_end}")
         json_response_current_year = self.__fetch_costs_and_commitments_from_sap(budat_start, budat_end, start_year, id, all_sap_commitments=False)
 
         grouped_costs_and_commitments_current_year = self.__group_costs_and_commitments( 
@@ -150,7 +151,7 @@ class SapApiService:
         ),
     ) -> dict:
         """Method to fetch costs and commitments from SAP with given SAP project id"""
-        logger.debug("in get_project_costs_and_commitments_from_sap")
+        logger.debug(f"in get_project_costs_and_commitments_from_sap")
 
         # Fetch projects by SAP ID and get earliest planning start year
         projects = ProjectService.get_by_sap_id(id)
@@ -166,8 +167,9 @@ class SapApiService:
                 sap_start_year = project.planningStartYear
 
         if sap_start_year:
-            # Timeframe for fetching all sap data is from 1.1.{planning_start_year_in_project} to 1.1.{currentyear+1}
-            logger.debug("Starting to fetch all costs for SAP id {id} from {sap_start_year} to {budat_end}, and all commitments from {sap_start_year} to {budat_end} +5 years")
+            # Timeframe for fetching all sap data costs is from 1.1.{planning_start_year_in_project} to 1.1.{currentyear+1},
+            # and for commitments from 1.1.{planning_start_year_in_project} to 1.1.{currentyear+1+5}
+            logger.debug(f"Starting to fetch all costs for SAP id {id} from {sap_start_year} to {budat_end.year}, and all commitments from {sap_start_year} to {budat_end.year}+5 years")
             json_response_all = self.__fetch_costs_and_commitments_from_sap(budat_start, budat_end, sap_start_year, id, all_sap_commitments=True)
 
             grouped_costs_and_commitments_all = self.__group_costs_and_commitments(
@@ -226,7 +228,7 @@ class SapApiService:
             # Fetch commitments from planning start year to end of the current year
             end_date_for_commitment_fetch = budat_end
 
-        logger.debug("In commitment-fetch: start year: {start_year} and end_year: {end_date_for_commitment_fetch}")
+        logger.debug(f"In commitment-fetch: start year: {start_year} and end_year: {end_date_for_commitment_fetch}")
         api_url = f"{self.sap_api_url}{self.sap_api_commitments_endpoint}".format(
             posid=id,
             budat_start=budat_start.replace(year=start_year).strftime(

--- a/infraohjelmointi_api/services/SapApiService.py
+++ b/infraohjelmointi_api/services/SapApiService.py
@@ -84,7 +84,7 @@ class SapApiService:
 
                 self.__start_and_finish_log_print(sync_group, group_id, sap_id, project_id_list, is_start=False, handling_time=handling_time)  
 
-                if self.__validate_costs_and_commitments(sap_costs_and_commitments):
+                if self.validate_costs_and_commitments(sap_costs_and_commitments):
                     costs_by_sap_id_all[sap_id] = sap_costs_and_commitments["all_sap_data"]
 
                     self.__store_sap_data(
@@ -402,7 +402,7 @@ class SapApiService:
         else:
             return response.json()["d"]["results"]
     
-    def __validate_costs_and_commitments(self, costs_and_commitments) -> bool:
+    def validate_costs_and_commitments(self, costs_and_commitments) -> bool:
         if 'all_sap_data' in costs_and_commitments and 'current_year' in costs_and_commitments:
             return True
         

--- a/infraohjelmointi_api/tests/test_SAP.py
+++ b/infraohjelmointi_api/tests/test_SAP.py
@@ -1,10 +1,21 @@
-import unittest
+from overrides import override
 from unittest.mock import patch, MagicMock
 from decimal import Decimal
 from datetime import datetime
+import uuid
+from infraohjelmointi_api.models import Project
 from infraohjelmointi_api.services.SapApiService import SapApiService
+from infraohjelmointi_api.views import BaseViewSet, SapCurrentYearViewSet
+import logging
+from django.test import TestCase
 
-class TestSAPService(unittest.TestCase):
+logger = logging.getLogger("infraohjelmointi_api")
+@patch.object(BaseViewSet, "authentication_classes", new=[])
+@patch.object(BaseViewSet, "permission_classes", new=[])
+class TestSAPService(TestCase):
+    project_1_Id = uuid.UUID("33814e76-7bdc-47c2-bf08-7ed43a96e042")
+    sapProjectId = "2814I00708"
+
     def setUp(self):
         # connection setup
         self.sap_service = SapApiService()
@@ -12,6 +23,17 @@ class TestSAPService(unittest.TestCase):
         self.sap_service.sap_api_costs_endpoint = "$/costs?id='{posid}'&start={budat_start}&end={budat_end}"
         self.sap_service.sap_api_commitments_endpoint = "$/costs?id='{posid}'&start={budat_start}&end={budat_end}"
         self.sap_service.session = MagicMock()
+        self.sap_current_year_viewset = SapCurrentYearViewSet()
+
+    @classmethod
+    @override
+    def setUpTestData(self):
+        self.project = Project.objects.create(
+            id=self.project_1_Id,
+            sapProject=self.sapProjectId,
+            name="testi",
+            description="testii"
+        )
 
     @patch('infraohjelmointi_api.services.ProjectService.ProjectService.get_by_sap_id')
     def test_get_project_costs_and_commitments_successful(self, mock_get_by_sap_id):
@@ -153,3 +175,32 @@ class TestSAPService(unittest.TestCase):
 
         self.assertEqual(response, True)
         self.assertEqual(response2, False)
+
+    def test_sync_all_projects_from_sap(self):
+        # Mock the SAP API response for current year costs
+        mock_response_current_year_costs = MagicMock()
+        mock_response_current_year_costs.status_code = 200
+        mock_response_current_year_costs.json.return_value = {
+            "d": {"results": [{"Posid": "{self.sapProjectId}.01", "Wkgbtr": Decimal('111.000')}]}
+        }
+
+        # Mock the SAP API response for current year commitments
+        mock_response_current_year_commitments = MagicMock()
+        mock_response_current_year_commitments.status_code = 200
+        mock_response_current_year_commitments.json.return_value = {
+            "d": {"results": [{"Posid": "{self.sapProjectId}.01", "Wkgbtr": Decimal('333.000')}]}
+        }
+
+        # Mock the session.get call to return the mocked responses in sequence
+        self.sap_service.session.get.side_effect = [
+            mock_response_current_year_costs,
+            mock_response_current_year_commitments
+        ]
+        # Call the method sync_all_projects_from_sap to do sap fetch and save data to database
+        self.sap_service.sync_all_projects_from_sap(for_financial_statement=True, sap_year=datetime.now().year)
+
+        # get the data from database
+        response = self.client.get("/sap-current-year-costs/{}/".format(datetime.now().year))
+        data_in_database = response.data[0]
+        self.assertEqual(data_in_database['production_task_costs'], '111.000')
+        self.assertEqual(data_in_database['production_task_commitments'], '333.000')

--- a/infraohjelmointi_api/tests/test_SAP.py
+++ b/infraohjelmointi_api/tests/test_SAP.py
@@ -58,7 +58,14 @@ class TestSAPService(unittest.TestCase):
 
         # Call the function with a known SAP ID
         project_id = '123'
-        result = self.sap_service.get_project_costs_and_commitments_from_sap(project_id)
+        result = {}
+
+        all_sap_data = self.sap_service.get_all_project_costs_and_commitments_from_sap(project_id)
+        current_year_data = self.sap_service.get_costs_and_commitments_by_year(project_id, datetime.now().year)
+        result = {
+            'all_sap_data': all_sap_data,
+            'current_year': current_year_data
+        }
 
         # Assertions to ensure the returned data structure is as expected
         # Assertions for all_sap_data
@@ -113,7 +120,15 @@ class TestSAPService(unittest.TestCase):
 
         # Call the function and assert an empty dict is returned due to the error
         project_id = '123'
-        result = self.sap_service.get_project_costs_and_commitments_from_sap(project_id)
+        result = {}
+
+        all_sap_data = self.sap_service.get_all_project_costs_and_commitments_from_sap(project_id)
+        current_year_data = self.sap_service.get_costs_and_commitments_by_year(project_id, datetime.now().year)
+        result = {
+            'all_sap_data': all_sap_data,
+            'current_year': current_year_data
+        }
+        
         expected_result = {
             'all_sap_data': {
                 'costs': {'project_task': Decimal('0'), 'production_task': Decimal('0')},

--- a/infraohjelmointi_api/tests/test_SAP.py
+++ b/infraohjelmointi_api/tests/test_SAP.py
@@ -140,3 +140,16 @@ class TestSAPService(unittest.TestCase):
             }
         }
         self.assertEqual(result, expected_result)
+
+    def test_validate_costs_and_commitments(self):
+        costs_and_commitments = {
+            'all_sap_data': {},
+            'current_year': {}
+        }
+        response = self.sap_service.validate_costs_and_commitments(costs_and_commitments)
+
+        costs_and_commitments_not_valid = {}
+        response2 = self.sap_service.validate_costs_and_commitments(costs_and_commitments_not_valid)
+
+        self.assertEqual(response, True)
+        self.assertEqual(response2, False)

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,1 +1,1 @@
-sonar.exclusions = infraohjelmointi_api/**/tests/**/*, infraohjelmointi_api/**/migrations/**/*, infraohjelmointi_api/management/commands/generatetoken.py, infraohjelmointi_api/management/commands/locationimporter.py
+sonar.exclusions = infraohjelmointi_api/**/tests/**/*, infraohjelmointi_api/**/migrations/**/*, infraohjelmointi_api/management/commands/generatetoken.py, infraohjelmointi_api/management/commands/locationimporter.py, infraohjelmointi_api/management/commands/sapsynchronizer.py, infraohjelmointi_api/management/commands/fetchsapdatabyyear.py


### PR DESCRIPTION
Adding script as a file fetchsapdatabyyear.py to handle sap fetch for certain year (given as a parameter). Script can be used from command line with
`python manage.py fetchsapdatabyyear --year <year>` 

Changes to SapApiService are done with thinking the future "tilinpäätös" (financial statement) feature for admin users. When implementing this new feature in the future, function sync_all_projects_from_sap can be called with arguments `for_financial_statement and sap_year = True`
`sap_year = year of the financial statement `
and then sap data is fetched only for that given year. 

SapApiService is now taking two new arguments, for_financial_statement and sap_year. When for_financial_statement is true, also wanted year is given as argument. Then sap fetch is done only for that given year. 

Otherwise sap fetch is done like previously. Both all sap data and also current year's sap data are fetched. 