### PR TITLE
HKISD-119: fix filtering search based on project location

### DIFF
--- a/infraohjelmointi_api/views/ProjectViewSet.py
+++ b/infraohjelmointi_api/views/ProjectViewSet.py
@@ -918,7 +918,7 @@ class ProjectViewSet(BaseViewSet):
         subDivision = self.request.query_params.getlist("subDivision", [])
 
         project_districts = self.request.query_params.getlist("projectdistrict", [])
-        project_divisions = self.request.query_params.getlist("prjectdivision", [])
+        project_divisions = self.request.query_params.getlist("projectdivision", [])
         project_sub_divisions = self.request.query_params.getlist("projectsubDivision", [])
 
         prYearMin = self.request.query_params.get("prYearMin", None)
@@ -950,10 +950,17 @@ class ProjectViewSet(BaseViewSet):
                 qs = qs.filter(projectDistrict__in=project_sub_divisions)
             
             elif len(project_divisions) > 0:
-                qs = qs.filter(projectDistrict__in=project_divisions)
+                qs = qs.filter(
+                    Q(projectDistrict__in=project_divisions) |
+                    Q(projectDistrict__parent__in=project_divisions)
+                )
 
             elif len(project_districts) > 0:
-                qs = qs.filter(projectDistrict__in=project_districts)
+                qs = qs.filter(
+                    Q(projectDistrict__in=project_districts) |
+                    Q(projectDistrict__parent__in=project_districts) |
+                    Q(projectDistrict__parent__parent__in=project_districts)
+                )
 
             if direct in ["true", "True"]:
                 direct = True

--- a/infraohjelmointi_api/views/ProjectViewSet.py
+++ b/infraohjelmointi_api/views/ProjectViewSet.py
@@ -917,6 +917,10 @@ class ProjectViewSet(BaseViewSet):
         division = self.request.query_params.getlist("division", [])
         subDivision = self.request.query_params.getlist("subDivision", [])
 
+        project_districts = self.request.query_params.getlist("projectdistrict", [])
+        project_divisions = self.request.query_params.getlist("prjectdivision", [])
+        project_sub_divisions = self.request.query_params.getlist("projectsubDivision", [])
+
         prYearMin = self.request.query_params.get("prYearMin", None)
         overMillion = self.request.query_params.get("overMillion", False)
         prYearMax = self.request.query_params.get("prYearMax", None)
@@ -942,7 +946,15 @@ class ProjectViewSet(BaseViewSet):
 
             qs = qs.filter(q_objects)
 
+            if len(project_sub_divisions) > 0:
+                qs = qs.filter(projectDistrict__in=project_sub_divisions)
             
+            elif len(project_divisions) > 0:
+                qs = qs.filter(projectDistrict__in=project_divisions)
+
+            elif len(project_districts) > 0:
+                qs = qs.filter(projectDistrict__in=project_districts)
+
             if direct in ["true", "True"]:
                 direct = True
             elif direct in ["false", "False"]:


### PR DESCRIPTION
- location filters in search used the locations from the hierarchy, which caused the lists to have multiple duplicates and missing options
- changed to use the same location options as the project card has, and that info is now compared to projectDistrict value on the Project model
- UI PR: https://github.com/City-of-Helsinki/infraohjelmointi-ui/pull/326