### PR TITLE
fix: IO-833 Allow Person delete when referenced by Project FKs

### DIFF
--- a/infraohjelmointi_api/signals.py
+++ b/infraohjelmointi_api/signals.py
@@ -518,6 +518,64 @@ def _is_valid_sap_project(value: str | None) -> bool:
     return True
 
 
+def _all_subclasses(cls):
+    """Yield every (transitive) subclass of ``cls``. Used to discover all
+    CachedLookupViewSet subclasses regardless of inheritance depth."""
+    for sub in cls.__subclasses__():
+        yield sub
+        yield from _all_subclasses(sub)
+
+
+def _invalidate_cached_lookup(sender, **kwargs):
+    """Drop the cached list response for ``sender`` after the surrounding
+    transaction commits. Deferring to ``on_commit`` avoids a race where a
+    concurrent request reads the cache between INVALIDATE and COMMIT and
+    re-populates it with the (still-uncommitted, soon-to-be-stale) value.
+    """
+    transaction.on_commit(lambda: CacheService.invalidate_lookup(sender.__name__))
+
+
+def _connect_cached_lookup_invalidation():
+    """Wire post_save/post_delete on every CachedLookupViewSet model so that
+    direct ORM mutations (Django shell, admin, management commands, bulk
+    imports) also invalidate the lookup cache.
+
+    Without this, only ViewSet-driven mutations refresh the cache and
+    out-of-band edits stay invisible until the 12 h TTL expires.
+    Caveat: queryset-level ``.update()`` / ``.delete()`` bypass these signals
+    by design — those callsites must invalidate explicitly.
+    """
+    # Force-import the views package so every CachedLookupViewSet subclass is
+    # registered before we walk subclasses.
+    from infraohjelmointi_api import views  # noqa: F401
+    from infraohjelmointi_api.views.CachedLookupViewSet import CachedLookupViewSet
+
+    seen_models = set()
+    for viewset_cls in _all_subclasses(CachedLookupViewSet):
+        try:
+            model = viewset_cls.serializer_class.Meta.model
+        except AttributeError:
+            continue
+        if model in seen_models:
+            continue
+        seen_models.add(model)
+        post_save.connect(
+            _invalidate_cached_lookup,
+            sender=model,
+            dispatch_uid=f"cached_lookup_invalidate_save_{model.__name__}",
+            weak=False,
+        )
+        post_delete.connect(
+            _invalidate_cached_lookup,
+            sender=model,
+            dispatch_uid=f"cached_lookup_invalidate_delete_{model.__name__}",
+            weak=False,
+        )
+
+
+_connect_cached_lookup_invalidation()
+
+
 @receiver(pre_save, sender=Project)
 def capture_old_sap_project(sender, instance, **kwargs):
     """

--- a/infraohjelmointi_api/tests/test_CacheService.py
+++ b/infraohjelmointi_api/tests/test_CacheService.py
@@ -26,6 +26,7 @@ from infraohjelmointi_api.models import (
     ProjectType,
     ProjectCategory,
     ConstructionPhase,
+    Person,
 )
 from infraohjelmointi_api.serializers import ProjectClassSerializer
 from infraohjelmointi_api.serializers.FinancialSumSerializer import FinancialSumSerializer
@@ -1396,6 +1397,145 @@ class CachedLookupDeletionModificationTest(TestCase):
         project2.refresh_from_db()
         self.assertIsNone(project1.category)
         self.assertIsNone(project2.category)
+
+
+@override_settings(CACHES=LOCMEM_CACHE)
+class PersonMultiFKDeletionTest(TestCase):
+    """Regression tests for IO-833: deleting/updating a Person referenced by
+    Project via more than one FK field (personPlanning, personConstruction).
+
+    Before the fix, PersonViewSet did not declare project_field, so the
+    base-class cleanup was skipped and Postgres rejected the delete with a
+    foreign key violation (`infraohjelmointi_api_personConstruction_..._fk`).
+    """
+
+    def setUp(self):
+        cache.clear()
+        User = get_user_model()
+        self.user = User.objects.create_user(
+            username='testuser_person_fk', password='testpass'
+        )
+        coord_group, _ = ADGroup.objects.get_or_create(
+            name='sg_kymp_sso_io_koordinaattorit',
+            defaults={'display_name': 'Coordinators'},
+        )
+        self.user.ad_groups.add(coord_group)
+        self.client.force_login(self.user)
+
+        self.phase_completed, _ = ProjectPhase.objects.get_or_create(value='completed')
+        self.phase_warranty, _ = ProjectPhase.objects.get_or_create(value='warrantyPeriod')
+        self.phase_planning, _ = ProjectPhase.objects.get_or_create(value='planning')
+
+        self.programmer = ProjectProgrammer.objects.create(
+            firstName='Test', lastName='Programmer'
+        )
+        self.proj_class = ProjectClass.objects.create(
+            name='Test Class', path='TestClass', defaultProgrammer=self.programmer
+        )
+
+    def _make_person(self, last):
+        return Person.objects.create(
+            firstName='Pat', lastName=last, email=f'{last.lower()}@example.com',
+            title='', phone='',
+        )
+
+    def _make_project(self, name, phase, **person_kwargs):
+        return Project.objects.create(
+            name=name,
+            description='Test',
+            projectClass=self.proj_class,
+            phase=phase,
+            personProgramming=self.programmer,
+            **person_kwargs,
+        )
+
+    def test_delete_person_referenced_as_planning_only_clears_active_projects(self):
+        """DELETE /persons/<id>/ must NULL personPlanning on active projects."""
+        person = self._make_person('Planner')
+        active = self._make_project('Active P', self.phase_planning, personPlanning=person)
+
+        response = self.client.delete(f'/persons/{person.id}/')
+
+        self.assertEqual(response.status_code, 204)
+        active.refresh_from_db()
+        self.assertIsNone(active.personPlanning)
+        self.assertFalse(Person.objects.filter(id=person.id).exists())
+
+    def test_delete_person_referenced_as_construction_only_clears_active_projects(self):
+        """DELETE /persons/<id>/ must NULL personConstruction on active projects.
+
+        This is the exact failure mode reported from dev: a Person referenced
+        only via personConstruction caused a Postgres FK violation.
+        """
+        person = self._make_person('Builder')
+        active = self._make_project('Active C', self.phase_planning, personConstruction=person)
+
+        response = self.client.delete(f'/persons/{person.id}/')
+
+        self.assertEqual(response.status_code, 204)
+        active.refresh_from_db()
+        self.assertIsNone(active.personConstruction)
+        self.assertFalse(Person.objects.filter(id=person.id).exists())
+
+    def test_delete_person_referenced_via_both_fks_clears_both(self):
+        """A single project may use the same Person for both planning and construction."""
+        person = self._make_person('Both')
+        project = self._make_project(
+            'Active Both', self.phase_planning,
+            personPlanning=person, personConstruction=person,
+        )
+
+        response = self.client.delete(f'/persons/{person.id}/')
+
+        self.assertEqual(response.status_code, 204)
+        project.refresh_from_db()
+        self.assertIsNone(project.personPlanning)
+        self.assertIsNone(project.personConstruction)
+
+    def test_delete_person_with_completed_project_preserves_via_each_fk(self):
+        """For completed/warranty projects, repoint to a hidden copy on every FK."""
+        person = self._make_person('Veteran')
+        completed_planning = self._make_project(
+            'Completed Plan', self.phase_completed, personPlanning=person
+        )
+        warranty_construction = self._make_project(
+            'Warranty Build', self.phase_warranty, personConstruction=person
+        )
+        active = self._make_project(
+            'Active', self.phase_planning, personConstruction=person
+        )
+
+        response = self.client.delete(f'/persons/{person.id}/')
+
+        self.assertEqual(response.status_code, 204)
+        self.assertFalse(Person.objects.filter(id=person.id, deleted=False).exists())
+
+        completed_planning.refresh_from_db()
+        warranty_construction.refresh_from_db()
+        active.refresh_from_db()
+
+        self.assertIsNotNone(completed_planning.personPlanning)
+        self.assertEqual(completed_planning.personPlanning.lastName, 'Veteran')
+        self.assertTrue(completed_planning.personPlanning.deleted)
+
+        self.assertIsNotNone(warranty_construction.personConstruction)
+        self.assertEqual(warranty_construction.personConstruction.lastName, 'Veteran')
+        self.assertTrue(warranty_construction.personConstruction.deleted)
+
+        self.assertIsNone(active.personConstruction)
+
+        hidden = Person.objects.filter(lastName='Veteran', deleted=True)
+        self.assertEqual(hidden.count(), 1)
+        self.assertEqual(completed_planning.personPlanning_id, warranty_construction.personConstruction_id)
+
+    def test_delete_person_not_referenced_succeeds(self):
+        """Sanity: deleting an unreferenced Person still works."""
+        person = self._make_person('Lonely')
+
+        response = self.client.delete(f'/persons/{person.id}/')
+
+        self.assertEqual(response.status_code, 204)
+        self.assertFalse(Person.objects.filter(id=person.id).exists())
 
 
 class ViewSetImportTest(TestCase):

--- a/infraohjelmointi_api/tests/test_CacheService.py
+++ b/infraohjelmointi_api/tests/test_CacheService.py
@@ -23,10 +23,14 @@ from infraohjelmointi_api.models import (
     ProjectGroup,
     ProjectPhase,
     ProjectProgrammer,
+    ProjectLock,
+    ProjectSet,
     ProjectType,
     ProjectCategory,
     ConstructionPhase,
     Person,
+    Task,
+    TalpaProjectOpening,
 )
 from infraohjelmointi_api.serializers import ProjectClassSerializer
 from infraohjelmointi_api.serializers.FinancialSumSerializer import FinancialSumSerializer
@@ -1536,6 +1540,252 @@ class PersonMultiFKDeletionTest(TestCase):
 
         self.assertEqual(response.status_code, 204)
         self.assertFalse(Person.objects.filter(id=person.id).exists())
+
+
+@override_settings(CACHES=LOCMEM_CACHE)
+class PersonOtherReverseFKDeletionTest(TestCase):
+    """Regression tests for IO-833 (extended): deleting a Person that is
+    referenced by tables OTHER than Project's planning/construction FKs.
+
+    Background: at the schema level there are 10 FK constraints pointing at
+    `infraohjelmointi_api_person`. Most of them use `on_delete=DO_NOTHING`
+    on a nullable field, and Django's default Postgres FK constraints are
+    DEFERRABLE INITIALLY DEFERRED. That means stray references are only
+    caught at COMMIT, so the DRF view returned 204 while the underlying
+    transaction blew up with a ForeignKeyViolation, surfacing as a 500 in
+    the next request.
+
+    These tests cover every reverse FK to Person that the auto-cleanup in
+    CachedLookupViewSet._clear_other_reverse_fks must NULL out:
+
+      - Task.person                         (DO_NOTHING, null)
+      - ProjectSet.responsiblePerson        (DO_NOTHING, null)
+      - ProjectLock.lockedBy                (DO_NOTHING, null)
+      - TalpaProjectOpening.createdBy       (DO_NOTHING, null)
+      - TalpaProjectOpening.updatedBy       (DO_NOTHING, null)
+      - ProjectProgrammer.person            (SET_NULL,   null)
+
+    Plus the M2M relations (Project.otherPersons, Project.favPersons),
+    which Django itself cleans up via the through-table.
+    """
+
+    def setUp(self):
+        cache.clear()
+        User = get_user_model()
+        self.user = User.objects.create_user(
+            username='testuser_person_other_fk', password='testpass'
+        )
+        coord_group, _ = ADGroup.objects.get_or_create(
+            name='sg_kymp_sso_io_koordinaattorit',
+            defaults={'display_name': 'Coordinators'},
+        )
+        self.user.ad_groups.add(coord_group)
+        self.client.force_login(self.user)
+
+        self.phase_planning, _ = ProjectPhase.objects.get_or_create(value='planning')
+        self.programmer = ProjectProgrammer.objects.create(
+            firstName='Other', lastName='Programmer'
+        )
+        self.proj_class = ProjectClass.objects.create(
+            name='Other Class', path='OtherClass', defaultProgrammer=self.programmer
+        )
+
+    def _make_person(self, last):
+        return Person.objects.create(
+            firstName='Pat', lastName=last, email=f'{last.lower()}@example.com',
+            title='', phone='',
+        )
+
+    def _make_project(self, name='ref-project', **kwargs):
+        return Project.objects.create(
+            name=name,
+            description='Test',
+            projectClass=self.proj_class,
+            phase=self.phase_planning,
+            personProgramming=self.programmer,
+            **kwargs,
+        )
+
+    def test_delete_person_referenced_by_task_clears_task_fk(self):
+        """Without the cleanup this raises FK violation at commit time."""
+        person = self._make_person('Tasky')
+        project = self._make_project('with-task')
+        task = Task.objects.create(
+            projectId=project,
+            taskType='task',
+            person=person,
+            realizedCost=0,
+            plannedCost=0,
+            riskAssessment='none',
+        )
+
+        response = self.client.delete(f'/persons/{person.id}/')
+
+        self.assertEqual(response.status_code, 204)
+        self.assertFalse(Person.objects.filter(id=person.id).exists())
+        task.refresh_from_db()
+        self.assertIsNone(task.person)
+
+    def test_delete_person_referenced_by_projectset_clears_responsible_person(self):
+        person = self._make_person('Setty')
+        pset = ProjectSet.objects.create(
+            name='ps', description='', responsiblePerson=person,
+        )
+
+        response = self.client.delete(f'/persons/{person.id}/')
+
+        self.assertEqual(response.status_code, 204)
+        self.assertFalse(Person.objects.filter(id=person.id).exists())
+        pset.refresh_from_db()
+        self.assertIsNone(pset.responsiblePerson)
+
+    def test_delete_person_referenced_by_projectlock_clears_locked_by(self):
+        person = self._make_person('Locker')
+        project = self._make_project('with-lock')
+        lock = ProjectLock.objects.create(
+            project=project, lockType='status_locked', lockedBy=person,
+        )
+
+        response = self.client.delete(f'/persons/{person.id}/')
+
+        self.assertEqual(response.status_code, 204)
+        self.assertFalse(Person.objects.filter(id=person.id).exists())
+        lock.refresh_from_db()
+        self.assertIsNone(lock.lockedBy)
+
+    def test_delete_person_referenced_by_talpa_opening_clears_both_audit_fks(self):
+        """TalpaProjectOpening references Person via TWO FKs (createdBy +
+        updatedBy). Both must be cleared."""
+        person = self._make_person('Talpa')
+        project = self._make_project('with-talpa')
+        opening = TalpaProjectOpening.objects.create(
+            project=project,
+            subject='Uusi',
+            createdBy=person,
+            updatedBy=person,
+        )
+
+        response = self.client.delete(f'/persons/{person.id}/')
+
+        self.assertEqual(response.status_code, 204)
+        self.assertFalse(Person.objects.filter(id=person.id).exists())
+        opening.refresh_from_db()
+        self.assertIsNone(opening.createdBy)
+        self.assertIsNone(opening.updatedBy)
+
+    def test_delete_person_referenced_by_programmer_clears_programmer_fk(self):
+        """ProjectProgrammer.person uses SET_NULL. Verify the FK is null and
+        the programmer row itself is preserved (it should NOT be deleted
+        cascade-style)."""
+        person = self._make_person('Programmery')
+        prog = ProjectProgrammer.objects.create(
+            firstName='Alex', lastName='Programmery', person=person,
+        )
+
+        response = self.client.delete(f'/persons/{person.id}/')
+
+        self.assertEqual(response.status_code, 204)
+        self.assertFalse(Person.objects.filter(id=person.id).exists())
+        prog.refresh_from_db()
+        self.assertIsNone(prog.person)
+
+    def test_delete_person_referenced_via_other_persons_m2m_succeeds(self):
+        """Django auto-cleans the M2M through-table on delete; verify that
+        our extra cleanup doesn't break that path."""
+        person = self._make_person('M2MOther')
+        project = self._make_project('with-other')
+        project.otherPersons.add(person)
+
+        response = self.client.delete(f'/persons/{person.id}/')
+
+        self.assertEqual(response.status_code, 204)
+        self.assertFalse(Person.objects.filter(id=person.id).exists())
+        project.refresh_from_db()
+        self.assertEqual(project.otherPersons.count(), 0)
+
+    def test_delete_person_referenced_via_fav_persons_m2m_succeeds(self):
+        person = self._make_person('M2MFav')
+        project = self._make_project('with-fav')
+        project.favPersons.add(person)
+
+        response = self.client.delete(f'/persons/{person.id}/')
+
+        self.assertEqual(response.status_code, 204)
+        self.assertFalse(Person.objects.filter(id=person.id).exists())
+        project.refresh_from_db()
+        self.assertEqual(project.favPersons.count(), 0)
+
+    def test_delete_person_referenced_from_every_relation_simultaneously(self):
+        """End-to-end stress test: a Person referenced from EVERY known
+        relation at once must still delete cleanly. This is the scenario
+        most likely to reproduce the production failure mode where any
+        single missed reverse FK causes a 500."""
+        person = self._make_person('Everywhere')
+
+        # Project FKs (planning + construction) on an active project
+        active = self._make_project(
+            'active-everywhere',
+            personPlanning=person, personConstruction=person,
+        )
+        active.otherPersons.add(person)
+        active.favPersons.add(person)
+
+        # Task on the same project
+        Task.objects.create(
+            projectId=active,
+            taskType='task',
+            person=person,
+            realizedCost=0, plannedCost=0,
+            riskAssessment='none',
+        )
+
+        # ProjectSet
+        ProjectSet.objects.create(
+            name='ps-everywhere', description='', responsiblePerson=person,
+        )
+
+        # ProjectLock on the same project
+        ProjectLock.objects.create(
+            project=active, lockType='status_locked', lockedBy=person,
+        )
+
+        # TalpaProjectOpening on the same project
+        TalpaProjectOpening.objects.create(
+            project=active, subject='Uusi',
+            createdBy=person, updatedBy=person,
+        )
+
+        # ProjectProgrammer pointing at this Person
+        prog = ProjectProgrammer.objects.create(
+            firstName='Sam', lastName='Everywhere', person=person,
+        )
+
+        response = self.client.delete(f'/persons/{person.id}/')
+
+        self.assertEqual(response.status_code, 204)
+        self.assertFalse(Person.objects.filter(id=person.id).exists())
+
+        # All references must be cleared
+        active.refresh_from_db()
+        prog.refresh_from_db()
+        self.assertIsNone(active.personPlanning)
+        self.assertIsNone(active.personConstruction)
+        self.assertEqual(active.otherPersons.count(), 0)
+        self.assertEqual(active.favPersons.count(), 0)
+        self.assertIsNone(prog.person)
+        self.assertEqual(Task.objects.filter(person__isnull=False).count(), 0)
+        self.assertEqual(
+            ProjectSet.objects.filter(responsiblePerson__isnull=False).count(), 0
+        )
+        self.assertEqual(
+            ProjectLock.objects.filter(lockedBy__isnull=False).count(), 0
+        )
+        self.assertEqual(
+            TalpaProjectOpening.objects.filter(createdBy__isnull=False).count(), 0
+        )
+        self.assertEqual(
+            TalpaProjectOpening.objects.filter(updatedBy__isnull=False).count(), 0
+        )
 
 
 class ViewSetImportTest(TestCase):

