### PR TITLE
IO-796 Show correct current year SAP on planning list and project form

### DIFF
--- a/infraohjelmointi_api/serializers/ProjectGetSerializer.py
+++ b/infraohjelmointi_api/serializers/ProjectGetSerializer.py
@@ -150,7 +150,12 @@ class ProjectGetSerializer(DynamicFieldsModelSerializer, ProjectWithFinancesSeri
         return project.projectReadiness()
 
     def get_currentYearsSapValue(self, project: Project):
-        projects_to_sap_values = self.context.get('projects_to_sap_values', {})
+        # Prefer canonical key; sap_values_by_project was a typo in planning list context (IO-796).
+        projects_to_sap_values = self.context.get("projects_to_sap_values") or self.context.get(
+            "sap_values_by_project", {}
+        )
+        if not isinstance(projects_to_sap_values, dict):
+            projects_to_sap_values = {}
         sap_values = projects_to_sap_values.get(project.id)
         
         if not sap_values:

--- a/infraohjelmointi_api/tests/test_Projects.py
+++ b/infraohjelmointi_api/tests/test_Projects.py
@@ -3739,12 +3739,23 @@ class ProjectTestCase(TestCase):
         )
 
     @patch('infraohjelmointi_api.serializers.serializer_utils.ProjectWiseService')
-    def test_pw_folder_project(self, mock_pw_class):
+    @patch('infraohjelmointi_api.serializers.ProjectGetSerializer.ProjectWiseService')
+    @patch('infraohjelmointi_api.serializers.ProjectCreateSerializer.ProjectWiseService')
+    def test_pw_folder_project(self, mock_pw_create_class, mock_pw_get_class, mock_pw_utils_class):
+        # Mock both serializers' ProjectWise service classes
         def mock_get_pw_response(id):
             return {"instanceId": f"instance-{id}"}
 
