### PR TITLE
HKISD-272/fix sending project phase to pw

### DIFF
--- a/infraohjelmointi_api/services/utils/ProjectWiseDataMapper.py
+++ b/infraohjelmointi_api/services/utils/ProjectWiseDataMapper.py
@@ -133,7 +133,7 @@ to_pw_map = {
     },
 }
 
-phase_map = {
+phase_map_for_pw = {
     "proposal": "1. Hanke-ehdotus",
     "design": "1.5 Yleissuunnittelu",
     "programming": "2. Ohjelmointi",
@@ -141,6 +141,19 @@ phase_map = {
         "3. Suunnittelun aloitus / Suunnitelmaluonnos",
         "3. Katu- ja puistosuunnittelun aloitus/suunnitelmaluonnos",
     ],
+    "draftApproval": "4. Katu- / puistosuunnitelmaehdotus ja hyväksyminen",
+    "constructionPlan": "5. Rakennussuunnitelma",
+    "constructionWait": "6. Odottaa rakentamista",
+    "construction": "7. Rakentaminen",
+    "warrantyPeriod": "8. Takuuaika",
+    "completed": "9. Valmis / ylläpidossa",
+}
+
+phase_map_for_infratool = {
+    "proposal": "1. Hanke-ehdotus",
+    "design": "1.5 Yleissuunnittelu",
+    "programming": "2. Ohjelmointi",
+    "draftInitiation": "3. Katu- ja puistosuunnittelun aloitus/suunnitelmaluonnos",
     "draftApproval": "4. Katu- / puistosuunnitelmaehdotus ja hyväksyminen",
     "constructionPlan": "5. Rakennussuunnitelma",
     "constructionWait": "6. Odottaa rakentamista",
@@ -215,7 +228,7 @@ class ProjectWiseDataMapper:
             elif mapped_field["type"] == "listvalue":
                 field_mapper = None
                 if field == "phase":
-                    field_mapper = phase_map
+                    field_mapper = phase_map_for_infratool
                     value = (
                         ProjectPhaseService.get_by_id(value).value
                         if not value is None
@@ -252,10 +265,7 @@ class ProjectWiseDataMapper:
                 else:
                     raise ProjectWiseDataFieldNotFound(f"Field '{field}' not supported")
                 
-                if isinstance(field_mapper[value], list):
-                    result[mapped_field["field"]] = field_mapper[value][1] if value else None
-                else:
-                    result[mapped_field["field"]] = field_mapper[value] if value else None
+                result[mapped_field["field"]] = field_mapper[value] if value else None
             # Class/Location field handling
             elif mapped_field["type"] == "enum":
                 if field == "projectClass":
@@ -318,7 +328,7 @@ class ProjectWiseDataMapper:
         """Helper method to load phases from DB and transform to match PW format"""
         phases = {}
         for pph in ProjectPhaseService.list_all():
-            mapped_value = phase_map[pph.value]
+            mapped_value = phase_map_for_pw[pph.value]
             if isinstance(mapped_value, list):
                 for key in mapped_value:
                     phases[key] = pph

--- a/infraohjelmointi_api/services/utils/ProjectWiseDataMapper.py
+++ b/infraohjelmointi_api/services/utils/ProjectWiseDataMapper.py
@@ -251,7 +251,11 @@ class ProjectWiseDataMapper:
                     )
                 else:
                     raise ProjectWiseDataFieldNotFound(f"Field '{field}' not supported")
-                result[mapped_field["field"]] = field_mapper[value] if value else None
+                
+                if isinstance(field_mapper[value], list):
+                    result[mapped_field["field"]] = field_mapper[value][0] if value else None
+                else:
+                    result[mapped_field["field"]] = field_mapper[value] if value else None
             # Class/Location field handling
             elif mapped_field["type"] == "enum":
                 if field == "projectClass":

--- a/infraohjelmointi_api/services/utils/ProjectWiseDataMapper.py
+++ b/infraohjelmointi_api/services/utils/ProjectWiseDataMapper.py
@@ -253,7 +253,7 @@ class ProjectWiseDataMapper:
                     raise ProjectWiseDataFieldNotFound(f"Field '{field}' not supported")
                 
                 if isinstance(field_mapper[value], list):
-                    result[mapped_field["field"]] = field_mapper[value][0] if value else None
+                    result[mapped_field["field"]] = field_mapper[value][1] if value else None
                 else:
                     result[mapped_field["field"]] = field_mapper[value] if value else None
             # Class/Location field handling


### PR DESCRIPTION
- pw data mapper had two values for if project phase in infratool is `draftInitiation` and it resulted in an error caused by trying to send an array to pw when that project phase was selected in infratool
- fixed the `convert_to_pw_data` function so that if the result of mapping the data is an array, the second option is sent
- note: the unnecessary/wrong phase can't be removed completely from the code since some projects in pw might still have the phase and if we need to fetch project data from pw, we need to be able to convert it to a phase in infratool
- ticket: [https://futurice.atlassian.net/jira/software/c/projects/HKISD/boards/62?selectedIssue=HKISD-272](https://futurice.atlassian.net/jira/software/c/projects/HKISD/boards/62?selectedIssue=HKISD-272)
- can only be tested in dev cause local environments don't have pw connection