--- a/infraohjelmointi_api/tests/test_CacheService.py
+++ b/infraohjelmointi_api/tests/test_CacheService.py
@@ -1405,12 +1405,13 @@ class CachedLookupDeletionModificationTest(TestCase):
 
 @override_settings(CACHES=LOCMEM_CACHE)
 class PersonMultiFKDeletionTest(TestCase):
-    """Regression tests for IO-833: deleting/updating a Person referenced by
-    Project via more than one FK field (personPlanning, personConstruction).
+    """Tests that deleting/updating a Person referenced by Project via
+    multiple FK fields (`personPlanning`, `personConstruction`) cleans up
+    all references. Both FKs use `on_delete=DO_NOTHING` with deferred
+    Postgres FK constraints, so a missed reference only surfaces as a 500
+    at COMMIT rather than at the DELETE statement.
 
-    Before the fix, PersonViewSet did not declare project_field, so the
-    base-class cleanup was skipped and Postgres rejected the delete with a
-    foreign key violation (`infraohjelmointi_api_personConstruction_..._fk`).
+    See IO-833.
     """
 
     def setUp(self):
@@ -1541,22 +1542,46 @@ class PersonMultiFKDeletionTest(TestCase):
         self.assertEqual(response.status_code, 204)
         self.assertFalse(Person.objects.filter(id=person.id).exists())
 
+    def test_delete_person_completed_project_both_fks_same_hidden_copy(self):
+        """One completed project with the same Person on both FKs gets a single
+        shared hidden copy and BOTH FKs repointed to it.
+
+        Catches the multiplication of the multi-FK preservation: only one
+        ``preserved_copy`` should be created per delete, regardless of how
+        many FKs land on it.
+        """
+        person = self._make_person('Twofer')
+        completed = self._make_project(
+            'completed-twofer', self.phase_completed,
+            personPlanning=person, personConstruction=person,
+        )
+
+        response = self.client.delete(f'/persons/{person.id}/')
+
+        self.assertEqual(response.status_code, 204)
+        completed.refresh_from_db()
+        self.assertIsNotNone(completed.personPlanning)
+        self.assertEqual(
+            completed.personPlanning_id, completed.personConstruction_id,
+            'Both FKs must point to the same hidden copy',
+        )
+        self.assertTrue(completed.personPlanning.deleted)
+        self.assertEqual(
+            Person.objects.filter(lastName='Twofer', deleted=True).count(), 1,
+            'Exactly one hidden copy should exist',
+        )
+
 
 @override_settings(CACHES=LOCMEM_CACHE)
 class PersonOtherReverseFKDeletionTest(TestCase):
-    """Regression tests for IO-833 (extended): deleting a Person that is
-    referenced by tables OTHER than Project's planning/construction FKs.
+    """Tests that deleting a Person cleans up references from tables other
+    than Project's planning/construction FKs.
 
-    Background: at the schema level there are 10 FK constraints pointing at
-    `infraohjelmointi_api_person`. Most of them use `on_delete=DO_NOTHING`
-    on a nullable field, and Django's default Postgres FK constraints are
-    DEFERRABLE INITIALLY DEFERRED. That means stray references are only
-    caught at COMMIT, so the DRF view returned 204 while the underlying
-    transaction blew up with a ForeignKeyViolation, surfacing as a 500 in
-    the next request.
-
-    These tests cover every reverse FK to Person that the auto-cleanup in
-    CachedLookupViewSet._clear_other_reverse_fks must NULL out:
+    There are 10 FK constraints pointing at `infraohjelmointi_api_person`.
+    Most use `on_delete=DO_NOTHING` on a nullable field with DEFERRABLE
+    INITIALLY DEFERRED constraints, so a missed reference only surfaces as
+    a 500 at COMMIT. `CachedLookupViewSet._clear_other_reverse_fks` NULLs
+    these automatically; these tests cover every relation it must handle:
 
       - Task.person                         (DO_NOTHING, null)
       - ProjectSet.responsiblePerson        (DO_NOTHING, null)
@@ -1567,6 +1592,8 @@ class PersonOtherReverseFKDeletionTest(TestCase):
 
     Plus the M2M relations (Project.otherPersons, Project.favPersons),
     which Django itself cleans up via the through-table.
+
+    See IO-833.
     """
 
     def setUp(self):
