### PR TITLE
HKSID-276: fix link path in search results

### DIFF
--- a/infraohjelmointi_api/serializers/SearchResultSerializer.py
+++ b/infraohjelmointi_api/serializers/SearchResultSerializer.py
@@ -1,10 +1,11 @@
+import logging
 from uuid import UUID
 from infraohjelmointi_api.models import ProjectHashTag
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
 from .ProjectHashtagSerializer import ProjectHashtagSerializer
 from .ProjectPhaseSerializer import ProjectPhaseSerializer
-
+logger = logging.getLogger("infraohjelmointi_api")
 
 class SearchResultSerializer(serializers.Serializer):
     name = serializers.SerializerMethodField()
@@ -21,15 +22,15 @@ class SearchResultSerializer(serializers.Serializer):
         locationInstance = None
         path = ""
         group = None
+        group_has_location = False
         if instanceType == "Project":
             classInstance = getattr(obj, "projectClass", None)
             locationInstance = getattr(obj, "projectLocation", None)
             group = getattr(obj, "projectGroup", None)
 
             if group:
-                group_district = getattr(group, "location", None)
                 group_location = getattr(group, "locationRelation", None)
-                group_has_location = (group_district is not None) and (group_location is not None)
+                group_has_location = group_location is not None
 
         elif instanceType == "ProjectClass":
             classInstance = obj

--- a/infraohjelmointi_api/serializers/SearchResultSerializer.py
+++ b/infraohjelmointi_api/serializers/SearchResultSerializer.py
@@ -27,13 +27,9 @@ class SearchResultSerializer(serializers.Serializer):
             group = getattr(obj, "projectGroup", None)
 
             if group:
-                # Ensure that the deepest class or location in the path is the same as the group's.
                 group_district = getattr(group, "location", None)
                 group_location = getattr(group, "locationRelation", None)
                 group_has_location = (group_district is not None) and (group_location is not None)
-                group_class = getattr(group, "classRelation", None)
-                if group_class and classInstance and (group_class is not classInstance):
-                    classInstance = group_class
 
         elif instanceType == "ProjectClass":
             classInstance = obj

--- a/infraohjelmointi_api/serializers/SearchResultSerializer.py
+++ b/infraohjelmointi_api/serializers/SearchResultSerializer.py
@@ -31,6 +31,9 @@ class SearchResultSerializer(serializers.Serializer):
                 group_district = getattr(group, "location", None)
                 group_location = getattr(group, "locationRelation", None)
                 group_has_location = (group_district is not None) and (group_location is not None)
+                group_class = getattr(group, "classRelation", None)
+                if group_class and classInstance and (group_class is not classInstance):
+                    classInstance = group_class
 
         elif instanceType == "ProjectClass":
             classInstance = obj

--- a/infraohjelmointi_api/serializers/SearchResultSerializer.py
+++ b/infraohjelmointi_api/serializers/SearchResultSerializer.py
@@ -1,11 +1,9 @@
-import logging
 from uuid import UUID
 from infraohjelmointi_api.models import ProjectHashTag
 from rest_framework import serializers
 from rest_framework.exceptions import ValidationError
 from .ProjectHashtagSerializer import ProjectHashtagSerializer
 from .ProjectPhaseSerializer import ProjectPhaseSerializer
-logger = logging.getLogger("infraohjelmointi_api")
 
 class SearchResultSerializer(serializers.Serializer):
     name = serializers.SerializerMethodField()

--- a/infraohjelmointi_api/serializers/SearchResultSerializer.py
+++ b/infraohjelmointi_api/serializers/SearchResultSerializer.py
@@ -27,10 +27,10 @@ class SearchResultSerializer(serializers.Serializer):
             group = getattr(obj, "projectGroup", None)
 
             if group:
-                # Ensure that the deepest class in the path is the same as the group's class.
-                group_class = getattr(group, "classRelation", None)
-                if group_class and classInstance and group_class != classInstance:
-                    classInstance = group_class
+                # Ensure that the deepest class or location in the path is the same as the group's.
+                group_district = getattr(group, "location", None)
+                group_location = getattr(group, "locationRelation", None)
+                group_has_location = (group_district is not None) and (group_location is not None)
 
         elif instanceType == "ProjectClass":
             classInstance = obj
@@ -64,18 +64,18 @@ class SearchResultSerializer(serializers.Serializer):
         if locationInstance is None:
             return path
 
-        if locationInstance.parent is None and group is None:
+        if locationInstance.parent is None and (group is None or group_has_location):
             path = path + "&district={}".format(str(locationInstance.id))
         if (
             locationInstance.parent is not None 
             and locationInstance.parent.parent is not None
-            and group is None
+            and (group is None or group_has_location)
         ):
             path = path + "&district={}".format(str(locationInstance.parent.parent.id))
         if (
             locationInstance.parent is not None
             and locationInstance.parent.parent is None
-            and group is None
+            and (group is None or group_has_location)
         ):
             path = path + "&district={}".format(str(locationInstance.parent.id))
 


### PR DESCRIPTION
### Description
Link path in search results did not work in cases, where project was belonging to group that had location data. Previous solution did not take in count cases where projects were in group that has location info. Link in search results lead only to showing subClass in planning view. 

Ticket: https://futurice.atlassian.net/jira/software/c/projects/HKISD/boards/62?selectedIssue=HKISD-276&useStoredSettings=true

(Previous ticket: https://futurice.atlassian.net/jira/software/c/projects/HKISD/boards/62?search=222&selectedIssue=HKISD-222&useStoredSettings=true)

### Testing
Create a project in 
'8 03 Kadut ja liikenneväylät', 'Perusparantaminen ja liikennejärjestelyt', 'Katujen peruskorjaukset', 'Eteläinen suurpiiri'. 
And also create a group to same location and put project to that group. 

The link from search results leads to viewing the project in planning view. 

Also testing can be done by searching groups and projects that have different kind of locations. Check that link leads to planning view where the project really locates (=you can see the project).
