### PR TITLE
HKISD-178: make projects in warranty period visible in hierarchy

### DIFF
--- a/infraohjelmointi_api/serializers/ProjectCreateSerializer.py
+++ b/infraohjelmointi_api/serializers/ProjectCreateSerializer.py
@@ -218,7 +218,6 @@ class ProjectCreateSerializer(ProjectWithFinancesSerializer):
 
         if phase is not None and (
             phase.value == "completed"
-            or phase.value == "warrantyPeriod"
             or phase.value == "proposal"
         ):
             data["programmed"] = False

--- a/infraohjelmointi_api/tests/test_Projects.py
+++ b/infraohjelmointi_api/tests/test_Projects.py
@@ -3282,7 +3282,11 @@ class ProjectTestCase(TestCase):
             msg="Status code != 200 , Error: {}".format(response.json()),
         )
 
-        data = {"phase": self.projectPhase_6_Id}
+        data = {
+            "phase": self.projectPhase_6_Id,
+            "programmed": True
+        }
+
         response = self.client.patch(
             "/projects/{}/".format(createdId),
             data,
@@ -3310,6 +3314,7 @@ class ProjectTestCase(TestCase):
         data = {
             "constructionPhaseDetail": self.conPhaseDetail_2_Id,
             "phase": self.projectPhase_5_Id,
+            "programmed": False,
         }
         response = self.client.patch(
             "/projects/{}/".format(createdId),


### PR DESCRIPTION
When project phase is changed to be "warrantyPeriod", don't change the "programmed" value anymore to "False". 

When phase is "warrantyPeriod", programmed needs to be "True", to keep project still visible in hierarchy. 

#### Testing
Set the project's phase to be for example "Programmed", then programmed is true and project is visible in hierarchy. Then change the phase to be "Warranty Period". Check that programmed stays true and project is still visible in hierarchy. 


[Ticket](https://futurice.atlassian.net/jira/software/c/projects/HKISD/boards/62?selectedIssue=HKISD-178)