### PR TITLE
HKISD-190: bring empty groups to search results

### DIFF
--- a/infraohjelmointi_api/tests/test_Projects.py
+++ b/infraohjelmointi_api/tests/test_Projects.py
@@ -2049,9 +2049,10 @@ class ProjectTestCase(TestCase):
         )
         self.assertEqual(
             len([x for x in response.json()["results"] if x["type"] == "groups"]),
-            1,
-            msg="Filtered result should contain 1 group with id {}. Found: {}".format(
+            2,
+            msg="Filtered result should contain 2 group with id {} and {}. Found: {}".format(
                 self.projectGroup_1_Id,
+                self.projectGroup_2_Id,
                 len([x for x in response.json()["results"] if x["type"] == "groups"]),
             ),
         )

--- a/infraohjelmointi_api/views/ProjectViewSet.py
+++ b/infraohjelmointi_api/views/ProjectViewSet.py
@@ -652,9 +652,7 @@ class ProjectViewSet(BaseViewSet):
             order = "new"
 
         if len(projectGroup) > 0:
-            groups = ProjectGroup.objects.filter(
-                id__in=queryset.values_list("projectGroup", flat=True).distinct()
-            ).select_related("classRelation")
+            groups = ProjectGroup.objects.filter(id__in=projectGroup).select_related("classRelation")
 
         if len(masterClass) > 0 or len(_class) > 0 or len(subClass) > 0:
             projectClasses = ProjectClass.objects.filter(


### PR DESCRIPTION
### Description
Empty groups were not in search results. That was cumbersome for user: the free search input field suggested also empty groups, but those were not in the result list. 

Ticket: [HKISD-222](https://futurice.atlassian.net/jira/software/c/projects/HKISD/boards/62?selectedIssue=HKISD-222&useStoredSettings=true)

### Testing
Find or create an empty group and search it from search component. Search result now includes also empty groups. 