### PR TITLE
HKISD-224: search groups and projects with same name

### DIFF
--- a/infraohjelmointi_api/services/ProjectWiseService.py
+++ b/infraohjelmointi_api/services/ProjectWiseService.py
@@ -115,6 +115,7 @@ class ProjectWiseService:
         if project.hkrId is None or str(project.hkrId).strip() == "":
             return
         try:
+            logger.info("PWDATA")
             pw_project_data = self.project_wise_data_mapper.convert_to_pw_data(
                 data=data, project=project
             )

--- a/infraohjelmointi_api/services/ProjectWiseService.py
+++ b/infraohjelmointi_api/services/ProjectWiseService.py
@@ -115,7 +115,6 @@ class ProjectWiseService:
         if project.hkrId is None or str(project.hkrId).strip() == "":
             return
         try:
-            logger.info("PWDATA")
             pw_project_data = self.project_wise_data_mapper.convert_to_pw_data(
                 data=data, project=project
             )

--- a/infraohjelmointi_api/tests/management/commands/test_responsiblepersons.py
+++ b/infraohjelmointi_api/tests/management/commands/test_responsiblepersons.py
@@ -49,7 +49,7 @@ class ResponsiblePersonsCommandTestCase(TestCase):
         call_command("responsiblepersons", "--file", "unknown-file.xlsx", stdout=out)
         command_output = out.getvalue()
 
-        expected_error_message = "\x1b[31;1mExcel file path is incorrect or missing. Usage: --file path/to/file.xlsx\x1b[0m\n"
+        expected_error_message = "Excel file path is incorrect or missing. Usage: --file path/to/file.xlsx"
 
         self.assertIn(expected_error_message, command_output)
 

