### PR TITLE
IO-775 Sync project to PW when it moves from programmed to unprogrammed

### DIFF
--- a/infraohjelmointi_api/tests/test_ProjectViewSet.py
+++ b/infraohjelmointi_api/tests/test_ProjectViewSet.py
@@ -171,6 +171,30 @@ class ProjectViewSetPWIntegrationTestCase(TestCase):
         )
         self.assertFalse(hkr_id_added_first_time, "Should not detect HKR ID addition for regular update")
 
+    def test_sync_on_programmed_to_unprogrammed_transition(self):
+        """
+        IO-775: When a project with hkrId transitions from programmed=True → False,
+        we must still sync once so PW receives the final phase/status before we stop
+        syncing it. Regression test for the Kehä I / Myllypuro case.
+        """
+        # Replicates the should_sync condition in
+        # ProjectViewSet._sync_project_to_projectwise (single PATCH path) and
+        # ProjectViewSet.patch_bulk_projects (bulk path).
+        # (was_programmed, updated_programmed, has_hkr_id, expected_should_sync, description)
+        cases = [
+            (True, True, True, True, "Regular update of programmed project with hkrId"),
+            (True, False, True, True, "programmed → unprogrammed transition (IO-775 fix)"),
+            (False, True, True, True, "unprogrammed → programmed transition (initial sync)"),
+            (False, False, True, False, "Project never programmed: do not sync (IO-396)"),
+            (True, False, False, False, "Transitioning out but no hkrId: nothing to sync"),
+            (True, True, False, False, "Programmed but no hkrId: nothing to sync"),
+        ]
+
+        for was_programmed, updated_programmed, has_hkr_id, expected, description in cases:
+            with self.subTest(case=description):
+                should_sync = has_hkr_id and (updated_programmed or was_programmed)
+                self.assertEqual(should_sync, expected, description)
+
     @patch('infraohjelmointi_api.services.ProjectWiseService.ProjectWiseService.get_project_from_pw')
     @patch('infraohjelmointi_api.services.ProjectWiseService.requests.Session.post')
     def test_automatic_sync_error_handling(self, mock_post, mock_get_pw):

--- a/infraohjelmointi_api/views/ProjectViewSet.py
+++ b/infraohjelmointi_api/views/ProjectViewSet.py
@@ -1423,8 +1423,9 @@ class ProjectViewSet(BaseViewSet):
                 )
                 qs = self.get_queryset().filter(id__in=projectIds).order_by(preserved)
 
-                # IO-775: Capture original hkrId values BEFORE update for PW sync detection
+                # IO-775: Capture original values BEFORE update for PW sync detection
                 original_hkr_ids = {str(p.id): p.hkrId for p in qs}
+                original_programmed = {str(p.id): p.programmed for p in qs}
                 # Also capture which projects are getting hkrId in this request
                 hkr_ids_in_request = {
                     projectData["id"]: projectData["data"].get("hkrId")
@@ -1509,8 +1510,10 @@ class ProjectViewSet(BaseViewSet):
 
                     # IO-396/IO-775: Sync whenever the updated project has an hkrId
                     # IO-396 requirement: Only sync programmed projects
-                    # This ensures that changes to phase, responsible person, dates, etc. sync to PW
-                    should_sync = has_hkr_id and updated_project.programmed
+                    # Also sync when project WAS programmed (transitioning programmed→unprogrammed)
+                    # so PW receives the updated phase/status
+                    was_programmed = original_programmed.get(project_id_str, False)
+                    should_sync = has_hkr_id and (updated_project.programmed or was_programmed)
 
                     if should_sync:
                         sync_reason = "HKR ID added for first time" if hkr_id_added_first_time else "updating existing PW project"
@@ -1782,18 +1785,18 @@ class ProjectViewSet(BaseViewSet):
             not original_had_hkr_id
         )
 
-        # IO-396/IO-775: Sync whenever the updated project has an hkrId
-        # This ensures that:
-        # 1. When hkrId is added for the first time, we sync (initial sync)
-        # 2. When a project with existing hkrId is updated (phase, responsible person, dates, etc.), we sync
-        # IO-396 requirement: Only sync programmed projects
-        should_sync = updated_has_hkr_id and updated_project.programmed
+        # IO-396/IO-775: Sync when the updated project has an hkrId AND
+        # 1. is programmed (initial sync or regular update of programmed project), OR
+        # 2. was programmed before this update (transition programmed→unprogrammed,
+        #    so PW receives the final phase/status before we stop syncing it).
+        original_was_programmed = bool(original_project.programmed)
+        should_sync = updated_has_hkr_id and (updated_project.programmed or original_was_programmed)
 
         if not should_sync:
             if not updated_has_hkr_id:
                 logger.debug(f"PW SYNC SKIPPED for '{updated_project.name}': Project has no hkrId")
-            elif not updated_project.programmed:
-                logger.debug(f"PW SYNC SKIPPED for '{updated_project.name}': Project is not programmed")
+            elif not updated_project.programmed and not original_was_programmed:
+                logger.debug(f"PW SYNC SKIPPED for '{updated_project.name}': Project is not and was not programmed")
             return
 
         if hkr_id_added_first_time:


### PR DESCRIPTION
Normally unprogrammed projects (programmed=False) are not synced, but this is an exception: when "programmed" is changed to from True to False, the project should get synced to PW