### PR TITLE
IO-388: automate setting takuuaika phase to two years

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,3 +24,4 @@ social-auth-app-django
 drf-yasg                                    # API Swagger documentation
 numpy
 setuptools>=70.0.0 # not directly required, pinned by Snyk to avoid a vulnerability
+python-dateutil


### PR DESCRIPTION
- added a feature to set takuuaika dates so that takuuaika is two years if no specific dates were set before project moves to warranty period