### PR TITLE
HKISD-279: add logging to ProjectViewSet to investigate getProjects

### DIFF
--- a/infraohjelmointi_api/views/ProjectViewSet.py
+++ b/infraohjelmointi_api/views/ProjectViewSet.py
@@ -743,7 +743,7 @@ class ProjectViewSet(BaseViewSet):
         start_time = time.time()
         logger.info(f"{request.user.id}: Starting get_projects with for_coordinator={for_coordinator}, forFrameView={forFrameView}")
         filter_start_time = time.time()
-        logger.info("f{request.user.id}: Filtering queryset using self.filter_queryset and self.get_queryset")
+        logger.info(f"{request.user.id}: Filtering queryset using self.filter_queryset and self.get_queryset")
         queryset = self.filter_queryset(
             self.get_queryset(for_coordinator=for_coordinator)
         )

--- a/infraohjelmointi_api/views/ProjectViewSet.py
+++ b/infraohjelmointi_api/views/ProjectViewSet.py
@@ -743,7 +743,7 @@ class ProjectViewSet(BaseViewSet):
         start_time = time.time()
         logger.info(f"{request.user.id}: Starting get_projects with for_coordinator={for_coordinator}, forFrameView={forFrameView}")
         filter_start_time = time.time()
-        logger.info("{request.user.id}: Filtering queryset using self.filter_queryset and self.get_queryset")
+        logger.info("f{request.user.id}: Filtering queryset using self.filter_queryset and self.get_queryset")
         queryset = self.filter_queryset(
             self.get_queryset(for_coordinator=for_coordinator)
         )
@@ -761,7 +761,7 @@ class ProjectViewSet(BaseViewSet):
 
         if financeYear is not None and not financeYear.isnumeric():
             logger.error(f"{request.user.id}: Invalid financeYear provided: {financeYear}")
-            raise ParseError(detail={"{request.user.id}: limit": "Invalid value"}, code="invalid")
+            raise ParseError(detail={f"{request.user.id}: limit": "Invalid value"}, code="invalid")
 
         # pagination
         logger.info(f"{request.user.id}: Initializing pagination with page size: {limit}")
@@ -810,7 +810,7 @@ class ProjectViewSet(BaseViewSet):
             logger.info(f"{request.user.id}: Total execution time for get_projects: {total_time:.4f} seconds")
             return paginator.get_paginated_response(serializer.data)
         
-        logger.info("{request.user.id}: Serializing all results (no pagination)")
+        logger.info(f"{request.user.id}: Serializing all results (no pagination)")
         serializer = self.get_serializer(
             queryset,
             many=True,

--- a/infraohjelmointi_api/views/ProjectViewSet.py
+++ b/infraohjelmointi_api/views/ProjectViewSet.py
@@ -796,9 +796,9 @@ class ProjectViewSet(BaseViewSet):
             "projects_to_finances": projects_to_finances
         }
         logger.info(f"Serializer context created: {serializerContext}")
-
+        serialization_start_time = time.time()
         if page is not None:
-            serialization_start_time = time.time()
+            
             serializer = self.get_serializer(
                 page,
                 many=True,


### PR DESCRIPTION
Add logging to getProjects endpoint. If needed, logging can be reduced afterwards. 

Logging is added to help investigating report downloading issues in production. 