-        mock_instance = mock_pw_class.return_value
-        mock_instance.get_project_from_pw.side_effect = mock_get_pw_response
+        # Mock the CreateSerializer's service instance
+        mock_create_instance = mock_pw_create_class.return_value
+        mock_create_instance.get_project_from_pw.side_effect = mock_get_pw_response
+
+        # Mock the GetSerializer's ProjectWise class (if constructed on serializer)
+        mock_get_instance = mock_pw_get_class.return_value
+        mock_get_instance.get_project_from_pw.side_effect = mock_get_pw_response
+
+        mock_utils_instance = mock_pw_utils_class.return_value
+        mock_utils_instance.get_project_from_pw.side_effect = mock_get_pw_response
 
         data = {
             "name": "Test Project for PW folder",

--- a/infraohjelmointi_api/tests/test_SAP.py
+++ b/infraohjelmointi_api/tests/test_SAP.py
@@ -7,6 +7,7 @@ from django.test import TestCase
 from overrides import override
 
 from infraohjelmointi_api.models import Project, ProjectGroup, ProjectPhase, SapCurrentYear
+from infraohjelmointi_api.serializers import ProjectGetSerializer
 from infraohjelmointi_api.services.SapApiService import SapApiService, SapAuthenticationError
 from infraohjelmointi_api.views import BaseViewSet, SapCurrentYearViewSet
 
@@ -481,6 +482,9 @@ class TestSAPService(TestCase):
 
         # Planning: 1000 + 2000 = 3000
         self.assertEqual(result['project_task'], Decimal('3000.00'))
+        # Construction: 3000 + 4000 = 7000
+        self.assertEqual(result['production_task'], Decimal('7000.00'))
+
     def test_calculate_values_consistency_edge_case(self):
         """
         Regression test for consistency between dot and concat formats.
@@ -543,4 +547,26 @@ class TestSAPService(TestCase):
 
         with self.assertRaises(SapAuthenticationError):
             self.sap_service.sync_all_projects_from_sap(for_financial_statement=True, sap_year=datetime.now().year)
+
+    def test_get_currentYearsSapValue_bulk_context_keys_io796(self):
+        """Planning list used sap_values_by_project; serializer expected projects_to_sap_values (IO-796)."""
+        year = datetime.now().year
+        scy = SapCurrentYear.objects.create(
+            project=self.project,
+            year=year,
+            sap_id=self.sapProjectId,
+            project_task_costs=Decimal("11.000"),
+            production_task_costs=Decimal("22.000"),
+            project_task_commitments=Decimal("0.000"),
+            production_task_commitments=Decimal("0.000"),
+        )
+        bulk_row = [scy]
+
+        for ctx_key in ("projects_to_sap_values", "sap_values_by_project"):
+            serializer = ProjectGetSerializer(context={ctx_key: {self.project.id: bulk_row}})
+            out = serializer.get_currentYearsSapValue(self.project)
+            self.assertEqual(len(out), 1)
+            self.assertEqual(out[0]["year"], year)
+            self.assertEqual(Decimal(str(out[0]["project_task_costs"])), Decimal("11.000"))
+            self.assertEqual(Decimal(str(out[0]["production_task_costs"])), Decimal("22.000"))
 

--- a/infraohjelmointi_api/views/ProjectViewSet.py
+++ b/infraohjelmointi_api/views/ProjectViewSet.py
@@ -251,7 +251,7 @@ class ProjectViewSet(BaseViewSet):
 
                     if update_finances:
                         ProjectFinancialService.update_or_create_bulk(project_financials=update_finances)
-                
+
                 # Invalidate cache for all affected projects (bulk operations bypass signals)
                 affected_project_ids = {f.project_id for f in finance_instances}
                 for project_id in affected_project_ids:
@@ -271,7 +271,7 @@ class ProjectViewSet(BaseViewSet):
                             instance_id=affected_project.projectGroup.id,
                             instance_type='ProjectGroup'
                         )
-                
+
                 # adding finance_year here so that on save the instance that gets to the post_save signal has this value on finance_update
                 updated_finance_instance.finance_year = year
                 post_save.send(
@@ -836,7 +836,7 @@ class ProjectViewSet(BaseViewSet):
             "for_coordinator": for_coordinator,
             "forcedToFrame": forFrameView,
             "projects_to_finances": projects_to_finances,
-            "sap_values_by_project": projects_to_sap_values
+            "projects_to_sap_values": projects_to_sap_values,
         }
 
         if page is not None:
@@ -1422,7 +1422,7 @@ class ProjectViewSet(BaseViewSet):
                     default=len(projectIds),
                 )
                 qs = self.get_queryset().filter(id__in=projectIds).order_by(preserved)
-                
+
                 # IO-775: Capture original hkrId values BEFORE update for PW sync detection
                 original_hkr_ids = {str(p.id): p.hkrId for p in qs}
                 # Also capture which projects are getting hkrId in this request
@@ -1431,7 +1431,7 @@ class ProjectViewSet(BaseViewSet):
                     for projectData in data
                     if "hkrId" in projectData.get("data", {})
                 }
-                
+
                 financesData = [
                     {
                         "project": projectData["id"],
@@ -1490,28 +1490,28 @@ class ProjectViewSet(BaseViewSet):
                 )
                 serializer.is_valid(raise_exception=True)
                 updated_projects = serializer.save()
-                
+
                 # IO-775: Trigger PW sync for projects with hkrId (either newly added or existing)
                 pw_sync_errors = []
                 for updated_project in updated_projects:
                     project_id_str = str(updated_project.id)
                     original_hkr_id = original_hkr_ids.get(project_id_str)
                     new_hkr_id = hkr_ids_in_request.get(project_id_str)
-                    
+
                     # Check if hkrId was added for the first time
                     hkr_id_added_first_time = (
                         new_hkr_id and
                         (not original_hkr_id or str(original_hkr_id).strip() == "")
                     )
-                    
+
                     # Check if project has hkrId (either newly added or already existed)
                     has_hkr_id = bool(updated_project.hkrId and str(updated_project.hkrId).strip())
-                    
+
                     # IO-396/IO-775: Sync whenever the updated project has an hkrId
                     # IO-396 requirement: Only sync programmed projects
                     # This ensures that changes to phase, responsible person, dates, etc. sync to PW
                     should_sync = has_hkr_id and updated_project.programmed
-                    
+
                     if should_sync:
                         sync_reason = "HKR ID added for first time" if hkr_id_added_first_time else "updating existing PW project"
                         logger.info(f"BULK UPDATE: PW sync triggered for project '{updated_project.name}' (HKR ID: {updated_project.hkrId}) - {sync_reason}")
@@ -1528,7 +1528,7 @@ class ProjectViewSet(BaseViewSet):
                                 "hkrId": updated_project.hkrId,
                                 "error": str(e)
                             })
-                
+
                 response_data = serializer.data
                 if pw_sync_errors:
                     # Include PW sync errors in response but don't fail the request
@@ -1537,7 +1537,7 @@ class ProjectViewSet(BaseViewSet):
                         "pw_sync_errors": pw_sync_errors,
                         "message": f"Projects updated successfully but {len(pw_sync_errors)} PW sync(s) failed"
                     }
-                
+
                 return Response(data=response_data, status=200)
             else:
                 return Response(
@@ -1765,7 +1765,7 @@ class ProjectViewSet(BaseViewSet):
         hkr_id_value = request_data.get('hkrId')
         original_had_hkr_id = bool(original_project.hkrId and str(original_project.hkrId).strip())
         updated_has_hkr_id = bool(updated_project.hkrId and str(updated_project.hkrId).strip())
-        
+
         logger.debug(
             f"PW SYNC CHECK for '{updated_project.name}': "
             f"hkrId_in_request={hkr_id_in_request}, "
@@ -1774,21 +1774,21 @@ class ProjectViewSet(BaseViewSet):
             f"original_had_hkr_id={original_had_hkr_id}, "
             f"updated_has_hkr_id={updated_has_hkr_id}"
         )
-        
+
         # Check if hkrId is being added for the first time (automatic update)
         hkr_id_added_first_time = (
             hkr_id_in_request and
             hkr_id_value and
             not original_had_hkr_id
         )
-        
+
         # IO-396/IO-775: Sync whenever the updated project has an hkrId
         # This ensures that:
         # 1. When hkrId is added for the first time, we sync (initial sync)
         # 2. When a project with existing hkrId is updated (phase, responsible person, dates, etc.), we sync
         # IO-396 requirement: Only sync programmed projects
         should_sync = updated_has_hkr_id and updated_project.programmed
-        
+
         if not should_sync:
             if not updated_has_hkr_id:
                 logger.debug(f"PW SYNC SKIPPED for '{updated_project.name}': Project has no hkrId")
@@ -1811,9 +1811,9 @@ class ProjectViewSet(BaseViewSet):
             self.projectWiseService.sync_project_to_pw(
                 data=automatic_update_data, project=updated_project
             )
-            
+
             logger.info(f"Automatic PW sync completed successfully for project '{updated_project.name}'")
-            
+
         except Exception as e:
             # Log detailed error but don't break the update
             logger.error(f"Automatic PW sync failed for project '{updated_project.name}' (HKR ID: {updated_project.hkrId})")


### PR DESCRIPTION
* Planning project list now passes SAP rows under the context key the serializer actually reads, so currentYearsSapValues matches the bulk-loaded data
* Project financials use the SAP row for the calendar year instead of always taking the first array entry