### PR TITLE
HKISD-275: When forcedToFrame is locked, prevent budget moving to forced to frame view

### DIFF
--- a/infraohjelmointi_api/views/ProjectViewSet.py
+++ b/infraohjelmointi_api/views/ProjectViewSet.py
@@ -313,21 +313,7 @@ class ProjectViewSet(BaseViewSet):
                 )
 
                 finance_instances.append(finance_instance)
-                if (
-                    forced_to_frame == False
-                    and not ProjectFinancialService.instance_exists(
-                        project_id=project.id,
-                        year=finance_year,
-                        for_frame_view=True,
-                    )
-                ):
-                    frameViewFinanceObject = ProjectFinancial(
-                        project=project,
-                        year=finance_year,
-                        value=finances[field],
-                        forFrameView=True,
-                    )
-                    finance_instances.append(frameViewFinanceObject)
+
         return finance_instances
 
     @override


### PR DESCRIPTION
Bug was that when creating a budget for the first time to project, budgets went also to forced to frame view, even if forced to frame was locked. 

This fixes that. Budgets are moving to forced to frame only if it's not locked. 