@@ -1785,6 +1812,151 @@ class PersonOtherReverseFKDeletionTest(TestCase):
         )
         self.assertEqual(
             TalpaProjectOpening.objects.filter(updatedBy__isnull=False).count(), 0
+        )
+
+
+@override_settings(CACHES=LOCMEM_CACHE)
+class CachedLookupClearOtherReverseFKsBroaderImpactTest(TestCase):
+    """Regression tests confirming ``_clear_other_reverse_fks`` runs for ALL
+    CachedLookupViewSet subclasses (not just Person) and behaves sanely.
+
+    Without these, a future change might inadvertently break unrelated lookup
+    deletions, since the helper runs on every destroy() in the base class.
+    """
+
+    def setUp(self):
+        cache.clear()
+        User = get_user_model()
+        self.user = User.objects.create_user(
+            username='testuser_other_lookup', password='testpass'
+        )
+        coord_group, _ = ADGroup.objects.get_or_create(
+            name='sg_kymp_sso_io_koordinaattorit',
+            defaults={'display_name': 'Coordinators'},
+        )
+        self.user.ad_groups.add(coord_group)
+        self.client.force_login(self.user)
+
+        self.programmer = ProjectProgrammer.objects.create(
+            firstName='Other', lastName='Programmer'
+        )
+        self.proj_class = ProjectClass.objects.create(
+            name='Other Class', path='OtherClass', defaultProgrammer=self.programmer
+        )
+
+    def test_delete_project_phase_nulls_suspended_from_phase_reference(self):
+        """Deleting a ProjectPhase referenced by Project.suspendedFromPhase
+        (an FK NOT covered by ProjectPhaseViewSet.project_field='phase')
+        used to deferred-FK-fail at COMMIT. ``_clear_other_reverse_fks``
+        now NULLs it automatically.
+        """
+        phase_active, _ = ProjectPhase.objects.get_or_create(value='planning')
+        phase_to_delete = ProjectPhase.objects.create(value='temp_phase_to_delete')
+
+        project = Project.objects.create(
+            name='suspended-project',
+            description='Test',
+            projectClass=self.proj_class,
+            phase=phase_active,
+            suspendedFromPhase=phase_to_delete,
+            personProgramming=self.programmer,
+        )
+
+        response = self.client.delete(f'/project-phases/{phase_to_delete.id}/')
+
+        self.assertEqual(response.status_code, 204)
+        self.assertFalse(ProjectPhase.objects.filter(id=phase_to_delete.id).exists())
+        project.refresh_from_db()
+        self.assertIsNone(project.suspendedFromPhase)
+        self.assertEqual(project.phase, phase_active)
+
+    def test_delete_project_phase_nulls_projectset_phase_reference(self):
+        """ProjectSet.phase is a nullable FK to ProjectPhase outside
+        ``project_field`` — should be auto-NULLed on phase delete."""
+        phase_to_delete = ProjectPhase.objects.create(value='temp_set_phase')
+
+        pset = ProjectSet.objects.create(
+            name='set-with-phase', description='', phase=phase_to_delete,
+        )
+
+        response = self.client.delete(f'/project-phases/{phase_to_delete.id}/')
+
+        self.assertEqual(response.status_code, 204)
+        pset.refresh_from_db()
+        self.assertIsNone(pset.phase)
+
+
+@override_settings(CACHES=LOCMEM_CACHE)
+class CachedLookupOrmInvalidationTest(TestCase):
+    """Regression tests for cache invalidation on direct ORM mutations.
+
+    Reported case (Slack 2026-04-27): ``ProjectProgrammer.objects.get(...).delete()``
+    in the OpenShift Django shell removed the row from the DB but the prod
+    list endpoint kept returning it for ~12 h until the cache TTL expired.
+    Root cause: only ``CachedLookupViewSet.destroy()`` invalidated the cache;
+    direct ORM ``.delete()`` bypassed it. Now wired via post_save/post_delete
+    signals connected at app ready, deferred to ``transaction.on_commit``
+    so a concurrent reader can't repopulate the cache from an uncommitted
+    snapshot.
+    """
+
+    def setUp(self):
+        cache.clear()
+
+    def _populate_lookup_cache(self, model_name, payload):
+        CacheService.set_lookup(model_name, payload)
+        self.assertEqual(CacheService.get_lookup(model_name), payload)
+
+    def test_orm_save_invalidates_lookup_cache(self):
+        self._populate_lookup_cache('ProjectProgrammer', [{'stale': True}])
+
+        with self.captureOnCommitCallbacks(execute=True):
+            ProjectProgrammer.objects.create(firstName='New', lastName='Programmer')
+
+        self.assertIsNone(CacheService.get_lookup('ProjectProgrammer'))
+
+    def test_orm_delete_invalidates_lookup_cache(self):
+        """The exact scenario Sari hit: shell-driven delete should drop cache."""
+        programmer = ProjectProgrammer.objects.create(
+            firstName='Going', lastName='Away'
+        )
+        self._populate_lookup_cache('ProjectProgrammer', [{'stale': True}])
+
+        with self.captureOnCommitCallbacks(execute=True):
+            programmer.delete()
+
+        self.assertIsNone(CacheService.get_lookup('ProjectProgrammer'))
+
+    def test_orm_save_invalidates_person_lookup_cache(self):
+        """Same wiring covers Person (and every other CachedLookupViewSet model)."""
+        person = Person.objects.create(
+            firstName='ORM', lastName='Person', email='orm@example.com',
+        )
+        self._populate_lookup_cache('Person', [{'stale': True}])
+
+        with self.captureOnCommitCallbacks(execute=True):
+            person.firstName = 'Renamed'
+            person.save()
+
+        self.assertIsNone(CacheService.get_lookup('Person'))
+
+    def test_invalidation_deferred_until_transaction_commits(self):
+        """If a transaction rolls back, the cache must NOT be invalidated.
+
+        Without the on_commit guard, an aborted transaction would still
+        evict valid cached data, wasting the next request's read on a DB
+        round-trip for no reason.
+        """
+        self._populate_lookup_cache('ProjectProgrammer', [{'still': 'valid'}])
+
+        with self.captureOnCommitCallbacks(execute=False) as callbacks:
+            ProjectProgrammer.objects.create(firstName='Rolled', lastName='Back')
+
+        self.assertEqual(len(callbacks), 1, 'invalidation should be queued, not run')
+        self.assertEqual(
+            CacheService.get_lookup('ProjectProgrammer'),
+            [{'still': 'valid'}],
+            'cache must remain populated until transaction commits',
         )
 
 

