### PR TITLE
HKISD-270: fix project managers permissions

### DIFF
--- a/infraohjelmointi_api/permissions.py
+++ b/infraohjelmointi_api/permissions.py
@@ -248,7 +248,6 @@ class IsProjectManager(permissions.BasePermission):
             in [
                 *DJANGO_BASE_READ_ONLY_ACTIONS,
                 *DJANGO_BASE_UPDATE_ONLY_ACTIONS,
-                *DJANGO_BASE_DELETE_ONLY_ACTIONS,
                 *PROJECT_ALL_ACTIONS,
                 *PROJECT_CLASS_ALL_GET_ACTIONS,
                 *PROJECT_LOCATION_ALL_GET_ACTIONS,


### PR DESCRIPTION
### Description
Project manager is not allowed to delete projects. 

Ticket: https://futurice.atlassian.net/jira/software/c/projects/HKISD/boards/62?selectedIssue=HKISD-270
Related PR in frontend: https://github.com/City-of-Helsinki/infraohjelmointi-ui/pull/325

### Testing
Set the roles in backend: in file BaseViewSet.py modify the permission_classes so that it includes only the projectManager role. In frontend: in file AuthSlice.ts uncomment from the ad_groups the projectManager group. This will simulate the case when user has only projectManager role. 