### PR TITLE
HKISD-279: decrease chache size from 6000 to 300

### DIFF
--- a/project/settings.py
+++ b/project/settings.py
@@ -246,7 +246,7 @@ CACHES = {
     "default": {
         "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
         "TIMEOUT": 60 * 60 * 2,  # 2 hour timeout default
-        "OPTIONS": {"MAX_ENTRIES": 6000},
+        "OPTIONS": {"MAX_ENTRIES": 300},
     }
 }
 


### PR DESCRIPTION
Decreasing the size of the cache to 300, which is default value. There's no need anymore for extra large cache. 