### PR TITLE
HKISD-268: get always current year in project card

### DIFF
--- a/infraohjelmointi_api/serializers/ProjectGetSerializer.py
+++ b/infraohjelmointi_api/serializers/ProjectGetSerializer.py
@@ -141,7 +141,7 @@ class ProjectGetSerializer(DynamicFieldsModelSerializer, ProjectWithFinancesSeri
     def get_projectReadiness(self, project):
         return project.projectReadiness()
 
-    def get_currentYearsSapValue(self):
+    def get_currentYearsSapValue(self, project: Project):
         #Get the current year sap-costs for project card
         current_year = datetime.datetime.now().year
 

--- a/infraohjelmointi_api/serializers/ProjectGetSerializer.py
+++ b/infraohjelmointi_api/serializers/ProjectGetSerializer.py
@@ -1,4 +1,5 @@
 from datetime import date
+import datetime
 from os import path
 from infraohjelmointi_api.models import Project
 from infraohjelmointi_api.serializers import (
@@ -45,7 +46,9 @@ from infraohjelmointi_api.serializers.ProjectTypeSerializer import ProjectTypeSe
 from infraohjelmointi_api.serializers.ProjectWithFinancesSerializer import (
     ProjectWithFinancesSerializer,
 )
+from infraohjelmointi_api.serializers.SapCurrentYearSerializer import SapCurrentYearSerializer
 from infraohjelmointi_api.services.ProjectWiseService import ProjectWiseService
+from infraohjelmointi_api.services.SapCurrentYearService import SapCurrentYearService
 from rest_framework import serializers
 import environ
 from overrides import override
@@ -92,6 +95,7 @@ class ProjectGetSerializer(DynamicFieldsModelSerializer, ProjectWithFinancesSeri
     spentBudget = serializers.SerializerMethodField(method_name="get_spent_budget")
     pwFolderLink = serializers.SerializerMethodField(method_name="get_pw_folder_link")
     projectWiseService = None
+    currentYearsSapValues = serializers.SerializerMethodField(method_name="get_currentYearsSapValue")
 
     class Meta(BaseMeta):
         model = Project
@@ -136,6 +140,16 @@ class ProjectGetSerializer(DynamicFieldsModelSerializer, ProjectWithFinancesSeri
 
     def get_projectReadiness(self, project):
         return project.projectReadiness()
+
+    def get_currentYearsSapValue(self):
+        #Get the current year sap-costs for project card
+        current_year = datetime.datetime.now().year
+
+        sap_values = SapCurrentYearService.get_by_year(int(current_year))
+        sap_serializer = SapCurrentYearSerializer(sap_values, many=True)
+        sap_data = sap_serializer.data
+        
+        return sap_data
 
     @override
     def to_representation(self, instance):


### PR DESCRIPTION
- Related UI-PR: https://github.com/City-of-Helsinki/infraohjelmointi-ui/pull/322
- Ticket: https://futurice.atlassian.net/jira/software/c/projects/HKISD/boards/62?selectedIssue=HKISD-268
- Description
   - variable "startYear" is taken from planningView's year selector, and all sap values and current year's sap values are 
   fetched from database to state based on that selected year.
   - In planning view we want to show sap values only for the year that is selected in year selector as start year for time line
   - In project card previously sap values were taken from state based on this start year. This was not wanted, since 
     project card should show always current year's sap costs sum and total sum of sap costs and total sum of sap 
     commitments, even if start year in planning view is something else than real current year. 
 - Changes:
    - when fetching all sap values in App.ts, the year is set to be always current year, not the selected year from planning view
    - Backend now sends project's sap values for current year in project response when calling endpoint /project/{id} and those are shown in project card 
 - Testing:
    - in dev we can test by checking values from tables sapCurrentYear and sapCosts and compare those to planning view's and project card's sap values
    - Locally if wanted, this can be tested by creating values in mentioned tables 