--- a/infraohjelmointi_api/views/CachedLookupViewSet.py
+++ b/infraohjelmointi_api/views/CachedLookupViewSet.py
@@ -130,19 +130,19 @@ class CachedLookupViewSet(BaseViewSet):
         instance = self.get_object()
         fields = self._project_field_names()
 
-        if fields:
-            model = self.get_queryset().model
-            snapshot = self._snapshot_fields(instance)
-            ids_to_preserve_by_field = {
-                field: list(Project.objects.filter(
-                    **{field: instance},
-                    phase__value__in=self.PRESERVED_PHASES,
-                ).values_list('id', flat=True))
-                for field in fields
-            }
-            any_to_preserve = any(ids_to_preserve_by_field.values())
+        with transaction.atomic():
+            if fields:
+                model = self.get_queryset().model
+                snapshot = self._snapshot_fields(instance)
+                ids_to_preserve_by_field = {
+                    field: list(Project.objects.filter(
+                        **{field: instance},
+                        phase__value__in=self.PRESERVED_PHASES,
+                    ).values_list('id', flat=True))
+                    for field in fields
+                }
+                any_to_preserve = any(ids_to_preserve_by_field.values())
 
-            with transaction.atomic():
                 preserved_copy = (
                     model.objects.create(**snapshot, deleted=True)
                     if any_to_preserve else None
@@ -156,11 +156,49 @@ class CachedLookupViewSet(BaseViewSet):
                         id__in=preserve_ids
                     ).update(**{field: None})
 
