### PR TITLE
fix: HKISD-279 remove duplicated swagger decorator

### DIFF
--- a/infraohjelmointi_api/views/api/ApiProjectsViewSet.py
+++ b/infraohjelmointi_api/views/api/ApiProjectsViewSet.py
@@ -25,17 +25,6 @@ class_parameter = openapi.Parameter(
 )
 
 
-@method_decorator(
-    name="list",
-    decorator=swagger_auto_schema(
-        operation_description="""
-    `GET /api/projects/`
-
-    Get all projects.
-    """,
-        manual_parameters=[class_parameter],
-    ),
-)
 class ApiProjectsViewSet(BaseViewSet):
     http_method_names = ["get"]
 


### PR DESCRIPTION
Duplicated decorator caused endpoint /api/projects/ crashing. This fix removes unnecessary Swagger decorator.