### PR TITLE
feat: IO-770 Fix Talpa Excel

### DIFF
--- a/infraohjelmointi_api/services/TalpaExcelService.py
+++ b/infraohjelmointi_api/services/TalpaExcelService.py
@@ -49,19 +49,27 @@ class TalpaExcelService:
 
     def _get_computed(self, opening, field: str) -> str:
         if field == "_budgetAccountNumber":
-            # Extract number from "8 03 01 02 Perusparantaminen..."
+            # Extract number: leading digit-only segments (e.g. "8 03 01 01" or "8 09 01")
             val = opening.budgetAccount or ""
-            parts = val.split(" ")
-            if len(parts) >= 4:
-                return " ".join(parts[0:4])
-            return val
+            parts = val.split()
+            number_parts = []
+            for p in parts:
+                if p.isdigit():
+                    number_parts.append(p)
+                else:
+                    break
+            return " ".join(number_parts) if number_parts else val
         if field == "_budgetAccountName":
-            # Extract name part after the number
+            # Extract name part: everything after the leading digit segments
             val = opening.budgetAccount or ""
-            parts = val.split(" ")
-            if len(parts) >= 5:
-                return " ".join(parts[4:]).strip()
-            return ""
+            parts = val.split()
+            name_start = 0
+            for i, p in enumerate(parts):
+                if not p.isdigit():
+                    name_start = i
+                    break
+                name_start = i + 1
+            return " ".join(parts[name_start:]).strip() if name_start < len(parts) else ""
         if field == "_numberRange" and opening.projectNumberRange:
             r = opening.projectNumberRange
             return f"{r.rangeStart} - {r.rangeEnd}"

--- a/infraohjelmointi_api/tests/test_TalpaExcelService.py
+++ b/infraohjelmointi_api/tests/test_TalpaExcelService.py
@@ -213,11 +213,57 @@ class TalpaExcelServiceTestCase(TestCase):
         self.assertEqual(budget_num, "8 03 01 02")
         self.assertEqual(budget_name, "Perusparantaminen")
         self.assertEqual(number_range, "2814I01000 - 2814I01599")
-        self.assertEqual(type_code, "INV")
-        self.assertEqual(type_priority, "03")
-        self.assertEqual(address_full, "Main Street 5 00100")
-        self.assertEqual(service_code, "4601")
-        self.assertEqual(asset_component, "K1230000")
+
+    def test_generate_excel_budget_account_three_part_number(self):
+        """Talousarviokohta with 3-part number (e.g. Malminkartano-Kannelmäki) splits number and name correctly."""
+        opening = TalpaProjectOpening.objects.create(
+            project=self.project,
+            subject="Uusi",
+            projectName="Test",
+            projectType=self.talpa_project_type,
+            projectNumberRange=self.talpa_range,
+            budgetAccount="8 09 01 Malminkartano-Kannelmäki",
+        )
+        excel_file = self.service.generate_excel(opening)
+        excel_file.seek(0)
+        wb = load_workbook(excel_file)
+        ws = wb.active
+        self.assertEqual(ws["A2"].value, "8 09 01")
+        self.assertEqual(ws["B2"].value, "Malminkartano-Kannelmäki")
+
+    def test_generate_excel_budget_account_two_part_number(self):
+        """Talousarviokohta with 2-part number splits number and name correctly."""
+        opening = TalpaProjectOpening.objects.create(
+            project=self.project,
+            subject="Uusi",
+            projectName="Test",
+            projectType=self.talpa_project_type,
+            projectNumberRange=self.talpa_range,
+            budgetAccount="8 03 Kadut ja liikenneväylät",
+        )
+        excel_file = self.service.generate_excel(opening)
+        excel_file.seek(0)
+        wb = load_workbook(excel_file)
+        ws = wb.active
+        self.assertEqual(ws["A2"].value, "8 03")
+        self.assertEqual(ws["B2"].value, "Kadut ja liikenneväylät")
+
+    def test_generate_excel_budget_account_number_only_no_name(self):
+        """Talousarviokohta with only number (no name) leaves name cell empty."""
+        opening = TalpaProjectOpening.objects.create(
+            project=self.project,
+            subject="Uusi",
+            projectName="Test",
+            projectType=self.talpa_project_type,
+            projectNumberRange=self.talpa_range,
+            budgetAccount="8 09 01",
+        )
+        excel_file = self.service.generate_excel(opening)
+        excel_file.seek(0)
+        wb = load_workbook(excel_file)
+        ws = wb.active
+        self.assertEqual(ws["A2"].value, "8 09 01")
+        self.assertIn(ws["B2"].value, (None, ""))
 
     def test_generate_excel_empty_fields(self):
         opening = TalpaProjectOpening.objects.create(


### PR DESCRIPTION
* Split budget account number and name for 2- and 3-part codes
* Parse number as leading digit-only tokens instead of fixed 4 segments (fixes Malminkartano-Kannelmäki etc.)

https://helsinkisolutionoffice.atlassian.net/browse/IO-770 (commit based on latest comment)