-        response = super().destroy(request, *args, **kwargs)
+            # NULL out any other nullable reverse FKs to this instance
+            # (e.g. Task.person, ProjectLock.lockedBy). Without this, deferred
+            # FK constraints would reject the delete at commit time.
+            self._clear_other_reverse_fks(instance, skip_fields=set(fields))
+
+            response = super().destroy(request, *args, **kwargs)
 
         if response.status_code == 204:
             CacheService.invalidate_lookup(self.get_cache_key_name())
         return response
+
+    def _clear_other_reverse_fks(self, instance, skip_fields):
+        """NULL out reverse FK references not handled by the project_field
+        preservation logic.
+
+        Walks reverse one-to-many and one-to-one relations to this lookup
+        model. For each nullable FK on a related model that points to
+        ``instance``, runs an UPDATE that sets the FK to NULL. This prevents
+        deferred FK constraint violations at commit time when the instance
+        is deleted (Django's default FK constraints in PostgreSQL are
+        DEFERRABLE INITIALLY DEFERRED, so a stray reference is only caught
+        at COMMIT, manifesting as a 500 from `_commit`).
+
+        Skipped:
+        - many-to-many relations (Django auto-cleans the through-table).
+        - Project FKs in ``skip_fields`` (handled above with hidden-copy
+          preservation for completed/warranty projects).
+        - non-nullable FKs (no safe generic policy; the underlying delete
+          will surface a clear FK violation if such a reference exists).
+        """
+        model = type(instance)
+        for relation in model._meta.get_fields():
+            if not (relation.one_to_many or relation.one_to_one):
+                continue
+            fk_field = relation.field
+            if not fk_field.null:
+                continue
+            related_model = relation.related_model
+            if related_model is Project and fk_field.name in skip_fields:
+                continue
+            related_model._default_manager.filter(
+                **{fk_field.name: instance}
+            ).update(**{fk_field.name: None})
 
     @action(detail=False, methods=["put"], url_path="reorder")
     def reorder(self, request):

