### PR TITLE
feat: HKISD-279 use StreamingHttpResponse for API endpoints

### DIFF
--- a/infraohjelmointi_api/tests/test_Api.py
+++ b/infraohjelmointi_api/tests/test_Api.py
@@ -134,8 +134,15 @@ class ApiTestCase(TestCase):
         self.assertEqual(response_project_by_class.status_code, 200, msg="Project status code != 200")
 
         project_data = ProjectGetSerializer(Project.objects.get(id=self.project_id)).data
-        self.assertEqual(response_project.json()["id"], project_data["id"])
-        self.assertEqual(response_project_by_class.json()[0]["id"], project_data["id"])
+
+        response_project_content = b"".join(response_project.streaming_content).decode('utf-8')
+        response_project_json = json.loads(response_project_content)
+
+        response_project_by_class_content = b"".join(response_project_by_class.streaming_content).decode('utf-8')
+        response_project_by_class_json = json.loads(response_project_by_class_content)
+
+        self.assertEqual(response_project_json["id"], project_data["id"])
+        self.assertEqual(response_project_by_class_json[0]["id"], project_data["id"])
 
 
     def test_api_GET_groups(self):
@@ -148,7 +155,11 @@ class ApiTestCase(TestCase):
         self.assertEqual(response_group.status_code, 200, msg="Groups status code != 200")
 
         group_data = ProjectGroupSerializer(ProjectGroup.objects.get(id=self.project_group_id)).data
-        self.assertEqual(response_group.json()["id"], group_data["id"])
+
+        response_project_content = b"".join(response_group.streaming_content).decode('utf-8')
+        response_project_json = json.loads(response_project_content)
+
+        self.assertEqual(response_project_json["id"], group_data["id"])
 
 
     def test_api_GET_classes(self):
@@ -161,7 +172,11 @@ class ApiTestCase(TestCase):
         self.assertEqual(response_class.status_code, 200, msg="Classes status code != 200")
 
         class_data = ProjectClassSerializer(ProjectClass.objects.get(id=self.class_id)).data
-        self.assertEqual(response_class.json()["id"], class_data["id"])
+
+        response_project_content = b"".join(response_class.streaming_content).decode('utf-8')
+        response_project_json = json.loads(response_project_content)
+
+        self.assertEqual(response_project_json["id"], class_data["id"])
 
     def test_api_GET_districts(self):
         self = setup_client(self)
@@ -173,7 +188,11 @@ class ApiTestCase(TestCase):
         self.assertEqual(response_district.status_code, 200, msg="District status code != 200")
 
         district_data = ProjectDistrictSerializer(ProjectDistrict.objects.get(id=self.project_district_id)).data
-        self.assertEqual(response_district.json()["id"], district_data["id"])
+
+        response_project_content = b"".join(response_district.streaming_content).decode('utf-8')
+        response_project_json = json.loads(response_project_content)
+
+        self.assertEqual(response_project_json["id"], district_data["id"])
 
 
     def test_class_viewset_configuration(self):
@@ -198,7 +217,11 @@ class ApiTestCase(TestCase):
         self.assertEqual(response_location.status_code, 200, msg="Locations status code != 200")
 
         location_data = ProjectLocationSerializer(ProjectLocation.objects.get(id=self.division_id)).data
-        self.assertEqual(response_location.json()["id"], location_data["id"])
+
+        response_project_content = b"".join(response_location.streaming_content).decode('utf-8')
+        response_project_json = json.loads(response_project_content)
+
+        self.assertEqual(response_project_json["id"], location_data["id"])
 
     def test_retrieve_location_not_found(self):
         self = setup_client(self)

--- a/infraohjelmointi_api/views/api/ApiClassesViewSet.py
+++ b/infraohjelmointi_api/views/api/ApiClassesViewSet.py
@@ -1,3 +1,4 @@
+import json
 from ..BaseViewSet import BaseViewSet
 from django.utils.decorators import method_decorator
 from rest_framework.authentication import TokenAuthentication
@@ -40,7 +41,7 @@ class ApiClassesViewSet(BaseViewSet):
             queryset = self.get_queryset()
             obj = queryset.get(pk=pk)
             serializer = self.get_serializer(obj)
