### PR TITLE
Fix/Api streamingHttpResponse iterators

### DIFF
--- a/infraohjelmointi_api/views/api/ApiGroupsViewSet.py
+++ b/infraohjelmointi_api/views/api/ApiGroupsViewSet.py
@@ -3,7 +3,6 @@ from django.utils.decorators import method_decorator
 from rest_framework.authentication import TokenAuthentication
 from rest_framework.permissions import IsAuthenticated
 from infraohjelmointi_api.serializers import ProjectGroupSerializer
-from rest_framework import status
 from django.http import StreamingHttpResponse
 from .utils import generate_response, generate_streaming_response, send_logger_api_generate_data_start
 

--- a/infraohjelmointi_api/views/api/ApiProjectsViewSet.py
+++ b/infraohjelmointi_api/views/api/ApiProjectsViewSet.py
@@ -12,7 +12,7 @@ from infraohjelmointi_api.serializers import (
 )
 import uuid
 from django.http import StreamingHttpResponse
-from .utils import generate_response, generate_response_not_found, generate_streaming_response, send_logger_api_generate_data_start
+from .utils import generate_response, generate_streaming_response, send_logger_api_generate_data_start
 
 from drf_yasg import openapi
 from drf_yasg.utils import swagger_auto_schema


### PR DESCRIPTION
- use asynchronous and not synchronous iterators with streamingHttpResponse
- update api/projects tests to correctly handle streamingHttpResponse
- remove unnecessary imports