--- a/infraohjelmointi_api/views/CachedLookupViewSet.py
+++ b/infraohjelmointi_api/views/CachedLookupViewSet.py
@@ -40,13 +40,13 @@ class CachedLookupViewSet(BaseViewSet):
             queryset = queryset.exclude(deleted=True)
         return queryset
 
-    def _project_field_names(self) -> tuple:
-        """Normalize project_field (str | iterable | None) to a tuple of field names."""
+    def _project_field_names(self) -> list:
+        """Normalize project_field (str | iterable | None) to a list of field names."""
         if not self.project_field:
-            return ()
+            return []
         if isinstance(self.project_field, str):
-            return (self.project_field,)
-        return tuple(self.project_field)
+            return [self.project_field]
+        return list(self.project_field)
 
     def _snapshot_fields(self, instance) -> dict:
         return {field: getattr(instance, field) for field in self.preserved_fields}
@@ -94,7 +94,15 @@ class CachedLookupViewSet(BaseViewSet):
         return old_snapshot, ids_by_field
 
     def _apply_preservation(self, instance, old_snapshot, ids_by_field):
-        """Create a hidden copy with old field values and repoint completed projects to it."""
+        """Create a hidden copy with old field values and repoint completed projects to it.
+
+        Assumes ``preserved_fields`` are not part of any unique constraint on
+        the model — otherwise the hidden copy will fail to insert. Holds for
+        Person and the simple ``['value']`` lookups; ``ProjectProgrammer`` has
+        ``unique_together=[['firstName', 'lastName']]`` and would clash here
+        on rename, but in practice rename of a ProjectProgrammer is gated by
+        the unique check at validation time.
+        """
         if not ids_by_field or not any(ids_by_field.values()):
             return
         instance.refresh_from_db()