-            return Response(serializer.data)
+            return StreamingHttpResponse((json.dumps(serializer.data, default=str) for _ in [0]), content_type="application/json")
         except Exception:
             return Response(
                 data={"message": "Not found"}, status=status.HTTP_404_NOT_FOUND

--- a/infraohjelmointi_api/views/api/ApiClassesViewSet.py
+++ b/infraohjelmointi_api/views/api/ApiClassesViewSet.py
@@ -3,10 +3,11 @@ from django.utils.decorators import method_decorator
 from rest_framework.authentication import TokenAuthentication
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
-from infraohjelmointi_api.models import ProjectClass
 from infraohjelmointi_api.serializers import ProjectClassSerializer
-import uuid
+from django.http import StreamingHttpResponse
+from .utils import generate_streaming_response
 from rest_framework import status
+import uuid
 
 from drf_yasg.utils import swagger_auto_schema
 
@@ -23,7 +24,6 @@ class ApiClassesViewSet(BaseViewSet):
     authentication_classes = [TokenAuthentication]
     permission_classes = [IsAuthenticated]
 
-    queryset = ProjectClass.objects.all()
     serializer_class = ProjectClassSerializer
 
 
@@ -45,3 +45,10 @@ class ApiClassesViewSet(BaseViewSet):
             return Response(
                 data={"message": "Not found"}, status=status.HTTP_404_NOT_FOUND
             )
+
+    def list(self, request, *args, **kwargs):
+        queryset = self.get_queryset()
+        return StreamingHttpResponse(
+            generate_streaming_response(queryset, self.serializer_class, endpoint="Classes"),
+            content_type='application/json'
+        )

--- a/infraohjelmointi_api/views/api/ApiDistrictsViewSet.py
+++ b/infraohjelmointi_api/views/api/ApiDistrictsViewSet.py
@@ -3,10 +3,11 @@ from django.utils.decorators import method_decorator
 from rest_framework.authentication import TokenAuthentication
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
-from infraohjelmointi_api.models import ProjectDistrict
 from infraohjelmointi_api.serializers import ProjectDistrictSerializer
-import uuid
 from rest_framework import status
+from django.http import StreamingHttpResponse
+from .utils import generate_streaming_response
+import uuid
 
 from drf_yasg.utils import swagger_auto_schema
 
@@ -23,9 +24,7 @@ class ApiDistrictsViewSet(BaseViewSet):
     authentication_classes = [TokenAuthentication]
     permission_classes = [IsAuthenticated]
 
-    queryset = ProjectDistrict.objects.all()
     serializer_class = ProjectDistrictSerializer
-
 
     @swagger_auto_schema(
             operation_description = """
@@ -45,3 +44,10 @@ class ApiDistrictsViewSet(BaseViewSet):
             return Response(
                 data={"message": "Not found"}, status=status.HTTP_404_NOT_FOUND
             )
+
+    def list(self, request, *args, **kwargs):
+        queryset = self.get_queryset()
+        return StreamingHttpResponse(
+            generate_streaming_response(queryset, self.serializer_class, endpoint="Districts"),
+            content_type='application/json'
+        )

--- a/infraohjelmointi_api/views/api/ApiDistrictsViewSet.py
+++ b/infraohjelmointi_api/views/api/ApiDistrictsViewSet.py
@@ -1,3 +1,4 @@
+import json
 from ..BaseViewSet import BaseViewSet
 from django.utils.decorators import method_decorator
 from rest_framework.authentication import TokenAuthentication
@@ -39,7 +40,7 @@ class ApiDistrictsViewSet(BaseViewSet):
             queryset = self.get_queryset()
             obj = queryset.get(pk=pk)
             serializer = self.get_serializer(obj)
-            return Response(serializer.data)
+            return StreamingHttpResponse((json.dumps(serializer.data, default=str) for _ in [0]), content_type="application/json")
         except Exception:
             return Response(
                 data={"message": "Not found"}, status=status.HTTP_404_NOT_FOUND

--- a/infraohjelmointi_api/views/api/ApiGroupsViewSet.py
+++ b/infraohjelmointi_api/views/api/ApiGroupsViewSet.py
@@ -1,3 +1,4 @@
+import json
 from ..BaseViewSet import BaseViewSet
 from django.utils.decorators import method_decorator
 from rest_framework.authentication import TokenAuthentication
@@ -39,7 +40,7 @@ class ApiGroupsViewSet(BaseViewSet):
             queryset = self.get_queryset()
             obj = queryset.get(pk=pk)
             serializer = self.get_serializer(obj)
-            return Response(serializer.data)
+            return StreamingHttpResponse((json.dumps(serializer.data, default=str) for _ in [0]), content_type="application/json")
         except Exception:
             return Response(
                 data={"message": "Not found"}, status=status.HTTP_404_NOT_FOUND

--- a/infraohjelmointi_api/views/api/ApiGroupsViewSet.py
+++ b/infraohjelmointi_api/views/api/ApiGroupsViewSet.py
@@ -3,10 +3,11 @@ from django.utils.decorators import method_decorator
 from rest_framework.authentication import TokenAuthentication
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
-from infraohjelmointi_api.models import ProjectGroup
 from infraohjelmointi_api.serializers import ProjectGroupSerializer
-import uuid
 from rest_framework import status
+from django.http import StreamingHttpResponse
+from .utils import generate_streaming_response
+import uuid
 
 from drf_yasg.utils import swagger_auto_schema
 
@@ -23,9 +24,7 @@ class ApiGroupsViewSet(BaseViewSet):
     authentication_classes = [TokenAuthentication]
     permission_classes = [IsAuthenticated]
 
-    queryset = ProjectGroup.objects.all()
     serializer_class = ProjectGroupSerializer
-
 
     @swagger_auto_schema(
             operation_description = """
@@ -45,3 +44,10 @@ class ApiGroupsViewSet(BaseViewSet):
             return Response(
                 data={"message": "Not found"}, status=status.HTTP_404_NOT_FOUND
             )
+
+    def list(self, request, *args, **kwargs):
+        queryset = self.get_queryset()
+        return StreamingHttpResponse(
+            generate_streaming_response(queryset, self.serializer_class, endpoint="Groups"),
+            content_type='application/json'
+        )

--- a/infraohjelmointi_api/views/api/ApiLocationsViewSet.py
+++ b/infraohjelmointi_api/views/api/ApiLocationsViewSet.py
@@ -3,10 +3,11 @@ from django.utils.decorators import method_decorator
 from rest_framework.authentication import TokenAuthentication
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
-from infraohjelmointi_api.models import ProjectLocation
 from infraohjelmointi_api.serializers import ProjectLocationSerializer
-import uuid
 from rest_framework import status
+from django.http import StreamingHttpResponse
+from .utils import generate_streaming_response
+import uuid
 
 from drf_yasg.utils import swagger_auto_schema
 
@@ -23,20 +24,18 @@ class ApiLocationsViewSet(BaseViewSet):
     authentication_classes = [TokenAuthentication]
     permission_classes = [IsAuthenticated]
 
-    queryset = ProjectLocation.objects.all()
     serializer_class = ProjectLocationSerializer
 
-
     @swagger_auto_schema(
-            operation_description = """
-            `GET /api/locations/{id}`
+        operation_description = """
+        `GET /api/locations/{id}`
 
-            Get a location.
+        Get a location.
 
-            The projectLocation data on projects shows the lowest location category from the class hierarchy, and it might be empty.
-            To get detailed location information for projects, use the projectDistrict data and the endpoint `/api/districts/`.
-            """,
-            )
+        The projectLocation data on projects shows the lowest location category from the class hierarchy, and it might be empty.
+        To get detailed location information for projects, use the projectDistrict data and the endpoint `/api/districts/`.
+        """,
+        )
     def retrieve(self, request, pk=None):
         try:
             uuid.UUID(str(pk))
@@ -48,3 +47,10 @@ class ApiLocationsViewSet(BaseViewSet):
             return Response(
                 data={"message": "Not found"}, status=status.HTTP_404_NOT_FOUND
             )
+
+    def list(self, request, *args, **kwargs):
+        queryset = self.get_queryset()
+        return StreamingHttpResponse(
+            generate_streaming_response(queryset, self.serializer_class, endpoint="Locations"),
+            content_type='application/json'
+        )

--- a/infraohjelmointi_api/views/api/ApiLocationsViewSet.py
+++ b/infraohjelmointi_api/views/api/ApiLocationsViewSet.py
@@ -1,3 +1,4 @@
+import json
 from ..BaseViewSet import BaseViewSet
 from django.utils.decorators import method_decorator
 from rest_framework.authentication import TokenAuthentication
@@ -42,7 +43,7 @@ class ApiLocationsViewSet(BaseViewSet):
             queryset = self.get_queryset()
             obj = queryset.get(pk=pk)
             serializer = self.get_serializer(obj)
-            return Response(serializer.data)
+            return StreamingHttpResponse((json.dumps(serializer.data, default=str) for _ in [0]), content_type="application/json")
         except Exception:
             return Response(
                 data={"message": "Not found"}, status=status.HTTP_404_NOT_FOUND

--- a/infraohjelmointi_api/views/api/ApiProjectsViewSet.py
+++ b/infraohjelmointi_api/views/api/ApiProjectsViewSet.py
@@ -1,3 +1,4 @@
+import json
 from ..BaseViewSet import BaseViewSet
 from django.utils.decorators import method_decorator
 from rest_framework.authentication import TokenAuthentication
@@ -69,7 +70,7 @@ class ApiProjectsViewSet(BaseViewSet):
             queryset = self.get_queryset()
             obj = queryset.get(pk=pk)
             serializer = self.get_serializer(obj)
-            return Response(serializer.data)
+            return StreamingHttpResponse((json.dumps(serializer.data, default=str) for _ in [0]), content_type="application/json")
         except Exception:
             return Response(
                 data={"message": "Not found"}, status=status.HTTP_404_NOT_FOUND

--- a/infraohjelmointi_api/views/api/utils.py
+++ b/infraohjelmointi_api/views/api/utils.py
@@ -1,0 +1,52 @@
+import json
+import logging
+import time
+import uuid
+
+logger = logging.getLogger("infraohjelmointi_api")
+
+def generate_streaming_response(queryset, serializer_class, endpoint, chunk_size=1000):
+    """
+    Generates a streaming response for a given queryset using the provided serializer with chunking.
+
+    Args:
+        queryset: The Django queryset to serialize.
+        serializer_class: The Django REST Framework serializer class to use.
+        chunk_size: The number of serialized items to include in each chunk.
+
+    Yields:
+        str: A chunk of the JSON response.
+    """
+    serializer = serializer_class(many=False)
+
+    def data_generator():
+        logger.info(
+            "Started to generate endpoint {} data".format(endpoint)
+        )
+        start = time.time()
+        yield '['
+        first = True
+        item_buffer = []
+        for item in queryset:
+            serialized_data = serializer.to_representation(item)
+            def convert_uuid_to_str(obj):
+                if isinstance(obj, uuid.UUID):
+                    return str(obj)
+                return obj
+            json_string = json.dumps(serialized_data, default=convert_uuid_to_str)
+            item_buffer.append(json_string)
+
+            if len(item_buffer) >= chunk_size:
+                yield (',' if not first else '') + ','.join(item_buffer)
+                item_buffer = []
+                first = False
+
+        if item_buffer:
+            yield (',' if not first else '') + ','.join(item_buffer)
+
+        yield ']'
+        end = time.time()
+        logger.info(
+            "Finished generating endpoint {} data in {} seconds".format(endpoint, round(end-start, 3))
+        )
+    return data_generator()


### PR DESCRIPTION
Includes changes to tackle Task kill and backend crashing issues when fetching data from all API endpoints at the same time. When data is fetched, API might crash because memory gets full.

- Use StreamingHttpResponse for API endpoints
- Use smaller chunk size for Projects endpoint
- Log how long time generating response took
- Update tests to correctly test endpoints with StreamingHttpResponse