### PR TITLE
HKISD-222: navigate to where project really locates from search

### DIFF
--- a/infraohjelmointi_api/serializers/SearchResultSerializer.py
+++ b/infraohjelmointi_api/serializers/SearchResultSerializer.py
@@ -1,5 +1,6 @@
 from uuid import UUID
 from infraohjelmointi_api.models import ProjectHashTag
+from infraohjelmointi_api.serializers import ProjectGroupSerializer
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
 from .ProjectHashtagSerializer import ProjectHashtagSerializer
@@ -14,6 +15,7 @@ class SearchResultSerializer(serializers.Serializer):
     phase = serializers.SerializerMethodField()
     path = serializers.SerializerMethodField()
     programmed = serializers.SerializerMethodField()
+    group = serializers.SerializerMethodField()
 
     def get_path(self, obj):
         instanceType = obj._meta.model.__name__
@@ -118,3 +120,15 @@ class SearchResultSerializer(serializers.Serializer):
         if hasattr(obj, "programmed"):
             return obj.programmed
         return None
+    
+    def get_group(self, obj):
+        """
+        Gets the field `projectGroup_id` from a Project instance
+        This function only concerns instances of Project
+        """
+        if hasattr(obj, "projectGroup_id"):
+            return obj.projectGroup_id
+        return None
+        # if not hasattr(obj, "projectGroup_id") or obj.projectGroup_id is None:
+        #     return None
+        # return ProjectGroupSerializer(obj.projectGroup_id).data

--- a/infraohjelmointi_api/tests/test_Projects.py
+++ b/infraohjelmointi_api/tests/test_Projects.py
@@ -1089,15 +1089,6 @@ class ProjectTestCase(TestCase):
         )
 
     def test_search_results_endpoint_project(self):
-        projectGroup_1 = ProjectGroup.objects.create(
-            id=self.projectGroup_1_Id, name="Test Group 1 rain"
-        )
-        projectGroup_2 = ProjectGroup.objects.create(
-            id=self.projectGroup_2_Id, name="Test Group 2"
-        )
-        projectGroup_3 = ProjectGroup.objects.create(
-            id=self.projectGroup_3_Id, name="Test Group 3 park"
-        )
         district_1 = ProjectLocation.objects.create(
             id=self.projectDistrict_2_Id,
             name="District 1",
@@ -1158,6 +1149,18 @@ class ProjectTestCase(TestCase):
             id=self.projectSubClass_2_Id,
             name="Sub class 2",
             path="Master Class 1/Test Class 1/Sub class 2",
+        )
+        projectGroup_1 = ProjectGroup.objects.create(
+            id=self.projectGroup_1_Id, name="Test Group 1 rain",
+            classRelation=subClass_2
+        )
+        projectGroup_2 = ProjectGroup.objects.create(
+            id=self.projectGroup_2_Id, name="Test Group 2",
+            classRelation=subClass_2
+        )
+        projectGroup_3 = ProjectGroup.objects.create(
+            id=self.projectGroup_3_Id, name="Test Group 3 park",
+            classRelation=None
         )
         hashTag_1 = ProjectHashTag.objects.create(
             id=self.projectHashTag_3_Id, value="Jira"
@@ -2127,7 +2130,7 @@ class ProjectTestCase(TestCase):
                 len([x for x in response.json()["results"] if x["type"] == "projects"]),
             ),
         )
-
+        # click search result for project_3:
         response = self.client.get(
             "/projects/search-results/?project={}".format(self.project_5_Id),
         )
@@ -2136,15 +2139,18 @@ class ProjectTestCase(TestCase):
             200,
             msg="Status code != 200, Error: {}".format(response.json()),
         )
+        # project_3 belongs to projectGroup_2 (it's classRelation=subClass_2) and
+        # project's projectClass=subClass_2 and projectLocation=district_2
+        # When class of group is higher in hierarhcy than project's deepest class/location,
+        # path's last class is same as group's.
         self.assertEqual(
             response.json()["results"][0]["path"],
-            "masterClass={}&class={}&subClass={}&district={}".format(
+            "masterClass={}&class={}&subClass={}".format(
                 self.projectMasterClass_2_Id,
                 self.projectClass_2_Id,
                 self.projectSubClass_2_Id,
-                self.projectDistrict_3_Id,
             ),
-            msg="Path does not follow the format masterClass=&class=&subClass&district=",
+            msg="Path does not follow the format masterClass=&class=&subClass",
         )
 
         response = self.client.get(


### PR DESCRIPTION
### Description
If project belongs to a group, that is located in upper level in hierarchy, clicking the project from search result navigates to project's exact location, not the group's location. This is fixed with checking if project belongs to a group while creating a path where search result link will navigate. 

### Testing
Create a project and add class informations to it. Then create a group to upper level in hierarchy and add the project in it. When you search this project and click the search result, planning view opens from the level where project locates. 
For example create a group to 8 03 Kadut ja liikenneväylät -> Perusparantaminen ja liikennejärjestelyt -> Joukkoliikenteen kehittäminen. And then create a project to 8 03 Kadut ja liikenneväylät -> Perusparantaminen ja liikennejärjestelyt -> Joukkoliikenteen kehittäminen -> Eteläinen suurpiiri. And then add this project to created group and try to find project via search. Clicking the search result will lead to planning view where project really is (the group). 