### PR TITLE
IO-411 Resolve default programmer from project district when class has none

### DIFF
--- a/infraohjelmointi_api/management/commands/programmerimporter.py
+++ b/infraohjelmointi_api/management/commands/programmerimporter.py
@@ -7,6 +7,7 @@ import os
 import uuid
 from django.core.management.base import BaseCommand, CommandError
 from django.db import transaction, IntegrityError
+from django.db.models import Q
 from django.utils import timezone
 
 try:
@@ -14,7 +15,11 @@ try:
 except ImportError:
     raise CommandError("openpyxl is required to read Excel files. Please install it.")
 
-from infraohjelmointi_api.utils.project_class_utils import get_programmer_from_hierarchy
+from infraohjelmointi_api.utils.project_class_utils import (
+    build_location_programmer_lookup,
+    get_default_programmer_for_project,
+    get_programmer_from_hierarchy,
+)
 from infraohjelmointi_api.models import (
     ProjectClass,
     ProjectProgrammer,
@@ -296,6 +301,15 @@ class Command(BaseCommand):
         """
         return get_programmer_from_hierarchy(project_class)
 
+    def _get_programmer_for_project(self, project, name_lookup=None):
+        """Class chain first, then location chain (IO-411). Pass ``name_lookup``
+        to avoid rebuilding it for every project in a backfill loop."""
+        return get_default_programmer_for_project(
+            project.projectClass,
+            project.projectLocation,
+            name_lookup=name_lookup,
+        )
+
     def show_dry_run(self, specific_assignments, fallback_assignments, clear_existing, apply_to_projects):
         """Show what would be imported in dry-run mode"""
         self.stdout.write(self.style.SUCCESS("\n=== DRY RUN MODE ==="))
@@ -305,11 +319,23 @@ class Command(BaseCommand):
             self.stdout.write(f"Would clear {existing_count} existing programmer assignments")
 
         if apply_to_projects:
-            projects_to_update = Project.objects.filter(
-                projectClass__defaultProgrammer__isnull=False,
-                personProgramming__isnull=True
-            ).count()
-            self.stdout.write(f"Would apply default programmers to {projects_to_update} existing projects")
+            # Resolve via the same logic the real run uses so the dry-run
+            # number is exact, not an upper bound.
+            candidates = (
+                Project.objects.filter(personProgramming__isnull=True)
+                .filter(Q(projectClass__isnull=False) | Q(projectLocation__isnull=False))
+                .select_related('projectClass', 'projectLocation')
+            )
+            candidate_count = candidates.count()
+            name_lookup = build_location_programmer_lookup()
+            resolvable = sum(
+                1 for project in candidates.iterator()
+                if self._get_programmer_for_project(project, name_lookup=name_lookup) is not None
+            )
+            self.stdout.write(
+                f"Would apply default programmers to {resolvable} of "
+                f"{candidate_count} programmer-less projects with a class or location"
+            )
 
         # Show specific assignments
         if specific_assignments:
@@ -443,27 +469,30 @@ class Command(BaseCommand):
         if apply_to_projects:
             self.stdout.write(f"\n--- APPLYING DEFAULT PROGRAMMERS TO EXISTING PROJECTS ---")
 
-            # Find all projects that:
-            # 1. Have a projectClass
-            # 2. Don't already have a personProgramming assigned
-            # Note: We use hierarchical fallback in Python to find programmers
-            projects_to_update = Project.objects.filter(
-                personProgramming__isnull=True,
-                projectClass__isnull=False
-            ).select_related('projectClass')
+            # Programmer-less projects with a class OR location we can resolve
+            # a default from (IO-411: suurpiiri often lives on projectLocation).
+            projects_to_update = (
+                Project.objects.filter(personProgramming__isnull=True)
+                .filter(Q(projectClass__isnull=False) | Q(projectLocation__isnull=False))
+                .select_related('projectClass', 'projectLocation')
+            )
 
             projects_count = projects_to_update.count()
             self.stdout.write(f"Found {projects_count} projects without programmers")
 
-            # Use hierarchical fallback to find programmers
-            for project in projects_to_update:
-                programmer = self._get_programmer_with_hierarchy(project.projectClass)
+            name_lookup = build_location_programmer_lookup()
+
+            for project in projects_to_update.iterator():
+                programmer = self._get_programmer_for_project(project, name_lookup=name_lookup)
                 if programmer:
                     project.personProgramming = programmer
                     project.save()
                     projects_updated += 1
 
-            self.stdout.write(f"Updated {projects_updated} projects with default programmers (including hierarchical fallback)")
+            self.stdout.write(
+                f"Updated {projects_updated} projects with default programmers "
+                f"(including class- and location-based hierarchical fallback)"
+            )
 
         # Summary
         self.stdout.write(self.style.SUCCESS(f"\n=== IMPORT SUMMARY ==="))

--- a/infraohjelmointi_api/serializers/ProjectCreateSerializer.py
+++ b/infraohjelmointi_api/serializers/ProjectCreateSerializer.py
@@ -11,7 +11,9 @@ from infraohjelmointi_api.services.ProjectWiseService import (
     ProjectWiseService,
 )
 from infraohjelmointi_api.services.utils import create_comprehensive_project_data
-from infraohjelmointi_api.utils.project_class_utils import get_programmer_from_hierarchy
+from infraohjelmointi_api.utils.project_class_utils import (
+    get_default_programmer_for_project,
+)
 from infraohjelmointi_api.serializers import (
     BaseMeta,
     PersonSerializer,
@@ -91,6 +93,12 @@ env.escape_proxy = True
 
 if path.exists(".env"):
     env.read_env(".env")
+
+
+# Distinguishes "key absent from payload" from "key set to None" so an
+# explicit null clear (IO-411) is not silently replaced by the persisted
+# instance value during default-programmer resolution.
+_FIELD_MISSING = object()
 
 
 class ProjectCreateSerializer(ProjectWithFinancesSerializer):
@@ -234,33 +242,65 @@ class ProjectCreateSerializer(ProjectWithFinancesSerializer):
 
     def get_projectReadiness(self, obj: Project) -> int:
         return obj.projectReadiness()
-    def _get_default_programmer_with_fallback(self, project_class):
+
+    def _get_default_programmer_with_fallback(self, project_class, project_location=None):
+        """Walk projectClass parents first, then projectLocation parents (IO-411)."""
+        return get_default_programmer_for_project(project_class, project_location)
+
+    def _resolve_class_and_location_for_programmer(self, data: dict, instance):
         """
-        Get default programmer with hierarchical fallback logic.
-        Uses shared utility with cycle detection.
+        Pick the projectClass / projectLocation values fed into the
+        default-programmer resolver. If a side is in ``data`` (even as
+        ``None``), use it verbatim; otherwise fall back to the persisted
+        instance value so the *other* side's change still has full context.
         """
-        return get_programmer_from_hierarchy(project_class)
+        incoming_class = data.get("projectClass", _FIELD_MISSING)
+        incoming_location = data.get("projectLocation", _FIELD_MISSING)
+
+        if incoming_class is not _FIELD_MISSING:
+            project_class = incoming_class
+        elif instance is not None:
+            project_class = getattr(instance, "projectClass", None)
+        else:
+            project_class = None
+
+        if incoming_location is not _FIELD_MISSING:
+            project_location = incoming_location
+        elif instance is not None:
+            project_location = getattr(instance, "projectLocation", None)
+        else:
+            project_location = None
+
+        return project_class, project_location
 
     def run_pre_create_update_validation(self, data: dict, instance=None):
         # remove projectId as it does not exist on the Project model
         data.pop("projectId", None)
 
-        # Set default programmer from project class if one is selected and no programmer is set
-        # Uses hierarchical fallback: check parent classes if current class has no default
-        project_class = data.get("projectClass", None)
+        # IO-411: only auto-assign personProgramming on create or on an update
+        # that touches projectClass / projectLocation, and only when no
+        # programmer is currently set. Explicit nulls are honoured (see the
+        # resolver above) so the user's clear is never silently undone.
+        request_touches_class_or_location = (
+            instance is None
+            or "projectClass" in data
+            or "projectLocation" in data
+        )
+        project_class, project_location = self._resolve_class_and_location_for_programmer(
+            data, instance
+        )
 
-        # Only set default programmer if:
-        # 1. We have a project class
-        # 2. No programmer is being explicitly set in this request
-        # 3. For updates: the existing project doesn't already have a programmer
         should_set_default = (
-            project_class and
-            not data.get("personProgramming", None) and
-            (instance is None or instance.personProgramming is None)
+            request_touches_class_or_location
+            and (project_class or project_location)
+            and not data.get("personProgramming", None)
+            and (instance is None or instance.personProgramming is None)
         )
 
         if should_set_default:
-            programmer = self._get_default_programmer_with_fallback(project_class)
+            programmer = self._get_default_programmer_with_fallback(
+                project_class, project_location
+            )
             if programmer:
                 data["personProgramming"] = programmer
 

--- a/infraohjelmointi_api/serializers/ProjectDistrictSerializer.py
+++ b/infraohjelmointi_api/serializers/ProjectDistrictSerializer.py
@@ -1,8 +1,58 @@
+import logging
+
+from rest_framework import serializers
+
 from infraohjelmointi_api.models import ProjectDistrict
 from infraohjelmointi_api.serializers import BaseMeta
-from rest_framework import serializers
+from infraohjelmointi_api.serializers.ProjectProgrammerSerializer import (
+    ProjectProgrammerSerializer,
+)
+from infraohjelmointi_api.utils.project_class_utils import (
+    build_location_programmer_lookup,
+    get_programmer_from_name_hierarchy,
+)
+
+logger = logging.getLogger(__name__)
+
+# Shared with ProjectLocationSerializer so a single request builds the
+# {name: ProjectProgrammer} table only once across both serializers.
+_LOOKUP_CONTEXT_KEY = "_default_programmer_by_class_name"
 
 
 class ProjectDistrictSerializer(serializers.ModelSerializer):
+    """
+    The project form's location dropdowns are backed by ``GET /project-districts/``,
+    so the IO-411 default-programmer preview lives here for the UI to consume
+    before save. ``computedDefaultProgrammer`` walks the district ``parent``
+    chain and matches each level's name against a programmer-view ``ProjectClass``.
+    """
+
+    computedDefaultProgrammer = serializers.SerializerMethodField()
+
     class Meta(BaseMeta):
         model = ProjectDistrict
+
+    def _get_name_lookup(self):
+        cached = self.context.get(_LOOKUP_CONTEXT_KEY)
+        if cached is not None:
+            return cached
+        lookup = build_location_programmer_lookup()
+        try:
+            self.context[_LOOKUP_CONTEXT_KEY] = lookup
+        except TypeError:
+            # Frozen mapping (e.g. MappingProxyType): rebuilding per row is
+            # still cheaper than per-row queries.
+            pass
+        return lookup
+
+    def get_computedDefaultProgrammer(self, obj):
+        try:
+            programmer = get_programmer_from_name_hierarchy(
+                obj, name_lookup=self._get_name_lookup()
+            )
+            if programmer:
+                return ProjectProgrammerSerializer(programmer).data
+            return None
+        except ValueError as e:
+            logger.error(f"District hierarchy error: {e}")
+            return None

--- a/infraohjelmointi_api/serializers/ProjectLocationSerializer.py
+++ b/infraohjelmointi_api/serializers/ProjectLocationSerializer.py
@@ -1,11 +1,59 @@
+import logging
+
+from rest_framework import serializers
+
 from infraohjelmointi_api.models import ProjectLocation
 from infraohjelmointi_api.serializers import BaseMeta
 from infraohjelmointi_api.serializers.FinancialSumSerializer import (
     FinancialSumSerializer,
 )
-from rest_framework import serializers
+from infraohjelmointi_api.serializers.ProjectProgrammerSerializer import (
+    ProjectProgrammerSerializer,
+)
+from infraohjelmointi_api.utils.project_class_utils import (
+    build_location_programmer_lookup,
+    get_programmer_from_name_hierarchy,
+)
+
+logger = logging.getLogger(__name__)
+
+# Shared with ProjectDistrictSerializer so a single request builds the
+# {name: ProjectProgrammer} table only once across both serializers.
+_LOOKUP_CONTEXT_KEY = "_default_programmer_by_class_name"
 
 
 class ProjectLocationSerializer(FinancialSumSerializer):
+    computedDefaultProgrammer = serializers.SerializerMethodField()
+
     class Meta(BaseMeta):
         model = ProjectLocation
+
+    def _get_name_lookup(self):
+        cached = self.context.get(_LOOKUP_CONTEXT_KEY)
+        if cached is not None:
+            return cached
+        lookup = build_location_programmer_lookup()
+        try:
+            self.context[_LOOKUP_CONTEXT_KEY] = lookup
+        except TypeError:
+            # Frozen mapping (e.g. MappingProxyType): rebuilding per row is
+            # still cheaper than per-row queries.
+            pass
+        return lookup
+
+    def get_computedDefaultProgrammer(self, obj):
+        """
+        Walk the location parent chain and match each name against a
+        programmer-view ProjectClass with a defaultProgrammer (IO-411).
+        Mirrors ProjectClassSerializer.computedDefaultProgrammer.
+        """
+        try:
+            programmer = get_programmer_from_name_hierarchy(
+                obj, name_lookup=self._get_name_lookup()
+            )
+            if programmer:
+                return ProjectProgrammerSerializer(programmer).data
+            return None
+        except ValueError as e:
+            logger.error(f"Location hierarchy error: {e}")
+            return None

--- a/infraohjelmointi_api/tests/test_ProjectClassSerializer.py
+++ b/infraohjelmointi_api/tests/test_ProjectClassSerializer.py
@@ -956,7 +956,7 @@ class ComputedDefaultProgrammerTestCase(TestCase):
             forCoordinatorOnly=False
         )
 
-        # Level 3 - no default programmer (Saija's case)
+        # Level 3 - no default programmer
         cls.level3_class = ProjectClass.objects.create(
             name="E Liikennejärjestelyt",
             path="8 03 Kadut ja liikenneväylät/8 03 01 Uudisrakentaminen ja perusparantaminen/8 03 01 02 Perusparantaminen ja liikennejärjestelyt/E Liikennejärjestelyt",
@@ -1067,18 +1067,18 @@ class ComputedDefaultProgrammerTestCase(TestCase):
         self.assertIn('lastName', computed)
         self.assertIn('person', computed)
 
-    def test_saija_case_simulation(self):
-        """Test the specific case mentioned in Jira: Saija's traffic arrangements"""
-        # This simulates the exact scenario from the Jira ticket
+    def test_traffic_arrangements_case_simulation(self):
+        """Test the specific case mentioned in Jira: traffic arrangements
+        under suurpiiri inherits the suurpiiri's default programmer."""
+        # Simulates the prod hierarchy:
         # "Katujen perusparantamiseen liikennejärjestelyjen alle itäiseen suurpiiriin"
 
-        # Create the specific hierarchy mentioned
         itainen_suurpiiri = ProjectClass.objects.create(
             name="Itäinen suurpiiri",
             path="8 03 Kadut ja liikenneväylät/Uudisrakentaminen/Itäinen suurpiiri",
             parent=self.root_class,
             forCoordinatorOnly=False,
-            defaultProgrammer=self.programmer_1  # Saija Vihervaara
+            defaultProgrammer=self.programmer_1
         )
 
         # Test that the traffic class inherits from suurpiiri

--- a/infraohjelmointi_api/tests/test_ProjectDistrictSerializer.py
+++ b/infraohjelmointi_api/tests/test_ProjectDistrictSerializer.py
@@ -1,0 +1,259 @@
+"""
+Tests for ProjectDistrictSerializer.computedDefaultProgrammer (IO-411).
+
+The project form's location dropdowns are backed by ``GET /project-districts/``
+(``ProjectDistrictSerializer``) — *not* ``project-locations/``. So the
+default-programmer preview the FE pre-fills the Ohjelmoija field with has to
+travel through this serializer for the preview to actually appear before save.
+The matching logic is the same as on the location side (walk parent chain,
+look up programmer-view ProjectClass by name).
+"""
+
+from unittest.mock import patch
+
+from django.test import RequestFactory, TestCase
+from rest_framework.test import force_authenticate
+
+from infraohjelmointi_api.models import (
+    ProjectClass,
+    ProjectDistrict,
+    ProjectProgrammer,
+    User,
+)
+from infraohjelmointi_api.serializers.ProjectDistrictSerializer import (
+    ProjectDistrictSerializer,
+)
+from infraohjelmointi_api.views.BaseViewSet import BaseViewSet
+from infraohjelmointi_api.views.ProjectDistrictViewSet import ProjectDistrictViewSet
+
+
+class ProjectDistrictSerializerComputedDefaultProgrammerTestCase(TestCase):
+    """
+    Mirror of GetProgrammerFromLocationHierarchyTestCase but exercising the
+    serializer-level field consumed by the FE form.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.programmer_anna = ProjectProgrammer.objects.create(
+            firstName="Anna", lastName="Esimerkki"
+        )
+        cls.programmer_eero = ProjectProgrammer.objects.create(
+            firstName="Eero", lastName="Esimerkki"
+        )
+
+        # Programmer-view suurpiiri classes (the ones that drive the lookup).
+        ProjectClass.objects.create(
+            name="Itäinen suurpiiri",
+            forCoordinatorOnly=False,
+            defaultProgrammer=cls.programmer_anna,
+        )
+        ProjectClass.objects.create(
+            name="Läntinen suurpiiri",
+            forCoordinatorOnly=False,
+            defaultProgrammer=cls.programmer_eero,
+        )
+        # A coordinator-only duplicate must be ignored.
+        ProjectClass.objects.create(
+            name="Itäinen suurpiiri",
+            forCoordinatorOnly=True,
+            defaultProgrammer=cls.programmer_eero,
+        )
+
+        # District tree:
+        #   Itäinen suurpiiri (district)
+        #     └─ 45. Vartiokylä (division)         ← matches via parent
+        #         └─ Vartiokylän alaosa (subDivision) ← matches via grand-parent
+        # Plus one stand-alone district that won't match anything.
+        cls.district_east = ProjectDistrict.objects.create(
+            name="Itäinen suurpiiri",
+            level="district",
+            path="Itäinen suurpiiri",
+        )
+        cls.division_vartiokyla = ProjectDistrict.objects.create(
+            name="45. Vartiokylä",
+            level="division",
+            path="Itäinen suurpiiri/45. Vartiokylä",
+            parent=cls.district_east,
+        )
+        cls.subdivision_alaosa = ProjectDistrict.objects.create(
+            name="Vartiokylän alaosa",
+            level="subDivision",
+            path="Itäinen suurpiiri/45. Vartiokylä/Vartiokylän alaosa",
+            parent=cls.division_vartiokyla,
+        )
+
+        cls.district_unmatched = ProjectDistrict.objects.create(
+            name="Muu alue",
+            level="district",
+            path="Muu alue",
+        )
+
+    def test_direct_district_match_returns_programmer_object(self):
+        data = ProjectDistrictSerializer(self.district_east).data
+
+        self.assertIn("computedDefaultProgrammer", data)
+        self.assertIsNotNone(data["computedDefaultProgrammer"])
+        self.assertEqual(
+            data["computedDefaultProgrammer"]["id"], str(self.programmer_anna.id)
+        )
+        self.assertEqual(data["computedDefaultProgrammer"]["firstName"], "Anna")
+        self.assertEqual(data["computedDefaultProgrammer"]["lastName"], "Esimerkki")
+
+    def test_walks_parent_chain_for_division(self):
+        """45. Vartiokylä has no matching class — its parent (suurpiiri) does."""
+        data = ProjectDistrictSerializer(self.division_vartiokyla).data
+        self.assertEqual(
+            data["computedDefaultProgrammer"]["id"], str(self.programmer_anna.id)
+        )
+
+    def test_walks_parent_chain_for_subdivision(self):
+        """Two levels up: subDivision → division → suurpiiri."""
+        data = ProjectDistrictSerializer(self.subdivision_alaosa).data
+        self.assertEqual(
+            data["computedDefaultProgrammer"]["id"], str(self.programmer_anna.id)
+        )
+
+    def test_no_match_returns_null(self):
+        data = ProjectDistrictSerializer(self.district_unmatched).data
+        self.assertIn("computedDefaultProgrammer", data)
+        self.assertIsNone(data["computedDefaultProgrammer"])
+
+    def test_ignores_coordinator_only_class(self):
+        """The duplicate ``forCoordinatorOnly=True`` row points at the other
+        programmer and must not be picked over the programmer-view row."""
+        data = ProjectDistrictSerializer(self.district_east).data
+        self.assertEqual(
+            data["computedDefaultProgrammer"]["lastName"], "Esimerkki"
+        )
+        self.assertEqual(
+            data["computedDefaultProgrammer"]["firstName"], "Anna"
+        )
+
+    def test_cycle_in_district_chain_is_logged_and_returns_null(self):
+        """A corrupt district chain must not crash the serializer; the row
+        falls back to ``None`` and the error is logged for ops to fix."""
+        loop_a = ProjectDistrict.objects.create(
+            name="LoopA", level="district", path="LoopA"
+        )
+        loop_b = ProjectDistrict.objects.create(
+            name="LoopB", level="division", path="LoopA/LoopB", parent=loop_a
+        )
+        ProjectDistrict.objects.filter(pk=loop_a.pk).update(parent=loop_b)
+        loop_b.refresh_from_db()
+
+        with self.assertLogs(
+            "infraohjelmointi_api.serializers.ProjectDistrictSerializer",
+            level="ERROR",
+        ) as cm:
+            data = ProjectDistrictSerializer(loop_b).data
+
+        self.assertIsNone(data["computedDefaultProgrammer"])
+        self.assertTrue(
+            any("District hierarchy error" in msg for msg in cm.output),
+            f"Expected an ERROR log for the cycle, got: {cm.output}",
+        )
+
+    def test_many_serialization_builds_lookup_once(self):
+        """
+        Serializing N districts in one ``many=True`` pass must build the
+        name→programmer lookup exactly once. Without the per-context cache
+        every row would re-query ``ProjectClass`` and the form's
+        ``GET /project-districts/`` would balloon to N+1 queries.
+        """
+        districts = [
+            self.district_east,
+            self.division_vartiokyla,
+            self.subdivision_alaosa,
+            self.district_unmatched,
+        ]
+
+        # Patch the lookup builder to count invocations while still returning
+        # real data. We resolve the submodule via ``importlib.import_module``
+        # on purpose: ``infraohjelmointi_api.serializers.__init__`` re-exports
+        # the class with the same name as the submodule, so plain ``import
+        # ... as mod`` resolves via attribute access and binds to the class
+        # rather than the module. Going through ``import_module`` always
+        # returns the module object that the serializer's global namespace
+        # actually lives in.
+        from importlib import import_module
+
+        mod = import_module(
+            "infraohjelmointi_api.serializers.ProjectDistrictSerializer"
+        )
+        real_builder = mod.build_location_programmer_lookup
+        with patch.object(
+            mod,
+            "build_location_programmer_lookup",
+            wraps=real_builder,
+        ) as spy:
+            data = ProjectDistrictSerializer(districts, many=True).data
+
+        self.assertEqual(spy.call_count, 1)
+        # And the data is still correct end-to-end:
+        ids = {row["id"]: row.get("computedDefaultProgrammer") for row in data}
+        self.assertIsNotNone(ids[str(self.district_east.id)])
+        self.assertIsNotNone(ids[str(self.division_vartiokyla.id)])
+        self.assertIsNotNone(ids[str(self.subdivision_alaosa.id)])
+        self.assertIsNone(ids[str(self.district_unmatched.id)])
+
+
+@patch.object(BaseViewSet, "authentication_classes", new=[])
+@patch.object(BaseViewSet, "permission_classes", new=[])
+class ProjectDistrictViewSetSmokeTestCase(TestCase):
+    """
+    Smoke test: ``GET /project-districts/`` must include
+    ``computedDefaultProgrammer`` in every row so the FE has the field
+    available to wire into the form.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.user = User.objects.create(username="districts-smoke")
+
+        cls.programmer = ProjectProgrammer.objects.create(
+            firstName="Anna", lastName="Esimerkki"
+        )
+        ProjectClass.objects.create(
+            name="Itäinen suurpiiri",
+            forCoordinatorOnly=False,
+            defaultProgrammer=cls.programmer,
+        )
+        cls.district_east = ProjectDistrict.objects.create(
+            name="Itäinen suurpiiri",
+            level="district",
+            path="Itäinen suurpiiri",
+        )
+        cls.district_unmatched = ProjectDistrict.objects.create(
+            name="Tuntematon",
+            level="district",
+            path="Tuntematon",
+        )
+
+    def test_list_endpoint_includes_computed_default_programmer(self):
+        request = RequestFactory().get("/project-districts/")
+        force_authenticate(request, user=self.user)
+        view = ProjectDistrictViewSet.as_view({"get": "list"})
+
+        response = view(request)
+        self.assertEqual(response.status_code, 200)
+
+        # Ensure the serializer has fully rendered before we read .data
+        response.render()
+        rows = response.data
+        self.assertGreaterEqual(len(rows), 2)
+        for row in rows:
+            self.assertIn(
+                "computedDefaultProgrammer",
+                row,
+                msg=f"Row {row.get('name')!r} missing computedDefaultProgrammer",
+            )
+
+        by_id = {str(r["id"]): r for r in rows}
+        self.assertEqual(
+            by_id[str(self.district_east.id)]["computedDefaultProgrammer"]["lastName"],
+            "Esimerkki",
+        )
+        self.assertIsNone(
+            by_id[str(self.district_unmatched.id)]["computedDefaultProgrammer"]
+        )

--- a/infraohjelmointi_api/tests/test_Projects.py
+++ b/infraohjelmointi_api/tests/test_Projects.py
@@ -4273,8 +4273,9 @@ class ProjectCreateSerializerHierarchicalProgrammerTestCase(TestCase):
         self.assertEqual(updated_project.personProgramming, existing_programmer)
 
     @patch('infraohjelmointi_api.serializers.ProjectCreateSerializer.ProjectWiseService')
-    def test_saija_case_simulation(self, mock_pw_service):
-        """Test the specific Saija case from Jira: creating project under traffic arrangements"""
+    def test_traffic_arrangements_case_from_jira(self, mock_pw_service):
+        """IO-411: creating a project under traffic arrangements where the
+        suurpiiri lives on projectLocation rather than projectClass."""
         itainen_suurpiiri = ProjectClass.objects.create(
             name="Itäinen suurpiiri",
             path="8 03 Kadut ja liikenneväylät/Itäinen suurpiiri",
@@ -4291,7 +4292,7 @@ class ProjectCreateSerializerHierarchicalProgrammerTestCase(TestCase):
         )
 
         serializer = ProjectCreateSerializer(data={
-            'name': 'Turunlinnantien hidastejärjestelyt',
+            'name': 'Test traffic calming project',
             'description': 'Test traffic arrangements',
             'projectClass': traffic_class.id,
         })
@@ -4317,6 +4318,214 @@ class ProjectCreateSerializerHierarchicalProgrammerTestCase(TestCase):
         serializer = ProjectCreateSerializer()
         programmer = serializer._get_default_programmer_with_fallback(self.orphan_class)
         self.assertIsNone(programmer)
+
+    @patch('infraohjelmointi_api.serializers.ProjectCreateSerializer.ProjectWiseService')
+    def test_create_project_with_location_based_programmer(self, mock_pw_service):
+        """
+        IO-411: when projectClass has no programmer in its parent chain, the
+        serializer must fall back to the projectLocation chain. This mirrors
+        the prod case where the suurpiiri lives only on projectLocation.
+        """
+        district_programmer = ProjectProgrammer.objects.create(
+            firstName="Anna", lastName="Esimerkki"
+        )
+        ProjectClass.objects.create(
+            name="Itäinen suurpiiri",
+            forCoordinatorOnly=False,
+            defaultProgrammer=district_programmer,
+        )
+        location = ProjectLocation.objects.create(name="Itäinen suurpiiri")
+
+        serializer = ProjectCreateSerializer(data={
+            'name': 'Test traffic calming project',
+            'description': 'Test traffic arrangements',
+            'projectClass': self.orphan_class.id,
+            'projectLocation': location.id,
+        })
+
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        project = serializer.save()
+        self.assertEqual(project.personProgramming, district_programmer)
+
+    @patch('infraohjelmointi_api.serializers.ProjectCreateSerializer.ProjectWiseService')
+    def test_create_project_class_chain_wins_over_location(self, mock_pw_service):
+        """When the class chain resolves a programmer, the location chain
+        is not consulted (IO-411: avoid changing behavior for projects whose
+        class already has a default)."""
+        district_programmer = ProjectProgrammer.objects.create(
+            firstName="Different", lastName="Person"
+        )
+        ProjectClass.objects.create(
+            name="Itäinen suurpiiri",
+            forCoordinatorOnly=False,
+            defaultProgrammer=district_programmer,
+        )
+        location = ProjectLocation.objects.create(name="Itäinen suurpiiri")
+
+        serializer = ProjectCreateSerializer(data={
+            'name': 'Class wins',
+            'description': 'Test',
+            'projectClass': self.child_class_with_programmer.id,
+            'projectLocation': location.id,
+        })
+
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        project = serializer.save()
+        self.assertEqual(project.personProgramming, self.programmer_child)
+
+    @patch('infraohjelmointi_api.serializers.ProjectCreateSerializer.ProjectWiseService')
+    def test_create_project_with_only_location(self, mock_pw_service):
+        """A project created with no class but with a suurpiiri location
+        should still get the district programmer (IO-411)."""
+        district_programmer = ProjectProgrammer.objects.create(
+            firstName="Eero", lastName="Esimerkki"
+        )
+        ProjectClass.objects.create(
+            name="Läntinen suurpiiri",
+            forCoordinatorOnly=False,
+            defaultProgrammer=district_programmer,
+        )
+        location = ProjectLocation.objects.create(name="Läntinen suurpiiri")
+
+        serializer = ProjectCreateSerializer(data={
+            'name': 'Western project',
+            'description': 'Test',
+            'projectLocation': location.id,
+        })
+
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        project = serializer.save()
+        self.assertEqual(project.personProgramming, district_programmer)
+
+    @patch('infraohjelmointi_api.serializers.ProjectCreateSerializer.ProjectWiseService')
+    def test_update_project_location_triggers_location_fallback(self, mock_pw_service):
+        """Updating a programmer-less project's location should pick up the
+        district programmer when neither the existing nor incoming class
+        resolves one."""
+        district_programmer = ProjectProgrammer.objects.create(
+            firstName="Anna", lastName="Esimerkki"
+        )
+        ProjectClass.objects.create(
+            name="Itäinen suurpiiri",
+            forCoordinatorOnly=False,
+            defaultProgrammer=district_programmer,
+        )
+        location = ProjectLocation.objects.create(name="Itäinen suurpiiri")
+
+        project = Project.objects.create(
+            name="Existing programmer-less project",
+            description="Test",
+            projectClass=self.orphan_class,
+        )
+        self.assertIsNone(project.personProgramming)
+
+        serializer = ProjectCreateSerializer(
+            project,
+            data={
+                'name': project.name,
+                'projectLocation': location.id,
+            },
+            partial=True,
+        )
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        updated_project = serializer.save()
+        self.assertEqual(updated_project.personProgramming, district_programmer)
+
+    @patch('infraohjelmointi_api.serializers.ProjectCreateSerializer.ProjectWiseService')
+    def test_explicit_null_class_clear_does_not_resurrect_old_programmer(self, mock_pw_service):
+        """
+        IO-411 regression: PATCHing `projectClass: null` on a programmer-less
+        project must NOT silently fall back to the persisted projectClass and
+        auto-assign its default programmer. The user is clearing the class
+        on purpose.
+        """
+        project = Project.objects.create(
+            name="Clear class",
+            description="Test",
+            projectClass=self.child_class_with_programmer,
+        )
+        # Sanity: starts with no programmer despite the class having one
+        # (Project.objects.create bypasses the serializer).
+        self.assertIsNone(project.personProgramming)
+
+        serializer = ProjectCreateSerializer(
+            project,
+            data={'projectClass': None},
+            partial=True,
+        )
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        updated = serializer.save()
+        self.assertIsNone(updated.personProgramming)
+        self.assertIsNone(updated.projectClass)
+
+    @patch('infraohjelmointi_api.serializers.ProjectCreateSerializer.ProjectWiseService')
+    def test_explicit_null_location_clear_does_not_resurrect_old_programmer(self, mock_pw_service):
+        """
+        IO-411 regression: same as the class case but for projectLocation.
+        Clearing the location must not auto-assign a programmer derived from
+        the old persisted location.
+        """
+        district_programmer = ProjectProgrammer.objects.create(
+            firstName="Anna", lastName="Esimerkki"
+        )
+        ProjectClass.objects.create(
+            name="Itäinen suurpiiri",
+            forCoordinatorOnly=False,
+            defaultProgrammer=district_programmer,
+        )
+        location = ProjectLocation.objects.create(name="Itäinen suurpiiri")
+
+        project = Project.objects.create(
+            name="Clear location",
+            description="Test",
+            projectClass=self.orphan_class,
+            projectLocation=location,
+        )
+        self.assertIsNone(project.personProgramming)
+
+        serializer = ProjectCreateSerializer(
+            project,
+            data={'projectLocation': None},
+            partial=True,
+        )
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        updated = serializer.save()
+        self.assertIsNone(updated.personProgramming)
+        self.assertIsNone(updated.projectLocation)
+
+    @patch('infraohjelmointi_api.serializers.ProjectCreateSerializer.ProjectWiseService')
+    def test_clearing_one_side_consults_persisted_other_side(self, mock_pw_service):
+        """
+        IO-411: clearing projectClass on a project that has a resolvable
+        projectLocation should still let the location chain resolve a
+        programmer — the *other* side's persisted value is still in play.
+        """
+        district_programmer = ProjectProgrammer.objects.create(
+            firstName="Anna", lastName="Esimerkki"
+        )
+        ProjectClass.objects.create(
+            name="Itäinen suurpiiri",
+            forCoordinatorOnly=False,
+            defaultProgrammer=district_programmer,
+        )
+        location = ProjectLocation.objects.create(name="Itäinen suurpiiri")
+
+        project = Project.objects.create(
+            name="Clear only class",
+            description="Test",
+            projectClass=self.child_class_with_programmer,
+            projectLocation=location,
+        )
+        self.assertIsNone(project.personProgramming)
+
+        serializer = ProjectCreateSerializer(
+            project,
+            data={'projectClass': None},
+            partial=True,
+        )
+        self.assertTrue(serializer.is_valid(), serializer.errors)
+        updated = serializer.save()
+        self.assertEqual(updated.personProgramming, district_programmer)
 
     @patch('infraohjelmointi_api.serializers.ProjectCreateSerializer.ProjectWiseService')
     def test_completed_phase_with_current_year_budget_sets_programmed_true(self, mock_pw_service):

--- a/infraohjelmointi_api/tests/test_programmerimporter.py
+++ b/infraohjelmointi_api/tests/test_programmerimporter.py
@@ -10,7 +10,12 @@ try:
 except ImportError:
     OPENPYXL_AVAILABLE = False
 
-from infraohjelmointi_api.models import ProjectClass, ProjectProgrammer, Project
+from infraohjelmointi_api.models import (
+    ProjectClass,
+    ProjectLocation,
+    ProjectProgrammer,
+    Project,
+)
 from infraohjelmointi_api.models.ProjectPhase import ProjectPhase
 
 
@@ -34,7 +39,7 @@ class ProgrammerImporterTestCase(TestCase):
             parent=cls.class_traffic
         )
 
