### PR TITLE
HKISD-277: fix permissions of project area planners

### DIFF
--- a/infraohjelmointi_api/permissions.py
+++ b/infraohjelmointi_api/permissions.py
@@ -121,6 +121,36 @@ PROJECT_GROUP_ALL_GET_ACTIONS = [
 ]
 PROJECT_GROUP_ALL_ACTIONS = [*PROJECT_GROUP_ALL_GET_ACTIONS]
 
+LIST_OF_DENIED_FIELDS_FOR_PROJECT_MANAGER = [
+    "finances",
+    "name", #* Kohde/hanke Ei (No) # name
+    "hkrId", # * PW hanketunnus Ei (No) # hkrId
+    "type", # * Hanketyyppi Ei (No) # type
+    "entityName", # * Hankekokonaisuuden nimi Ei (No) #entityName
+    "sapProject", # * Projektinumero Ei (No) # sapProject
+    "sapNetwork", # * Verkkonumerot Ei (No) # sapNetwork
+    "programmed", # * Ohjelmoitu Ei (No) # programmed
+    "planningStartYear", # * Suunnittelun aloitusvuosi Ei (No) # planningStartYear
+    "constructionEndYear", # * Rakentamisen valmistumisvuosi Ei (No) # constructionEndYear
+    "category", # * Kategoria Ei (No) # category
+    "effectHousing", # * Vaikutus asuntotuotantoon Ei (No) # effectHousing
+    "riskAssessment", # * Riskiarvio Ei (No) # riskAssessment
+    "projectClass", # luokka: value can be masterClass/class/subClass
+    "costForecast",
+    "realizedCost", # * Toteumatiedot Ei (No) # realizedCost
+    "comittedCost", # * Sidotut Ei (No) # comittedCost
+    "spentCost", # * Käytetty Ei (No) # spentCost
+    "budgetOverrunYear", # ylistysoikeus vuosi Ei (No) # budgetOverrunYear
+    "budgetOverrunAmount", # * Ylitysoikeus Ei (No) # budgetOverrunAmount
+    "personProgramming", # * Ohjelmoija Ei (No) # personProgramming
+    "responsibleZone", # * Alueen vastuujaon mukaan Ei (No) # responsibleZone
+    "projectLocation", # value can be district/division/subDivision
+
+    # preliminaryBudgetDivision is not yet implemented in UI
+    #"preliminaryBudgetDivision", # * Kustannusarvion alustava jakautuminen Ei (No)
+    # preliminaryBudgetDivision # ei löydy project.py
+]
+
 # ALL THE PERMISSION LOGIC GOES HERE, CAN BE REFACTORED LATER.
 # THESE CLASSES CAN BE ADDED TO BaseViewSet.py To APPLY THE REQUIRED PERMISSIONS AND ROLES
 # WORK STILL NEEDED
@@ -278,35 +308,7 @@ class IsProjectManager(permissions.BasePermission):
                     item
                     for item in request.data.keys()
                     if item
-                    in [
-                        "finances",
-                        "name", #* Kohde/hanke Ei (No) # name
-                        "hkrId", # * PW hanketunnus Ei (No) # hkrId
-                        "type", # * Hanketyyppi Ei (No) # type
-                        "entityName", # * Hankekokonaisuuden nimi Ei (No) #entityName
-                        "sapProject", # * Projektinumero Ei (No) # sapProject
-                        "sapNetwork", # * Verkkonumerot Ei (No) # sapNetwork
-                        "programmed", # * Ohjelmoitu Ei (No) # programmed
-                        "planningStartYear", # * Suunnittelun aloitusvuosi Ei (No) # planningStartYear
-                        "constructionEndYear", # * Rakentamisen valmistumisvuosi Ei (No) # constructionEndYear
-                        "category", # * Kategoria Ei (No) # category
-                        "effectHousing", # * Vaikutus asuntotuotantoon Ei (No) # effectHousing
-                        "riskAssessment", # * Riskiarvio Ei (No) # riskAssessment
-                        "projectClass", # luokka: value can be masterClass/class/subClass
-                        "costForecast",
-                        "realizedCost", # * Toteumatiedot Ei (No) # realizedCost
-                        "comittedCost", # * Sidotut Ei (No) # comittedCost
-                        "spentCost", # * Käytetty Ei (No) # spentCost
-                        "budgetOverrunYear", # ylistysoikeus vuosi Ei (No) # budgetOverrunYear
-                        "budgetOverrunAmount", # * Ylitysoikeus Ei (No) # budgetOverrunAmount
-                        "personProgramming", # * Ohjelmoija Ei (No) # personProgramming
-                        "responsibleZone", # * Alueen vastuujaon mukaan Ei (No) # responsibleZone
-                        "projectLocation", # value can be district/division/subDivision
-
-                        # preliminaryBudgetDivision is not yet implemented in UI
-                        #"preliminaryBudgetDivision", # * Kustannusarvion alustava jakautuminen Ei (No)
-                        # preliminaryBudgetDivision # ei löydy project.py
-                ]
+                    in LIST_OF_DENIED_FIELDS_FOR_PROJECT_MANAGER
             ]):
                 return False
 