--- a/infraohjelmointi_api/tests/test_Projects.py
+++ b/infraohjelmointi_api/tests/test_Projects.py
@@ -2049,9 +2049,10 @@ class ProjectTestCase(TestCase):
         )
         self.assertEqual(
             len([x for x in response.json()["results"] if x["type"] == "groups"]),
-            1,
-            msg="Filtered result should contain 1 group with id {}. Found: {}".format(
+            2,
+            msg="Filtered result should contain 2 group with id {} and {}. Found: {}".format(
                 self.projectGroup_1_Id,
+                self.projectGroup_2_Id,
                 len([x for x in response.json()["results"] if x["type"] == "groups"]),
             ),
         )

--- a/infraohjelmointi_api/tests/test_Projects.py
+++ b/infraohjelmointi_api/tests/test_Projects.py
@@ -48,7 +48,9 @@ class ProjectTestCase(TestCase):
     project_1_Id = uuid.UUID("33814e76-7bdc-47c2-bf08-7ed43a96e042")
     project_2_Id = uuid.UUID("5d82c31b-4dee-4e48-be7c-b417e6c5bb9e")
     project_3_Id = uuid.UUID("fdc89f56-b631-4109-a137-45b950de6b10")
+    project_3_name = "Parking Helsinki"
     project_4_Id = uuid.UUID("7c5b981e-286f-4065-9d9e-29d8d1714e4c")
+    project_4_name = "Random name"
     project_5_Id = uuid.UUID("441d80e1-9ab1-4b35-91cc-6017ea308d87")
     project_6_Id = uuid.UUID("90852adc-d47e-4fd9-944f-cb8d36076c21")
     project_7_Id = uuid.UUID("e98e3787-e19f-4af6-94c9-12c8e31ea040")
@@ -1185,7 +1187,7 @@ class ProjectTestCase(TestCase):
         project_1 = Project.objects.create(
             id=self.project_3_Id,
             hkrId=2222,
-            name="Parking Helsinki",
+            name=self.project_3_name,
             description="Random desc",
             programmed=True,
             category=category_1,
@@ -1198,7 +1200,7 @@ class ProjectTestCase(TestCase):
         project_2 = Project.objects.create(
             id=self.project_4_Id,
             hkrId=1111,
-            name="Random name",
+            name=self.project_4_name,
             description="Random desc",
             programmed=True,
             category=category_2,
@@ -1997,8 +1999,8 @@ class ProjectTestCase(TestCase):
 
         response = self.client.get(
             "/projects/search-results/?group={}&group={}&subClass={}&district={}".format(
-                self.projectGroup_2_Id,
-                self.projectGroup_1_Id,
+                self.projectGroup2_name,
+                self.projectGroup1_name,
                 self.projectSubClass_1_Id,
                 self.projectDistrict_2_Id,
             ),
@@ -2095,27 +2097,7 @@ class ProjectTestCase(TestCase):
             len([x for x in response.json()["results"] if x["type"] == "projects"]),
             2,
             msg="Filtered result should contain 2 projects with id {} and {}".format(
-                self.project_3_Id, self.project_4_Id
-            ),
-        )
-
-        response = self.client.get(
-            "/projects/search-results/?project={}&project={}&projectName={}".format(
-                self.project_3_Id, self.project_4_Id, "park"
-            ),
-        )
-        self.assertEqual(
-            response.status_code,
-            200,
-            msg="Status code != 200, Error: {}".format(response.json()),
-        )
-
-        self.assertEqual(
-            len([x for x in response.json()["results"] if x["type"] == "projects"]),
-            1,
-            msg="Filtered result should contain 1 project with id {} and the string 'park' in its name. Found: {}".format(
-                self.project_3_Id,
-                len([x for x in response.json()["results"] if x["type"] == "projects"]),
+                self.project_3_name, self.project_4_name
             ),
         )
 

--- a/infraohjelmointi_api/tests/test_Projects.py
+++ b/infraohjelmointi_api/tests/test_Projects.py
@@ -37,6 +37,9 @@ from ..serializers import (
 )
 
 from infraohjelmointi_api.views import BaseViewSet
+import logging
+
+logger = logging.getLogger("infraohjelmointi_api")
 
 
 @patch.object(BaseViewSet, "authentication_classes", new=[])
@@ -137,7 +140,9 @@ class ProjectTestCase(TestCase):
     projectSubDivision_4_Id = uuid.UUID("e65d7bc1-61f5-42f9-a52c-417cd1cf085b")
     projectSubDivision_5_Id = uuid.UUID("06004dd7-5b27-43c8-85ef-34d2b5115749")
     projectGroup_1_Id = uuid.UUID("bbba45f2-b0d4-4297-b0e2-4e60f8fa8412")
+    projectGroup1_name = "Test Group 1 rain"
     projectGroup_2_Id = uuid.UUID("bee657d4-a2cc-4c04-a75b-edc12275dd62")
+    projectGroup2_name = "Test Group 2"
     projectGroup_3_Id = uuid.UUID("b2e2808c-831b-4db2-b0a8-f6c6d270af1a")
     projectFinancial_1_Id = uuid.UUID("0ace4e90-4318-4282-8bb7-a0b152888642")
     projectFinancial_2_Id = uuid.UUID("ec17c3c6-7414-4fec-ad2e-6e6f63a88bcb")
@@ -1151,11 +1156,11 @@ class ProjectTestCase(TestCase):
             path="Master Class 1/Test Class 1/Sub class 2",
         )
         projectGroup_1 = ProjectGroup.objects.create(
-            id=self.projectGroup_1_Id, name="Test Group 1 rain",
+            id=self.projectGroup_1_Id, name=self.projectGroup1_name,
             classRelation=subClass_2
         )
         projectGroup_2 = ProjectGroup.objects.create(
-            id=self.projectGroup_2_Id, name="Test Group 2",
+            id=self.projectGroup_2_Id, name=self.projectGroup2_name,
             classRelation=subClass_2
         )
         projectGroup_3 = ProjectGroup.objects.create(
@@ -1925,7 +1930,7 @@ class ProjectTestCase(TestCase):
             "/projects/search-results/?hashtag={}&hashtag={}&group={}".format(
                 self.projectHashTag_3_Id,
                 self.projectHashTag_4_Id,
-                self.projectGroup_1_Id,
+                self.projectGroup1_name,
             ),
         )
         self.assertEqual(
@@ -1936,7 +1941,7 @@ class ProjectTestCase(TestCase):
 
         self.assertEqual(
             len([x for x in response.json()["results"] if x["type"] == "projects"]),
-            2,
+            3,
             msg="Filtered result should contain 2 projects with hashTag: {} or {} and group: {}. Found: {}".format(
                 self.projectHashTag_3_Id,
                 self.projectHashTag_4_Id,
@@ -1954,8 +1959,8 @@ class ProjectTestCase(TestCase):
         )
         response = self.client.get(
             "/projects/search-results/?group={}&group={}".format(
-                self.projectGroup_2_Id,
-                self.projectGroup_1_Id,
+                self.projectGroup2_name,
+                self.projectGroup1_name,
             ),
         )
         self.assertEqual(

--- a/infraohjelmointi_api/tests/test_Projects.py
+++ b/infraohjelmointi_api/tests/test_Projects.py
@@ -37,9 +37,6 @@ from ..serializers import (
 )
 
 from infraohjelmointi_api.views import BaseViewSet
-import logging
-
-logger = logging.getLogger("infraohjelmointi_api")
 
 
 @patch.object(BaseViewSet, "authentication_classes", new=[])

--- a/infraohjelmointi_api/views/ProjectViewSet.py
+++ b/infraohjelmointi_api/views/ProjectViewSet.py
@@ -652,9 +652,7 @@ class ProjectViewSet(BaseViewSet):
             order = "new"
 
         if len(projectGroup) > 0:
-            groups = ProjectGroup.objects.filter(
-                id__in=queryset.values_list("projectGroup", flat=True).distinct()
-            ).select_related("classRelation")
+            groups = ProjectGroup.objects.filter(id__in=projectGroup).select_related("classRelation")
 
         if len(masterClass) > 0 or len(_class) > 0 or len(subClass) > 0:
             projectClasses = ProjectClass.objects.filter(

--- a/infraohjelmointi_api/views/ProjectViewSet.py
+++ b/infraohjelmointi_api/views/ProjectViewSet.py
@@ -581,7 +581,6 @@ class ProjectViewSet(BaseViewSet):
         response = {}
         freeSearch = request.query_params.get("freeSearch", None)
         projectGroup = request.query_params.getlist("group", [])
-        logger.info("GROUPIT:")
         masterClass = self.request.query_params.getlist("masterClass", [])
         _class = self.request.query_params.getlist("class", [])
         subClass = self.request.query_params.getlist("subClass", [])
@@ -941,6 +940,7 @@ class ProjectViewSet(BaseViewSet):
         inGroup = self.request.query_params.get("inGroup", None)
         projectName = self.request.query_params.getlist("projectName", [])
         hash_tags = self.request.query_params.getlist("hashtag", [])
+        projectGroup = self.request.query_params.getlist("group", [])
 
         # This query param gives the projects which are directly under any given location or class if set to True
         # Else the queryset will also contain the projects containing the child locations/districts
@@ -949,8 +949,9 @@ class ProjectViewSet(BaseViewSet):
         try:
             q_objects = Q()
 
-            if len(projectName) > 0:
+            if len(projectName) > 0 or len(projectGroup) > 0:
                 q_objects |= Q(name__in=projectName)
+                q_objects |= Q(projectGroup__name__in=projectGroup)
 
             if len(hash_tags) > 0:
                 q_objects |= Q(hashTags__id__in=hash_tags)

--- a/infraohjelmointi_api/views/ProjectViewSet.py
+++ b/infraohjelmointi_api/views/ProjectViewSet.py
@@ -581,6 +581,7 @@ class ProjectViewSet(BaseViewSet):
         response = {}
         freeSearch = request.query_params.get("freeSearch", None)
         projectGroup = request.query_params.getlist("group", [])
+        logger.info("GROUPIT:")
         masterClass = self.request.query_params.getlist("masterClass", [])
         _class = self.request.query_params.getlist("class", [])
         subClass = self.request.query_params.getlist("subClass", [])
@@ -715,6 +716,8 @@ class ProjectViewSet(BaseViewSet):
             "count": searchPaginator.page.paginator.count,
             "results": serializer.data,
         }
+
+        logger.info(response)
 
         return Response(response)
 
@@ -937,15 +940,24 @@ class ProjectViewSet(BaseViewSet):
         projects = self.request.query_params.getlist("project", [])
         inGroup = self.request.query_params.get("inGroup", None)
         projectName = self.request.query_params.getlist("projectName", [])
+        hash_tags = self.request.query_params.getlist("hashtag", [])
 
         # This query param gives the projects which are directly under any given location or class if set to True
         # Else the queryset will also contain the projects containing the child locations/districts
         direct = self.request.query_params.get("direct", False)
 
         try:
-            if projectName != []:
-                qs = qs.filter(name__in=projectName)
+            q_objects = Q()
 
+            if len(projectName) > 0:
+                q_objects |= Q(name__in=projectName)
+
+            if len(hash_tags) > 0:
+                q_objects |= Q(hashTags__id__in=hash_tags)
+
+            qs = qs.filter(q_objects)
+
+            
             if direct in ["true", "True"]:
                 direct = True
             elif direct in ["false", "False"]:

--- a/infraohjelmointi_api/views/ProjectViewSet.py
+++ b/infraohjelmointi_api/views/ProjectViewSet.py
@@ -936,9 +936,9 @@ class ProjectViewSet(BaseViewSet):
         prYearMax = self.request.query_params.get("prYearMax", None)
         projects = self.request.query_params.getlist("project", [])
         inGroup = self.request.query_params.get("inGroup", None)
-        projectName = self.request.query_params.getlist("projectName", [])
+        project_name = self.request.query_params.getlist("projectName", [])
         hash_tags = self.request.query_params.getlist("hashtag", [])
-        projectGroup = self.request.query_params.getlist("group", [])
+        project_group = self.request.query_params.getlist("group", [])
 
         # This query param gives the projects which are directly under any given location or class if set to True
         # Else the queryset will also contain the projects containing the child locations/districts
@@ -947,9 +947,9 @@ class ProjectViewSet(BaseViewSet):
         try:
             q_objects = Q()
 
-            if len(projectName) > 0 or len(projectGroup) > 0:
-                q_objects |= Q(name__in=projectName)
-                q_objects |= Q(projectGroup__name__in=projectGroup)
+            if len(project_name) > 0 or len(project_group) > 0:
+                q_objects |= Q(name__in=project_name)
+                q_objects |= Q(projectGroup__name__in=project_group)
 
             if len(hash_tags) > 0:
                 q_objects |= Q(hashTags__id__in=hash_tags)

--- a/infraohjelmointi_api/views/ProjectViewSet.py
+++ b/infraohjelmointi_api/views/ProjectViewSet.py
@@ -716,8 +716,6 @@ class ProjectViewSet(BaseViewSet):
             "results": serializer.data,
         }
 
-        logger.info(response)
-
         return Response(response)
 
     @override

--- a/infraohjelmointi_api/views/ProjectViewSet.py
+++ b/infraohjelmointi_api/views/ProjectViewSet.py
@@ -652,7 +652,7 @@ class ProjectViewSet(BaseViewSet):
             order = "new"
 
         if len(projectGroup) > 0:
-            groups = ProjectGroup.objects.filter(id__in=projectGroup).select_related("classRelation")
+            groups = ProjectGroup.objects.filter(name__in=projectGroup).select_related("classRelation")
 
         if len(masterClass) > 0 or len(_class) > 0 or len(subClass) > 0:
             projectClasses = ProjectClass.objects.filter(
@@ -937,15 +937,15 @@ class ProjectViewSet(BaseViewSet):
         projects = self.request.query_params.getlist("project", [])
         projectGroups = self.request.query_params.getlist("group", [])
         inGroup = self.request.query_params.get("inGroup", None)
-        projectName = self.request.query_params.get("projectName", None)
+        projectName = self.request.query_params.getlist("projectName", [])
 
         # This query param gives the projects which are directly under any given location or class if set to True
         # Else the queryset will also contain the projects containing the child locations/districts
         direct = self.request.query_params.get("direct", False)
 
         try:
-            if projectName is not None:
-                qs = qs.filter(name__icontains=projectName)
+            if projectName != []:
+                qs = qs.filter(name__in=projectName)
 
             if direct in ["true", "True"]:
                 direct = True
@@ -967,7 +967,7 @@ class ProjectViewSet(BaseViewSet):
                 qs, prYearMin=prYearMin, prYearMax=prYearMax
             )
             if len(projectGroups) > 0:
-                qs = qs.filter(projectGroup__in=projectGroups)
+                qs = qs.filter(projectGroup__name__in=projectGroups)
             if len(masterClass) > 0:
                 qs = self._filter_projects_by_hierarchy(
                     qs=qs,

--- a/infraohjelmointi_api/views/ProjectViewSet.py
+++ b/infraohjelmointi_api/views/ProjectViewSet.py
@@ -935,7 +935,6 @@ class ProjectViewSet(BaseViewSet):
         overMillion = self.request.query_params.get("overMillion", False)
         prYearMax = self.request.query_params.get("prYearMax", None)
         projects = self.request.query_params.getlist("project", [])
-        projectGroups = self.request.query_params.getlist("group", [])
         inGroup = self.request.query_params.get("inGroup", None)
         projectName = self.request.query_params.getlist("projectName", [])
 
@@ -966,8 +965,6 @@ class ProjectViewSet(BaseViewSet):
             qs = self._filter_projects_by_programming_year(
                 qs, prYearMin=prYearMin, prYearMax=prYearMax
             )
-            if len(projectGroups) > 0:
-                qs = qs.filter(projectGroup__name__in=projectGroups)
             if len(masterClass) > 0:
                 qs = self._filter_projects_by_hierarchy(
                     qs=qs,


### PR DESCRIPTION
- ticket: [https://futurice.atlassian.net/browse/HKISD-224](https://futurice.atlassian.net/browse/HKISD-224)
- previously search only returned one project or group with same name even when there actually was more (no projects or groups with duplicate names where returned)
- you can test by creating multiple projects and groups with same name and see that search results has all of them when you search with the name
- you also need the UI PR for testing: [https://github.com/City-of-Helsinki/infraohjelmointi-ui/pull/319](https://github.com/City-of-Helsinki/infraohjelmointi-ui/pull/319)