### PR TITLE
HKISD-264/feat add api project districts

### DIFF
--- a/infraohjelmointi_api/serializers/__init__.py
+++ b/infraohjelmointi_api/serializers/__init__.py
@@ -15,7 +15,7 @@ from .ProjectAreaSerializer import ProjectAreaSerializer
 from .ProjectCategorySerializer import ProjectCategorySerializer
 from .ProjectClassSerializer import ProjectClassSerializer
 from .ProjectCreateSerializer import ProjectCreateSerializer
-from .ProjectDistrictSerializer import ProjectDistrict
+from .ProjectDistrictSerializer import ProjectDistrictSerializer
 from .ProjectGetSerializer import ProjectGetSerializer
 from .ProjectGroupSerializer import ProjectGroupSerializer
 from .ProjectHashtagSerializer import ProjectHashtagSerializer

--- a/infraohjelmointi_api/views/__init__.py
+++ b/infraohjelmointi_api/views/__init__.py
@@ -32,6 +32,7 @@ from .WhoAmIViewSet import *
 from .SapCostViewSet import *
 from .ProjectDistrictViewSet import *
 from .api.ApiClassesViewSet import *
+from .api.ApiDistrictsViewSet import *
 from .api.ApiGroupsViewSet import *
 from .api.ApiLocationsViewSet import *
 from .api.ApiProjectsViewSet import *

--- a/infraohjelmointi_api/views/api/ApiDistrictsViewSet.py
+++ b/infraohjelmointi_api/views/api/ApiDistrictsViewSet.py
@@ -1,0 +1,47 @@
+from ..BaseViewSet import BaseViewSet
+from django.utils.decorators import method_decorator
+from rest_framework.authentication import TokenAuthentication
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from infraohjelmointi_api.models import ProjectDistrict
+from infraohjelmointi_api.serializers import ProjectDistrictSerializer
+import uuid
+from rest_framework import status
+
+from drf_yasg.utils import swagger_auto_schema
+
+@method_decorator(name='list', decorator=swagger_auto_schema(
+    operation_description="""
+    `GET /api/districts/`
+
+    Get all districts. A district is the lowest level of location where a project is situated.
+    """
+))
+class ApiDistrictsViewSet(BaseViewSet):
+    http_method_names = ['get']
+
+    authentication_classes = [TokenAuthentication]
+    permission_classes = [IsAuthenticated]
+
+    queryset = ProjectDistrict.objects.all()
+    serializer_class = ProjectDistrictSerializer
+
+
+    @swagger_auto_schema(
+            operation_description = """
+            `GET /api/districts/{id}`
+
+            Get all project districts.
+            """,
+            )
+    def retrieve(self, request, pk=None):
+        try:
+            uuid.UUID(str(pk))
+            queryset = self.get_queryset()
+            obj = queryset.get(pk=pk)
+            serializer = self.get_serializer(obj)
+            return Response(serializer.data)
+        except Exception:
+            return Response(
+                data={"message": "Not found"}, status=status.HTTP_404_NOT_FOUND
+            )

--- a/infraohjelmointi_api/views/api/ApiGroupsViewSet.py
+++ b/infraohjelmointi_api/views/api/ApiGroupsViewSet.py
@@ -3,7 +3,7 @@ from django.utils.decorators import method_decorator
 from rest_framework.authentication import TokenAuthentication
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
-from infraohjelmointi_api.models import ProjectLocation
+from infraohjelmointi_api.models import ProjectGroup
 from infraohjelmointi_api.serializers import ProjectGroupSerializer
 import uuid
 from rest_framework import status
@@ -23,7 +23,7 @@ class ApiGroupsViewSet(BaseViewSet):
     authentication_classes = [TokenAuthentication]
     permission_classes = [IsAuthenticated]
 
-    queryset = ProjectLocation.objects.all()
+    queryset = ProjectGroup.objects.all()
     serializer_class = ProjectGroupSerializer
 
 

--- a/infraohjelmointi_api/views/api/ApiLocationsViewSet.py
+++ b/infraohjelmointi_api/views/api/ApiLocationsViewSet.py
@@ -32,6 +32,9 @@ class ApiLocationsViewSet(BaseViewSet):
             `GET /api/locations/{id}`
 
             Get a location.
+
+            The projectLocation data on projects shows the lowest location category from the class hierarchy, and it might be empty.
+            To get detailed location information for projects, use the projectDistrict data and the endpoint `/api/districts/`.
             """,
             )
     def retrieve(self, request, pk=None):

--- a/project/urls_api.py
+++ b/project/urls_api.py
@@ -11,6 +11,12 @@ def api_router():
     )
 
     router.register(
+        r"api/districts",
+        views.ApiDistrictsViewSet,
+        basename="apiDistricts"
+    )
+
+    router.register(
         r"api/groups",
         views.ApiGroupsViewSet,
         basename="apiGroups"


### PR DESCRIPTION
Adds a new endpoint to fetch project district information.

- Add endpoint /api/districts/{id}
- With the same PR, group endpoint is fixed to use correct model
  - Change `ProjectLocation` to `ProjectGroup`
- Add documentation about locations and districts data