@@ -391,8 +393,17 @@ class IsPlannerOfProjectAreas(BaseProjectAreaPermissions):
 
             if _type == "Note":
                 return True
+            
+            if _type == "Project" and any(
+                [
+                    item
+                    for item in request.data.keys()
+                    if item
+                    in LIST_OF_DENIED_FIELDS_FOR_PROJECT_MANAGER
+                ]):
+                return False
 
-        return False
+        return True
 
 class IsAdmin(permissions.BasePermission):
     def user_in_test_group(self, request):

--- a/infraohjelmointi_api/permissions.py
+++ b/infraohjelmointi_api/permissions.py
@@ -382,12 +382,12 @@ class IsPlannerOfProjectAreas(BaseProjectAreaPermissions):
         _type = obj._meta.model.__name__
 
         if view.action in [
-                *DJANGO_BASE_READ_ONLY_ACTIONS,
-                *DJANGO_BASE_UPDATE_ONLY_ACTIONS,
-                *DJANGO_BASE_CREATE_ONLY_ACTIONS,
-                *DJANGO_BASE_DELETE_ONLY_ACTIONS,
-                *PROJECT_ALL_ACTIONS,
-                *PROJECT_NOTE_ALL_ACTIONS,
+            *DJANGO_BASE_READ_ONLY_ACTIONS,
+            *DJANGO_BASE_UPDATE_ONLY_ACTIONS,
+            *DJANGO_BASE_CREATE_ONLY_ACTIONS,
+            *DJANGO_BASE_DELETE_ONLY_ACTIONS,
+            *PROJECT_ALL_ACTIONS,
+            *PROJECT_NOTE_ALL_ACTIONS,
         ] and _type in ["Project", "ProjectGroup", "Note"]:
             if (
                 (_type == "Project" and self.project_belongs_to_808_main_class(obj, request))


### PR DESCRIPTION
### Description
Project area planners had permissions to open and modify project cards only in main class 8 08. Project area planners should have full permissions to see and modify projects under main class 8 08. Projects under other main classes project area planners should be able to see project cards and modify same fields that project managers have permission to modify. Permission ticket: https://helsinkisolutionoffice.atlassian.net/browse/IO-78. 

Notice: projectAreaPlanner does not have permissions to delete or create projects that goes under other than 8 08 main class. 

Ticket: https://futurice.atlassian.net/jira/software/c/projects/HKISD/boards/62?selectedIssue=HKISD-277

### Testing
Set the roles in backend: in file BaseViewSet.py modify the permission_classes so that it includes only the projectAreaPlanner role. In frontend: in file AuthSlice.ts uncomment from the ad_groups the projectAreaPlanner group. This will simulate the case when user has only projectAreaPlanner role.

With this role you are able to modify every field in projects that are under main class 8 08. Project under other main classes you can modify only fields that are not:
    "finances",
    "name", #* Kohde/hanke Ei (No) # name
    "hkrId", # * PW hanketunnus Ei (No) # hkrId
    "type", # * Hanketyyppi Ei (No) # type
    "entityName", # * Hankekokonaisuuden nimi Ei (No) #entityName
    "sapProject", # * Projektinumero Ei (No) # sapProject
    "sapNetwork", # * Verkkonumerot Ei (No) # sapNetwork
    "programmed", # * Ohjelmoitu Ei (No) # programmed
    "planningStartYear", # * Suunnittelun aloitusvuosi Ei (No) # planningStartYear
    "constructionEndYear", # * Rakentamisen valmistumisvuosi Ei (No) # constructionEndYear
    "category", # * Kategoria Ei (No) # category
    "effectHousing", # * Vaikutus asuntotuotantoon Ei (No) # effectHousing
    "riskAssessment", # * Riskiarvio Ei (No) # riskAssessment
    "projectClass", # luokka: value can be masterClass/class/subClass
    "costForecast",
    "realizedCost", # * Toteumatiedot Ei (No) # realizedCost
    "comittedCost", # * Sidotut Ei (No) # comittedCost
    "spentCost", # * Käytetty Ei (No) # spentCost
    "budgetOverrunYear", # ylistysoikeus vuosi Ei (No) # budgetOverrunYear
    "budgetOverrunAmount", # * Ylitysoikeus Ei (No) # budgetOverrunAmount
    "personProgramming", # * Ohjelmoija Ei (No) # personProgramming
    "responsibleZone", # * Alueen vastuujaon mukaan Ei (No) # responsibleZone
    "projectLocation", # value can be district/division/subDivision