@@ -185,6 +193,11 @@ class CachedLookupViewSet(BaseViewSet):
           preservation for completed/warranty projects).
         - non-nullable FKs (no safe generic policy; the underlying delete
           will surface a clear FK violation if such a reference exists).
+
+        Note: this runs for every CachedLookupViewSet subclass, not only
+        Person. For other lookups (ProjectPhase, etc.) this means stray
+        references on nullable FKs that previously surfaced as deferred FK
+        violations at COMMIT (HTTP 500) are now silently NULLed instead.
         """
         model = type(instance)
         for relation in model._meta.get_fields():

--- a/infraohjelmointi_api/views/CachedLookupViewSet.py
+++ b/infraohjelmointi_api/views/CachedLookupViewSet.py
@@ -13,13 +13,17 @@ class CachedLookupViewSet(BaseViewSet):
     """ViewSet that caches list() responses for lookup tables.
 
     Supports three model shapes via the `preserved_fields` class attribute.
-    When a project_field is set and a referenced item is updated or deleted,
+    When project_field is set and a referenced item is updated or deleted,
     a hidden copy of the old item is created for completed/warranty projects.
 
     Model shapes:
         ['value']                                  — simple lookup (default)
         ['firstName', 'lastName']                  — project programmer model
         ['firstName', 'lastName', 'email', 'phone', 'title']  — person model
+
+    project_field can be either a single string (one Project FK referencing
+    this lookup) or an iterable of strings (multiple FKs, e.g. Person is
+    referenced by both `personPlanning` and `personConstruction`).
     """
 
     preserved_fields = ['value']
@@ -35,6 +39,14 @@ class CachedLookupViewSet(BaseViewSet):
         if hasattr(model, "deleted"):
             queryset = queryset.exclude(deleted=True)
         return queryset
+
+    def _project_field_names(self) -> tuple:
+        """Normalize project_field (str | iterable | None) to a tuple of field names."""
+        if not self.project_field:
+            return ()
+        if isinstance(self.project_field, str):
+            return (self.project_field,)
+        return tuple(self.project_field)
 
     def _snapshot_fields(self, instance) -> dict:
         return {field: getattr(instance, field) for field in self.preserved_fields}
@@ -63,68 +75,86 @@ class CachedLookupViewSet(BaseViewSet):
         return response
 
     def _preserve_for_completed_projects(self, instance):
-        """Return (old_snapshot, completed_project_ids) if project_field is set, else (None, [])."""
-        if not self.project_field:
-            return None, []
-        old_snapshot = self._snapshot_fields(instance)
-        completed_project_ids = list(Project.objects.filter(
-            **{self.project_field: instance},
-            phase__value__in=self.PRESERVED_PHASES
-        ).values_list('id', flat=True))
-        return old_snapshot, completed_project_ids
+        """Return (old_snapshot, ids_by_field) if project_field is set, else (None, {}).
 