-        cls.programmer_saija = ProjectProgrammer.objects.create(
+        cls.programmer_anna = ProjectProgrammer.objects.create(
             firstName="TestProgrammer",
             lastName="Test"
         )
@@ -87,7 +92,7 @@ class ProgrammerImporterTestCase(TestCase):
             os.unlink(excel_path)
 
     def test_hierarchical_fallback(self):
-        self.class_traffic.defaultProgrammer = self.programmer_saija
+        self.class_traffic.defaultProgrammer = self.programmer_anna
         self.class_traffic.save()
 
         project = Project.objects.create(
@@ -107,5 +112,81 @@ class ProgrammerImporterTestCase(TestCase):
             project.refresh_from_db()
             self.assertIsNotNone(project.personProgramming)
             self.assertEqual(project.personProgramming.firstName, "TestProgrammer")
+        finally:
+            os.unlink(excel_path)
+
+    def test_location_based_backfill(self):
+        """
+        IO-411: a project picks a generic class (e.g. Liikennejärjestelyt)
+        plus a suurpiiri location. The class chain has no programmer, but a
+        programmer-view ProjectClass with the same name as the location does.
+        The importer must backfill via the location chain.
+        """
+        programmer = ProjectProgrammer.objects.create(
+            firstName="Anna", lastName="Esimerkki"
+        )
+        # Programmer-view suurpiiri ProjectClass with default programmer
+        ProjectClass.objects.create(
+            name="Itäinen suurpiiri",
+            forCoordinatorOnly=False,
+            defaultProgrammer=programmer,
+        )
+        # Generic class with no default programmer anywhere up the chain
+        generic_class = ProjectClass.objects.create(name="Liikennejärjestelyt")
+        location = ProjectLocation.objects.create(name="Itäinen suurpiiri")
+
+        project = Project.objects.create(
+            name="Test traffic calming project",
+            description="Test",
+            projectClass=generic_class,
+            projectLocation=location,
+            phase=self.phase_proposal,
+        )
+
+        excel_path = self._create_test_excel([
+            ["8 01", "Liikennejärjestelyt", "TestProgrammer Test"]
+        ])
+
+        try:
+            call_command('programmerimporter', '--file', excel_path)
+            project.refresh_from_db()
+            self.assertIsNotNone(project.personProgramming)
+            self.assertEqual(project.personProgramming.firstName, "Anna")
+            self.assertEqual(project.personProgramming.lastName, "Esimerkki")
+        finally:
+            os.unlink(excel_path)
+
+    def test_location_only_backfill_with_no_class(self):
+        """
+        Even when projectClass is null, a project with a suurpiiri location
+        should still get a programmer assigned.
+        """
+        programmer = ProjectProgrammer.objects.create(
+            firstName="Eero", lastName="Esimerkki"
+        )
+        ProjectClass.objects.create(
+            name="Läntinen suurpiiri",
+            forCoordinatorOnly=False,
+            defaultProgrammer=programmer,
+        )
+        location = ProjectLocation.objects.create(name="Läntinen suurpiiri")
+
+        project = Project.objects.create(
+            name="Some western project",
+            description="Test",
+            projectClass=None,
+            projectLocation=location,
+            phase=self.phase_proposal,
+        )
+
+        excel_path = self._create_test_excel([
+            ["8 01", "Liikennejärjestelyt", "TestProgrammer Test"]
+        ])
+
+        try:
+            call_command('programmerimporter', '--file', excel_path)
+            project.refresh_from_db()
+            self.assertIsNotNone(project.personProgramming)
+            self.assertEqual(project.personProgramming.firstName, "Eero")
         finally:
             os.unlink(excel_path)

--- a/infraohjelmointi_api/tests/test_project_class_utils.py
+++ b/infraohjelmointi_api/tests/test_project_class_utils.py
@@ -1,0 +1,318 @@
+"""
+Tests for the project_class_utils helpers, covering both class-based and
+location-based default programmer resolution (IO-411).
+"""
+
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from infraohjelmointi_api.models import (
+    ProjectClass,
+    ProjectLocation,
+    ProjectProgrammer,
+)
+from infraohjelmointi_api.utils.project_class_utils import (
+    build_location_programmer_lookup,
+    get_default_programmer_for_project,
+    get_programmer_from_hierarchy,
+    get_programmer_from_location_hierarchy,
+)
+
+
+class GetProgrammerFromHierarchyTestCase(TestCase):
+    """Existing class-parent walker behavior."""
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.programmer = ProjectProgrammer.objects.create(
+            firstName="Eero", lastName="Esimerkki"
+        )
+        cls.parent_class = ProjectClass.objects.create(
+            name="8 01 Liikennejärjestelyt",
+            defaultProgrammer=cls.programmer,
+        )
+        cls.child_class = ProjectClass.objects.create(
+            name="8 01 02 Some sub class", parent=cls.parent_class
+        )
+        cls.orphan_class = ProjectClass.objects.create(name="Standalone")
+
+    def test_returns_none_for_none(self):
+        self.assertIsNone(get_programmer_from_hierarchy(None))
+
+    def test_returns_direct_programmer(self):
+        self.assertEqual(
+            get_programmer_from_hierarchy(self.parent_class), self.programmer
+        )
+
+    def test_walks_parent_chain(self):
+        self.assertEqual(
+            get_programmer_from_hierarchy(self.child_class), self.programmer
+        )
+
+    def test_returns_none_when_no_default_anywhere(self):
+        self.assertIsNone(get_programmer_from_hierarchy(self.orphan_class))
+
+
+class GetProgrammerFromLocationHierarchyTestCase(TestCase):
+    """
+    Location-based fallback: matches each location name against a
+    programmer-view ProjectClass with defaultProgrammer set.
+    Mirrors the IO-411 prod scenario where the suurpiiri lives on
+    projectLocation rather than projectClass.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.programmer_anna = ProjectProgrammer.objects.create(
+            firstName="Anna", lastName="Esimerkki"
+        )
+        cls.programmer_eero = ProjectProgrammer.objects.create(
+            firstName="Eero", lastName="Esimerkki"
+        )
+
+        # Programmer-view (forCoordinatorOnly=False) suurpiiri classes with
+        # defaultProgrammer set, mirroring how prod data looks.
+        cls.cls_east = ProjectClass.objects.create(
+            name="Itäinen suurpiiri",
+            forCoordinatorOnly=False,
+            defaultProgrammer=cls.programmer_anna,
+        )
+        cls.cls_west = ProjectClass.objects.create(
+            name="Läntinen suurpiiri",
+            forCoordinatorOnly=False,
+            defaultProgrammer=cls.programmer_eero,
+        )
+
+        # A coordinator-only class with the same name should be ignored.
+        ProjectClass.objects.create(
+            name="Itäinen suurpiiri",
+            forCoordinatorOnly=True,
+            defaultProgrammer=cls.programmer_eero,
+        )
+
+        # Locations
+        cls.loc_east = ProjectLocation.objects.create(name="Itäinen suurpiiri")
+        cls.loc_west = ProjectLocation.objects.create(name="Läntinen suurpiiri")
+        cls.loc_district = ProjectLocation.objects.create(
+            name="45. Vartiokylä", parent=cls.loc_east
+        )
+        cls.loc_unmatched = ProjectLocation.objects.create(name="Muu alue")
+
+    def test_returns_none_for_none(self):
+        self.assertIsNone(get_programmer_from_location_hierarchy(None))
+
+    def test_direct_location_match(self):
+        self.assertEqual(
+            get_programmer_from_location_hierarchy(self.loc_east),
+            self.programmer_anna,
+        )
+
+    def test_walks_location_parent_chain(self):
+        # Vartiokylä has no matching ProjectClass, but its parent is
+        # Itäinen suurpiiri which does.
+        self.assertEqual(
+            get_programmer_from_location_hierarchy(self.loc_district),
+            self.programmer_anna,
+        )
+
+    def test_unmatched_location_returns_none(self):
+        self.assertIsNone(
+            get_programmer_from_location_hierarchy(self.loc_unmatched)
+        )
+
+    def test_ignores_coordinator_only_class(self):
+        # The Eastern programmer-view class points at the programmer-view
+        # row; the coordinator-only duplicate must not be picked.
+        self.assertEqual(
+            get_programmer_from_location_hierarchy(self.loc_east),
+            self.programmer_anna,
+        )
+
+    def test_cycle_detection_raises(self):
+        loc_a = ProjectLocation.objects.create(name="LoopA")
+        loc_b = ProjectLocation.objects.create(name="LoopB", parent=loc_a)
+        # Force a cycle bypassing model validation
+        ProjectLocation.objects.filter(pk=loc_a.pk).update(parent=loc_b)
+        loc_b.refresh_from_db()
+        with self.assertRaises(ValueError):
+            get_programmer_from_location_hierarchy(loc_b)
+
+
+class GetDefaultProgrammerForProjectTestCase(TestCase):
+    """
+    Combined resolver used by ProjectCreateSerializer and the
+    programmerimporter backfill.
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.programmer_class_owner = ProjectProgrammer.objects.create(
+            firstName="Maija", lastName="Esimerkki"
+        )
+        cls.programmer_loc_owner = ProjectProgrammer.objects.create(
+            firstName="Anna", lastName="Esimerkki"
+        )
+
+        cls.parent_class = ProjectClass.objects.create(
+            name="8 03 Some thing",
+            defaultProgrammer=cls.programmer_class_owner,
+        )
+        cls.generic_child_class = ProjectClass.objects.create(
+            name="8 03 01 Liikennejärjestelyt", parent=cls.parent_class
+        )
+        cls.unrelated_class = ProjectClass.objects.create(name="Liikennejärjestelyt")
+
+        ProjectClass.objects.create(
+            name="Itäinen suurpiiri",
+            forCoordinatorOnly=False,
+            defaultProgrammer=cls.programmer_loc_owner,
+        )
+        cls.location_east = ProjectLocation.objects.create(name="Itäinen suurpiiri")
+
+    def test_class_chain_wins_when_present(self):
+        result = get_default_programmer_for_project(
+            self.generic_child_class, self.location_east
+        )
+        self.assertEqual(result, self.programmer_class_owner)
+
+    def test_falls_back_to_location_when_class_has_none(self):
+        result = get_default_programmer_for_project(
+            self.unrelated_class, self.location_east
+        )
+        self.assertEqual(result, self.programmer_loc_owner)
+
+    def test_returns_none_when_neither_resolves(self):
+        empty_loc = ProjectLocation.objects.create(name="No match")
+        self.assertIsNone(
+            get_default_programmer_for_project(self.unrelated_class, empty_loc)
+        )
+
+    def test_works_with_only_location(self):
+        result = get_default_programmer_for_project(None, self.location_east)
+        self.assertEqual(result, self.programmer_loc_owner)
+
+    def test_works_with_only_class(self):
+        result = get_default_programmer_for_project(self.parent_class, None)
+        self.assertEqual(result, self.programmer_class_owner)
+
+    def test_class_cycle_does_not_block_location_fallback(self):
+        """
+        A corrupted class hierarchy (cycle) must not prevent the location
+        chain from being consulted. The class-side ValueError is logged and
+        swallowed, then the location chain is tried.
+        """
+        a = ProjectClass.objects.create(name="cycle-a")
+        b = ProjectClass.objects.create(name="cycle-b", parent=a)
+        ProjectClass.objects.filter(pk=a.pk).update(parent=b)
+        a.refresh_from_db()
+        b.refresh_from_db()
+
+        result = get_default_programmer_for_project(b, self.location_east)
+        self.assertEqual(result, self.programmer_loc_owner)
+
+
+class BuildLocationProgrammerLookupTestCase(TestCase):
+    """
+    The lookup table is the request-scoped cache that backs the location
+    walker. It must:
+      - ignore coordinator-only ProjectClass rows
+      - ignore rows without a defaultProgrammer
+      - be deterministic when multiple programmer-view classes share a name
+      - emit a warning when same-named classes resolve to *different*
+        programmers (data-quality alert)
+    """
+
+    @classmethod
+    def setUpTestData(cls):
+        cls.programmer_a = ProjectProgrammer.objects.create(firstName="A", lastName="One")
+        cls.programmer_b = ProjectProgrammer.objects.create(firstName="B", lastName="Two")
+
+    def test_excludes_coordinator_only_and_unset(self):
+        ProjectClass.objects.create(
+            name="Programmer view",
+            forCoordinatorOnly=False,
+            defaultProgrammer=self.programmer_a,
+        )
+        ProjectClass.objects.create(
+            name="Coordinator only",
+            forCoordinatorOnly=True,
+            defaultProgrammer=self.programmer_b,
+        )
+        ProjectClass.objects.create(
+            name="No programmer",
+            forCoordinatorOnly=False,
+            defaultProgrammer=None,
+        )
+
+        lookup = build_location_programmer_lookup()
+        self.assertIn("Programmer view", lookup)
+        self.assertNotIn("Coordinator only", lookup)
+        self.assertNotIn("No programmer", lookup)
+        self.assertEqual(lookup["Programmer view"], self.programmer_a)
+
+    def test_duplicates_with_same_programmer_resolve_consistently(self):
+        # Three programmer-view rows ("Itäinen suurpiiri" exists 3 times in
+        # prod, one per project type) all pointing at the same programmer.
+        for _ in range(3):
+            ProjectClass.objects.create(
+                name="Itäinen suurpiiri",
+                forCoordinatorOnly=False,
+                defaultProgrammer=self.programmer_a,
+            )
+
+        lookup = build_location_programmer_lookup()
+        self.assertEqual(lookup["Itäinen suurpiiri"], self.programmer_a)
+
+    def test_duplicates_with_conflicting_programmers_warn_and_stay_deterministic(self):
+        """
+        When two same-named classes point at different programmers, the
+        oldest (by createdDate) wins deterministically and a warning is
+        logged so the data drift can be reconciled.
+        """
+        ProjectClass.objects.create(
+            name="Itäinen suurpiiri",
+            forCoordinatorOnly=False,
+            defaultProgrammer=self.programmer_a,
+        )
+        ProjectClass.objects.create(
+            name="Itäinen suurpiiri",
+            forCoordinatorOnly=False,
+            defaultProgrammer=self.programmer_b,
+        )
+
+        with self.assertLogs("infraohjelmointi_api.utils.project_class_utils", level="WARNING") as cm:
+            lookup_first = build_location_programmer_lookup()
+            lookup_second = build_location_programmer_lookup()
+
+        self.assertEqual(lookup_first["Itäinen suurpiiri"], self.programmer_a)
+        self.assertEqual(lookup_second["Itäinen suurpiiri"], self.programmer_a)
+        self.assertTrue(
+            any("Itäinen suurpiiri" in msg for msg in cm.output),
+            f"Expected a warning naming the conflicting class, got: {cm.output}",
+        )
+
+    def test_walker_uses_supplied_lookup_without_extra_queries(self):
+        """
+        When a precomputed lookup is supplied, the walker must not query the
+        database for ProjectClass rows again (the whole point of the cache).
+        """
+        ProjectClass.objects.create(
+            name="Itäinen suurpiiri",
+            forCoordinatorOnly=False,
+            defaultProgrammer=self.programmer_a,
+        )
+        location = ProjectLocation.objects.create(name="Itäinen suurpiiri")
+        precomputed = build_location_programmer_lookup()
+
+        # Patch the model loader inside the util to make any further queries
+        # explode; the walker must not touch it when name_lookup is supplied.
+        with patch(
+            "infraohjelmointi_api.utils.project_class_utils.build_location_programmer_lookup",
+            side_effect=AssertionError("should not rebuild lookup"),
+        ):
+            result = get_programmer_from_location_hierarchy(
+                location, name_lookup=precomputed
+            )
+
+        self.assertEqual(result, self.programmer_a)

--- a/infraohjelmointi_api/utils/project_class_utils.py
+++ b/infraohjelmointi_api/utils/project_class_utils.py
@@ -1,3 +1,8 @@
+import logging
+
+logger = logging.getLogger(__name__)
+
+
 def get_programmer_from_hierarchy(project_class, max_depth=10):
     if not project_class:
         return None
@@ -15,3 +20,144 @@ def get_programmer_from_hierarchy(project_class, max_depth=10):
             return current.defaultProgrammer
         current = current.parent
     return None
+
+
+def build_location_programmer_lookup():
+    """
+    Build a {class_name: ProjectProgrammer} lookup from programmer-view
+    ProjectClass rows with a defaultProgrammer (IO-411).
+
+    Suurpiiri names appear in multiple rows (one per project type) and are
+    expected to all point at the same programmer; on drift we pick the oldest
+    deterministically and warn so the data can be reconciled.
+    """
+    from infraohjelmointi_api.models import ProjectClass
+
+    rows = (
+        ProjectClass.objects
+        .filter(forCoordinatorOnly=False, defaultProgrammer__isnull=False)
+        .order_by("createdDate")
+        .values_list("id", "name", "defaultProgrammer_id")
+    )
+
+    by_name: dict[str, tuple] = {}
+    conflicts: dict[str, set] = {}
+    for cls_id, name, programmer_id in rows:
+        existing = by_name.get(name)
+        if existing is None:
+            by_name[name] = (programmer_id, cls_id)
+        elif existing[0] != programmer_id:
+            conflicts.setdefault(name, {existing[0]}).add(programmer_id)
+
+    for name, programmer_ids in conflicts.items():
+        logger.warning(
+            "Multiple programmer-view ProjectClass rows named %r resolve to "
+            "different defaultProgrammers (%s). Picking the oldest "
+            "deterministically; please reconcile the data.",
+            name, sorted(str(pid) for pid in programmer_ids),
+        )
+
+    if not by_name:
+        return {}
+
+    from infraohjelmointi_api.models import ProjectProgrammer
+
+    programmer_ids = {pid for pid, _ in by_name.values()}
+    programmers = {
+        p.id: p
+        for p in ProjectProgrammer.objects.filter(id__in=programmer_ids)
+    }
+
+    return {
+        name: programmers[pid]
+        for name, (pid, _cls_id) in by_name.items()
+        if pid in programmers
+    }
+
+
+def get_programmer_from_name_hierarchy(
+    node,
+    max_depth=10,
+    name_lookup=None,
+):
+    """
+    Walk a generic ``parent``-linked hierarchy and look up each node's
+    ``name`` in a programmer-view ProjectClass lookup (IO-411).
+
+    Used by both ProjectLocation and ProjectDistrict chains; both models
+    expose ``id``, ``name`` and ``parent``, which is all this walker needs.
+    Pass ``name_lookup`` (from ``build_location_programmer_lookup``) to share
+    the lookup across many calls; it is built lazily otherwise.
+    """
+    if not node:
+        return None
+
+    if name_lookup is None:
+        name_lookup = build_location_programmer_lookup()
+
+    if not name_lookup:
+        return None
+
+    visited = set()
+    current = node
+    depth = 0
+    while current:
+        if current.id in visited:
+            raise ValueError(
+                "Cycle detected in name hierarchy at "
+                f"'{current.name}' (ID: {current.id})"
+            )
+        visited.add(current.id)
+        depth += 1
+        if depth > max_depth:
+            raise ValueError(
+                f"Maximum name hierarchy depth ({max_depth}) exceeded"
+            )
+
+        programmer = name_lookup.get(current.name)
+        if programmer is not None:
+            return programmer
+
+        current = current.parent
+
+    logger.debug(
+        "No default programmer found while walking the name hierarchy "
+        "starting at '%s' (ID: %s).",
+        getattr(node, "name", None),
+        getattr(node, "id", None),
+    )
+    return None
+
+
+def get_programmer_from_location_hierarchy(
+    project_location,
+    max_depth=10,
+    name_lookup=None,
+):
+    """Backwards-compatible alias for :func:`get_programmer_from_name_hierarchy`."""
+    return get_programmer_from_name_hierarchy(
+        project_location, max_depth=max_depth, name_lookup=name_lookup
+    )
+
+
+def get_default_programmer_for_project(project_class, project_location=None, name_lookup=None):
+    """
+    Resolve the default programmer for a project: walk the class parent chain
+    first, then fall back to the location chain (IO-411). A corrupted class
+    hierarchy must not prevent the location chain from being consulted.
+    """
+    try:
+        programmer = get_programmer_from_hierarchy(project_class)
+    except ValueError as exc:
+        logger.error(
+            "ProjectClass hierarchy error while resolving default programmer "
+            "for class '%s' (ID: %s): %s. Falling back to location chain.",
+            getattr(project_class, "name", None),
+            getattr(project_class, "id", None),
+            exc,
+        )
+        programmer = None
+
+    if programmer:
+        return programmer
+    return get_programmer_from_name_hierarchy(project_location, name_lookup=name_lookup)

--- a/infraohjelmointi_api/views/ProjectDistrictViewSet.py
+++ b/infraohjelmointi_api/views/ProjectDistrictViewSet.py
@@ -1,4 +1,7 @@
-from infraohjelmointi_api.serializers.ProjectDistrictSerializer import ProjectDistrictSerializer
+from infraohjelmointi_api.models import ProjectDistrict
+from infraohjelmointi_api.serializers.ProjectDistrictSerializer import (
+    ProjectDistrictSerializer,
+)
 
 from .CachedLookupViewSet import CachedLookupViewSet
 
@@ -7,3 +10,18 @@ class ProjectDistrictViewSet(CachedLookupViewSet):
     """API endpoint for project districts (cached)."""
 
     serializer_class = ProjectDistrictSerializer
+
+    # Bump on response-shape changes so post-deploy clients hit a cold cache
+    # instead of stale Redis entries missing computedDefaultProgrammer (IO-411).
+    _CACHE_KEY_VERSION = "v2-io411"
+
+    def get_cache_key_name(self) -> str:
+        return f"{super().get_cache_key_name()}:{self._CACHE_KEY_VERSION}"
+
+    def get_queryset(self):
+        # Pre-load the parent chain (district → division → subDivision) so
+        # serializing computedDefaultProgrammer doesn't issue per-row queries.
+        return (
+            ProjectDistrict.objects.all()
+            .select_related("parent", "parent__parent", "parent__parent__parent")
+        )

--- a/infraohjelmointi_api/views/ProjectLocationViewSet.py
+++ b/infraohjelmointi_api/views/ProjectLocationViewSet.py
@@ -27,7 +27,15 @@ class ProjectLocationViewSet(BaseClassLocationViewSet):
         """Default is programmer view with optimized prefetching"""
         return (
             ProjectLocationService.list_all()
-            .select_related('coordinatorLocation', 'parent', 'parentClass')
+            # Pre-load the full parent chain (district → division → subDivision)
+            # so computedDefaultProgrammer doesn't issue per-row queries (IO-411).
+            .select_related(
+                'coordinatorLocation',
+                'parent',
+                'parent__parent',
+                'parent__parent__parent',
+                'parentClass',
+            )
             .prefetch_related(
                 'coordinatorLocation__finances',
                 Prefetch(


### PR DESCRIPTION
* Generalise the location walker into get_programmer_from_name_hierarchy so it works on both ProjectLocation and ProjectDistrict
* ProjectCreateSerializer and the programmerimporter backfill now resolve class-first, then district/location
* Expose computedDefaultProgrammer on ProjectDistrictSerializer (the endpoint the form actually consumes) and on ProjectLocationSerializer
* Anonymize test data