### PR TITLE
fix: IO-740 Fix ProjectWise phase assignment bug

### DIFF
--- a/infraohjelmointi_api/services/ProjectWiseService.py
+++ b/infraohjelmointi_api/services/ProjectWiseService.py
@@ -631,9 +631,7 @@ class ProjectWiseService:
         if project_properties["PROJECT_Hankkeen_vaihe"]:
             project.phase = (
                 self.project_phases[project_properties["PROJECT_Hankkeen_vaihe"]]
-                if hasattr(
-                    self.project_phases, project_properties["PROJECT_Hankkeen_vaihe"]
-                )
+                if project_properties["PROJECT_Hankkeen_vaihe"] in self.project_phases
                 else self.project_phases["2. Ohjelmointi"]
             )
 


### PR DESCRIPTION
Fixed hasattr() bug that caused ProjectWise-imported projects to default to programming phase instead of correct planning phases