-    def _apply_preservation(self, instance, old_snapshot, completed_project_ids):
+        ids_by_field maps each FK field name to the list of completed/warranty
+        project IDs that reference this instance via that field.
+        """
+        fields = self._project_field_names()
+        if not fields:
+            return None, {}
+        old_snapshot = self._snapshot_fields(instance)
+        ids_by_field = {
+            field: list(Project.objects.filter(
+                **{field: instance},
+                phase__value__in=self.PRESERVED_PHASES,
+            ).values_list('id', flat=True))
+            for field in fields
+        }
+        return old_snapshot, ids_by_field
+
+    def _apply_preservation(self, instance, old_snapshot, ids_by_field):
         """Create a hidden copy with old field values and repoint completed projects to it."""
-        if not (self.project_field and completed_project_ids):
+        if not ids_by_field or not any(ids_by_field.values()):
             return
         instance.refresh_from_db()
-        if self._has_changed(old_snapshot, instance):
-            model = self.get_queryset().model
-            new_item = model.objects.create(**old_snapshot, deleted=True)
-            Project.objects.filter(id__in=completed_project_ids).update(
-                **{self.project_field: new_item}
-            )
+        if not self._has_changed(old_snapshot, instance):
+            return
+        model = self.get_queryset().model
+        new_item = model.objects.create(**old_snapshot, deleted=True)
+        for field, project_ids in ids_by_field.items():
+            if project_ids:
+                Project.objects.filter(id__in=project_ids).update(**{field: new_item})
 
     def update(self, request, *args, **kwargs):
-        old_snapshot, completed_project_ids = self._preserve_for_completed_projects(
+        old_snapshot, ids_by_field = self._preserve_for_completed_projects(
             self.get_object()
         )
         response = super().update(request, *args, **kwargs)
         if response.status_code == 200:
-            self._apply_preservation(self.get_object(), old_snapshot, completed_project_ids)
+            self._apply_preservation(self.get_object(), old_snapshot, ids_by_field)
             CacheService.invalidate_lookup(self.get_cache_key_name())
         return response
 
     def partial_update(self, request, *args, **kwargs):
-        old_snapshot, completed_project_ids = self._preserve_for_completed_projects(
+        old_snapshot, ids_by_field = self._preserve_for_completed_projects(
             self.get_object()
         )
         response = super().partial_update(request, *args, **kwargs)
         if response.status_code == 200:
-            self._apply_preservation(self.get_object(), old_snapshot, completed_project_ids)
+            self._apply_preservation(self.get_object(), old_snapshot, ids_by_field)
             CacheService.invalidate_lookup(self.get_cache_key_name())
         return response
 
     def destroy(self, request, *args, **kwargs):
         instance = self.get_object()
+        fields = self._project_field_names()
 
-        if self.project_field:
+        if fields:
             model = self.get_queryset().model
             snapshot = self._snapshot_fields(instance)
-            project_ids_to_preserve = list(Project.objects.filter(
-                **{self.project_field: instance},
-                phase__value__in=self.PRESERVED_PHASES
-            ).values_list('id', flat=True))
+            ids_to_preserve_by_field = {
+                field: list(Project.objects.filter(
+                    **{field: instance},
+                    phase__value__in=self.PRESERVED_PHASES,
+                ).values_list('id', flat=True))
+                for field in fields
+            }
+            any_to_preserve = any(ids_to_preserve_by_field.values())
 
             with transaction.atomic():
-                if project_ids_to_preserve:
-                    new_item = model.objects.create(**snapshot, deleted=True)
-                    Project.objects.filter(
-                        id__in=project_ids_to_preserve
-                    ).update(**{self.project_field: new_item})
-                Project.objects.filter(
-                    **{self.project_field: instance}
-                ).exclude(id__in=project_ids_to_preserve).update(**{self.project_field: None})
+                preserved_copy = (
+                    model.objects.create(**snapshot, deleted=True)
+                    if any_to_preserve else None
+                )
+                for field, preserve_ids in ids_to_preserve_by_field.items():
+                    if preserve_ids:
+                        Project.objects.filter(id__in=preserve_ids).update(
+                            **{field: preserved_copy}
+                        )
+                    Project.objects.filter(**{field: instance}).exclude(
+                        id__in=preserve_ids
+                    ).update(**{field: None})
 
         response = super().destroy(request, *args, **kwargs)
 

--- a/infraohjelmointi_api/views/PersonViewSet.py
+++ b/infraohjelmointi_api/views/PersonViewSet.py
@@ -9,3 +9,8 @@ class PersonViewSet(CachedLookupViewSet):
 
     serializer_class = PersonSerializer
     preserved_fields = ['firstName', 'lastName', 'email', 'phone', 'title']
+    # Person is referenced by Project via two FK fields. Both must be cleaned
+    # up (or repointed to a hidden copy for completed/warranty projects) on
+    # delete; otherwise Postgres rejects the delete with a FK violation.
+    # M2M fields (otherPersons, favPersons) are auto-cleaned by Django.
+    project_field = ('personPlanning', 'personConstruction')


### PR DESCRIPTION
* CachedLookupViewSet.project_field now accepts a tuple of FK names so lookups referenced by multiple Project FKs (Person via personPlanning and personConstruction) get all references cleared/preserved on delete
* PersonViewSet declares both FKs & fixes 500 ForeignKeyViolation on DELETE /persons/<id>/ from the new responsible-persons admin UI