### PR TITLE
refactor: use cache layers to build docker image quicker

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,6 @@ FROM registry.access.redhat.com/ubi9/python-311:1-77.1726664316
 WORKDIR /app
 
 ENV STATIC_ROOT /srv/app/static
-COPY . .
 
 USER root
 
@@ -27,12 +26,17 @@ RUN TZ="Europe/Helsinki" && \
     pip install uwsgi && \
     # Ensure pip and python are accessible globally
     ln -s /usr/bin/pip3 /usr/local/bin/pip && \
-    ln -s /usr/bin/python3 /usr/local/bin/python && \
-    # Install Python project dependencies
-    pip install --no-cache-dir -r requirements.txt && \
+    ln -s /usr/bin/python3 /usr/local/bin/python
+
+COPY requirements.txt .
+
+RUN pip install --no-cache-dir -r requirements.txt && \
     # Collect static files using Django settings
-    mkdir -p /srv/app/static && \
-    DJANGO_SECRET_KEY="only-used-for-collectstatic" DATABASE_URL="sqlite:///" \
+    mkdir -p /srv/app/static
+
+COPY . .
+
+RUN DJANGO_SECRET_KEY="only-used-for-collectstatic" DATABASE_URL="sqlite:///" \
     python manage.py collectstatic --noinput && \
     chmod +x /app/sync-from-sap.sh
 


### PR DESCRIPTION
When there is a need to build docker image again, with current docker file it takes some time before all needed packages are installed.

Refactored file adds more build steps. With this, docker build can use cached layers for `yum` command. Previously one step included `yum` and `pip` commands, which took 119s to create.

`docker compose up --build`

Before
```output
[+] Building 124.8s (10/10) FINISHED                                                                                       docker:default
 => [api internal] load build definition from Dockerfile                                                                             0.0s
 => => transferring dockerfile: 1.16kB                                                                                               0.0s
 => [api internal] load metadata for registry.access.redhat.com/ubi9/python-311:1-77.1726664316                                      0.5s
 => [api internal] load .dockerignore                                                                                                0.0s
 => => transferring context: 2B                                                                                                      0.0s
 => [api 1/4] FROM registry.access.redhat.com/ubi9/python-311:1-77.1726664316@sha256:3dc479c15b8c8e1e09ca03a6eed59bc2d0f9d2e9291184  0.0s
 => [api internal] load build context                                                                                                0.1s
 => => transferring context: 191.22kB                                                                                                0.1s
 => CACHED [api 2/4] WORKDIR /app                                                                                                    0.0s
 => [api 3/4] COPY . .                                                                                                               0.2s
 => [api 4/4] RUN TZ="Europe/Helsinki" &&     yum -y update &&     yum install -y nano     libffi-devel     gcc     python3     p  119.9s
 => [api] exporting to image                                                                                                         4.1s 
 => => exporting layers                                                                                                              4.0s 
 => => writing image sha256:d3833a02f6da27f10ef2dab876a9b7692e332d2649a6c52af78ed4bb0f26ae26                                         0.0s 
 => => naming to docker.io/library/infraohjelmointi_api                                                                              0.0s 
 => [api] resolving provenance for metadata file                                                                                     0.0s 
[+] Running 3/3      
```

`[+] Building 124.8s (10/10) FINISHED`

After
```output
[+] Building 47.6s (13/13) FINISHED                                                                                        docker:default
 => [api internal] load build definition from Dockerfile                                                                             0.0s
 => => transferring dockerfile: 1.13kB                                                                                               0.0s
 => [api internal] load metadata for registry.access.redhat.com/ubi9/python-311:1-77.1726664316                                      0.5s
 => [api internal] load .dockerignore                                                                                                0.0s
 => => transferring context: 2B                                                                                                      0.0s
 => [api 1/7] FROM registry.access.redhat.com/ubi9/python-311:1-77.1726664316@sha256:3dc479c15b8c8e1e09ca03a6eed59bc2d0f9d2e9291184  0.0s
 => [api internal] load build context                                                                                                0.1s
 => => transferring context: 190.99kB                                                                                                0.1s
 => CACHED [api 2/7] WORKDIR /app                                                                                                    0.0s
 => CACHED [api 3/7] RUN TZ="Europe/Helsinki" &&     yum -y update &&     yum install -y nano     libffi-devel     gcc     python3   0.0s
 => [api 4/7] COPY requirements.txt .                                                                                                0.0s
 => [api 5/7] RUN pip install --no-cache-dir -r requirements.txt &&     mkdir -p /srv/app/static                                    44.5s
 => [api 6/7] COPY . .                                                                                                               0.2s 
 => [api 7/7] RUN DJANGO_SECRET_KEY="only-used-for-collectstatic" DATABASE_URL="sqlite:///"     python manage.py collectstatic --no  0.9s 
 => [api] exporting to image                                                                                                         1.2s 
 => => exporting layers                                                                                                              1.2s 
 => => writing image sha256:29df550acd044db31c889502633b523b06e9f964a72ce5fb6da0e4d03325bbac                                         0.0s 
 => => naming to docker.io/library/infraohjelmointi_api                                                                              0.0s 
 => [api] resolving provenance for metadata file                                                                                     0.0s 
[+] Running 3/3
```

`[+] Building 47.6s (13/13) FINISHED`