### PR TITLE
fix: IO-818 Wrong budget sums for groups

### DIFF
--- a/infraohjelmointi_api/serializers/FinancialSumSerializer.py
+++ b/infraohjelmointi_api/serializers/FinancialSumSerializer.py
@@ -257,6 +257,8 @@ class FinancialSumSerializer(serializers.ModelSerializer):
             # Planning locations: don't cache (have coordinatorLocation attribute)
             elif getattr(instance, "coordinatorLocation", None):
                 use_cache = False
+        elif _type == "ProjectGroup":
+            use_cache = False
 
         cached_result = None
         if use_cache:

--- a/infraohjelmointi_api/tests/test_FinancialSumSerializer.py
+++ b/infraohjelmointi_api/tests/test_FinancialSumSerializer.py
@@ -2,10 +2,14 @@ from django.test import TestCase
 from datetime import date
 from collections import defaultdict
 import uuid
+from unittest.mock import patch
 
 from infraohjelmointi_api.models import (
     ProjectClass,
     ClassFinancial,
+    ProjectGroup,
+    Project,
+    ProjectFinancial,
 )
 from infraohjelmointi_api.serializers.FinancialSumSerializer import FinancialSumSerializer
 
@@ -103,4 +107,44 @@ class FinancialSumSerializerTestCase(TestCase):
             result_with_context["year0"]["isFrameBudgetOverlap"],
             "Should not show budget overlap when children sum equals parent budget (TSE-2028 scenario)"
         )
+
+    @patch("infraohjelmointi_api.serializers.FinancialSumSerializer.CacheService.set_financial_sum")
+    @patch("infraohjelmointi_api.serializers.FinancialSumSerializer.CacheService.get_financial_sum")
+    def test_project_group_finance_sums_bypass_cache(self, mock_get_financial_sum, mock_set_financial_sum):
+        """Regression test: ProjectGroup sums must be calculated fresh and bypass cache."""
+        year = date.today().year
+
+        project_group = ProjectGroup.objects.create(name="Group A")
+        project = Project.objects.create(
+            name="Group project",
+            description="Project in group",
+            projectGroup=project_group,
+            programmed=True,
+        )
+        ProjectFinancial.objects.create(
+            project=project,
+            year=year,
+            value=1234,
+            forFrameView=False,
+        )
+
+        mock_get_financial_sum.return_value = {
+            "year0": {"plannedBudget": 999999},
+            "year": year,
+        }
+
+        serializer = FinancialSumSerializer(
+            context={
+                "finance_year": year,
+                "forcedToFrame": False,
+                "for_coordinator": False,
+                "frame_budgets": defaultdict(lambda: 0),
+            }
+        )
+
+        result = serializer.get_finance_sums(project_group)
+
+        self.assertEqual(result["year0"]["plannedBudget"], 1234)
+        mock_get_financial_sum.assert_not_called()
+        mock_set_financial_sum.assert_not_called()
 


### PR DESCRIPTION
Do not return cached finances for project groups in planning view as they could have stale data.

https://helsinkisolutionoffice.atlassian.net/browse/IO-818