### PR TITLE
HKISD-257: change sap fetch start date

### DIFF
--- a/infraohjelmointi_api/tests/test_SAP.py
+++ b/infraohjelmointi_api/tests/test_SAP.py
@@ -25,6 +25,9 @@ class TestSAPService(TestCase):
         self.sap_service.session = MagicMock()
         self.sap_current_year_viewset = SapCurrentYearViewSet()
 
+        # Set the sap start year to be 2017 to get all data from sap
+        self.sap_fetch_all_data_start_year = 2017
+
     @classmethod
     @override
     def setUpTestData(self):
@@ -73,11 +76,6 @@ class TestSAPService(TestCase):
             mock_response_current_year_commitments
         ]
 
-        # Mock the ProjectService.get_by_sap_id to return a project with a planning start year
-        mock_project = MagicMock()
-        mock_project.planningStartYear = 2022
-        mock_get_by_sap_id.return_value = [mock_project]
-
         # Call the function with a known SAP ID
         project_id = '123'
         result = {}
@@ -109,7 +107,7 @@ class TestSAPService(TestCase):
         # Assert that the session.get was called with the correct URL and parameters
         start_date = datetime.now().replace(
             month=1, day=1, hour=0, minute=0, second=0
-        ).replace(year=mock_project.planningStartYear).strftime("%Y-%m-%dT%H:%M:%S")
+        ).replace(year=self.sap_fetch_all_data_start_year).strftime("%Y-%m-%dT%H:%M:%S")
         end_date = datetime.now().replace(
             year=datetime.now().year + 1, month=1, day=1, hour=0, minute=0, second=0
         ).strftime("%Y-%m-%dT%H:%M:%S")


### PR DESCRIPTION
### Description
Previously all sap data was fetched from the start of the planning year. 
This is now changed so, that start date for all data fetching is 1.1.2017. 

### Testing
You can test this locally with this branch:
- in container run `python manage.py sapsynchronizer` 
   - this will show you first logs of the costs for all sap data fetch 
   - from logs you can check the dates in the sap-url
   - logs for commitments fetch can't be seen locally, because there's no connection to sap locally
- in container run `python manage.py fetchsapdatabyyear --year 2023` 
   - with this you can see logs for sap costs fetch for certain year (here 2023) 
   - from logs you can check the dates in the sap-url
