### PR TITLE
IO-841 Add management command to find and zero ghost budget rows

### DIFF
--- a/infraohjelmointi_api/management/commands/find_out_of_schedule_finances.py
+++ b/infraohjelmointi_api/management/commands/find_out_of_schedule_finances.py
@@ -9,6 +9,7 @@ that the cache-invalidation and event-stream signals defined in
 ``signals.py`` fire correctly.
 """
 
+import argparse
 import csv
 import logging
 from dataclasses import dataclass, field
@@ -94,8 +95,13 @@ def _resolve_schedule(project: Project) -> Schedule:
     )
 
 
-def _is_nonzero(value: Decimal | None) -> bool:
-    return value is not None and value != 0
+def _positive_int(value: str) -> int:
+    ivalue = int(value)
+    if ivalue < 1:
+        raise argparse.ArgumentTypeError(
+            f"--limit must be a positive integer (got {ivalue})"
+        )
+    return ivalue
 
 
 class Command(BaseCommand):
@@ -133,9 +139,9 @@ class Command(BaseCommand):
         )
         parser.add_argument(
             "--limit",
-            type=int,
+            type=_positive_int,
             default=None,
-            help="Process at most N projects (development aid).",
+            help="Process at most N projects (development aid). Must be >= 1.",
         )
 
     def handle(self, *args, **options):

--- a/infraohjelmointi_api/management/commands/find_out_of_schedule_finances.py
+++ b/infraohjelmointi_api/management/commands/find_out_of_schedule_finances.py
@@ -1,0 +1,317 @@
+"""Find (and optionally zero) ProjectFinancial rows whose year falls
+outside the project's planning and construction schedule — the data
+artefacts known internally as "haamuluvut" (ghost numbers). See
+``tickets/IO-841.md`` for full background and design notes.
+
+Default mode is dry-run: the command prints a CSV report and never writes.
+With ``--apply`` it zeroes the offending rows in place via ``save()`` so
+that the cache-invalidation and event-stream signals defined in
+``signals.py`` fire correctly.
+"""
+
+import csv
+import logging
+from dataclasses import dataclass, field
+from decimal import Decimal
+from typing import Iterable
+
+from django.core.management.base import BaseCommand
+from django.db import transaction
+from django.db.models import Q
+
+from infraohjelmointi_api.models import Project, ProjectFinancial
+
+
+logger = logging.getLogger("infraohjelmointi_api")
+
+
+CSV_HEADER = [
+    "projectId",
+    "projectName",
+    "hkrId",
+    "sapProject",
+    "programmed",
+    "phase",
+    "planningStartYear",
+    "estPlanningEnd",
+    "estConstructionStart",
+    "constructionEndYear",
+    "forFrameView",
+    "year",
+    "value",
+    "action",
+]
+
+
+@dataclass(frozen=True)
+class Schedule:
+    """Resolved planning + construction year range for a project.
+
+    A range with ``start > end`` is treated as empty so that data with
+    inverted dates (e.g. ``estPlanningEnd < planningStartYear``) does not
+    silently mark every year as in-schedule.
+    """
+
+    planning_start: int | None
+    planning_end: int | None
+    construction_start: int | None
+    construction_end: int | None
+
+    @property
+    def is_complete(self) -> bool:
+        return all(
+            v is not None
+            for v in (
+                self.planning_start,
+                self.planning_end,
+                self.construction_start,
+                self.construction_end,
+            )
+        )
+
+    def contains(self, year: int) -> bool:
+        in_planning = (
+            self.planning_start is not None
+            and self.planning_end is not None
+            and self.planning_start <= year <= self.planning_end
+        )
+        in_construction = (
+            self.construction_start is not None
+            and self.construction_end is not None
+            and self.construction_start <= year <= self.construction_end
+        )
+        return in_planning or in_construction
+
+
+def _resolve_schedule(project: Project) -> Schedule:
+    return Schedule(
+        planning_start=project.planningStartYear,
+        planning_end=project.estPlanningEnd.year if project.estPlanningEnd else None,
+        construction_start=(
+            project.estConstructionStart.year if project.estConstructionStart else None
+        ),
+        construction_end=project.constructionEndYear,
+    )
+
+
+def _is_nonzero(value: Decimal | None) -> bool:
+    return value is not None and value != 0
+
+
+class Command(BaseCommand):
+    help = (
+        "Find ProjectFinancial rows whose year is outside the project's "
+        "planning/construction schedule (haamuluvut, IO-841). "
+        "Dry-run by default; pass --apply to zero the rows."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--apply",
+            action="store_true",
+            default=False,
+            help=(
+                "Zero the offending rows in the database. Without this "
+                "flag, the command only reports what it would do."
+            ),
+        )
+        parser.add_argument(
+            "--include-frame-view",
+            action="store_true",
+            default=False,
+            help=(
+                "Also process ProjectFinancial rows with forFrameView=True. "
+                "Default is forFrameView=False only, matching the scope of "
+                "IO-826's prevention fix."
+            ),
+        )
+        parser.add_argument(
+            "--quiet",
+            action="store_true",
+            default=False,
+            help="Suppress the CSV header and the summary log lines.",
+        )
+        parser.add_argument(
+            "--limit",
+            type=int,
+            default=None,
+            help="Process at most N projects (development aid).",
+        )
+
+    def handle(self, *args, **options):
+        apply_changes: bool = options["apply"]
+        include_frame_view: bool = options["include_frame_view"]
+        quiet: bool = options["quiet"]
+        limit: int | None = options["limit"]
+
+        for_frame_view_values: tuple[bool, ...] = (
+            (False, True) if include_frame_view else (False,)
+        )
+
+        writer = csv.writer(self.stdout)
+        if not quiet:
+            writer.writerow(CSV_HEADER)
+
+        projects_qs = Project.objects.all().order_by("id")
+        if limit is not None:
+            projects_qs = projects_qs[:limit]
+
+        report = _Report()
+
+        for project in projects_qs.iterator():
+            schedule = _resolve_schedule(project)
+
+            if not schedule.is_complete:
+                self._emit_skip_row(writer, project, schedule)
+                report.skipped_projects += 1
+                continue
+
+            self._process_project(
+                project=project,
+                schedule=schedule,
+                for_frame_view_values=for_frame_view_values,
+                apply_changes=apply_changes,
+                writer=writer,
+                report=report,
+            )
+
+        if not quiet:
+            self._log_summary(report=report, apply_changes=apply_changes)
+
+    def _process_project(
+        self,
+        *,
+        project: Project,
+        schedule: Schedule,
+        for_frame_view_values: tuple[bool, ...],
+        apply_changes: bool,
+        writer,
+        report: "_Report",
+    ) -> None:
+        candidates = (
+            ProjectFinancial.objects.filter(
+                project=project,
+                forFrameView__in=for_frame_view_values,
+            )
+            .filter(Q(value__gt=0) | Q(value__lt=0))
+            .order_by("year", "forFrameView")
+        )
+
+        haamuluvut = [c for c in candidates if not schedule.contains(c.year)]
+        if not haamuluvut:
+            return
+
+        # Snapshot the original values BEFORE we (potentially) zero them so the
+        # CSV row and the summary report show what was destroyed, not zero.
+        original_values = [row.value or Decimal("0") for row in haamuluvut]
+
+        if apply_changes:
+            self._zero_in_transaction(project=project, rows=haamuluvut)
+
+        for row, original_value in zip(haamuluvut, original_values):
+            self._emit_row(
+                writer=writer,
+                project=project,
+                schedule=schedule,
+                fin=row,
+                value=original_value,
+                action="zeroed" if apply_changes else "would_zero",
+            )
+            report.haamulukuja += 1
+            report.total_value += original_value
+            report.affected_project_ids.add(project.id)
+
+    @staticmethod
+    def _zero_in_transaction(
+        *, project: Project, rows: Iterable[ProjectFinancial]
+    ) -> None:
+        with transaction.atomic():
+            for row in rows:
+                row.value = Decimal("0")
+                row.save(update_fields=["value", "updatedDate"])
+
+    @staticmethod
+    def _emit_row(
+        *,
+        writer,
+        project: Project,
+        schedule: Schedule,
+        fin: ProjectFinancial,
+        value: Decimal,
+        action: str,
+    ) -> None:
+        writer.writerow(
+            [
+                project.id,
+                project.name,
+                project.hkrId or "",
+                project.sapProject or "",
+                project.programmed,
+                project.phase.value if project.phase else "",
+                schedule.planning_start if schedule.planning_start is not None else "",
+                project.estPlanningEnd.isoformat() if project.estPlanningEnd else "",
+                (
+                    project.estConstructionStart.isoformat()
+                    if project.estConstructionStart
+                    else ""
+                ),
+                (
+                    schedule.construction_end
+                    if schedule.construction_end is not None
+                    else ""
+                ),
+                fin.forFrameView,
+                fin.year,
+                value,
+                action,
+            ]
+        )
+
+    @staticmethod
+    def _emit_skip_row(writer, project: Project, schedule: Schedule) -> None:
+        writer.writerow(
+            [
+                project.id,
+                project.name,
+                project.hkrId or "",
+                project.sapProject or "",
+                project.programmed,
+                project.phase.value if project.phase else "",
+                schedule.planning_start if schedule.planning_start is not None else "",
+                project.estPlanningEnd.isoformat() if project.estPlanningEnd else "",
+                (
+                    project.estConstructionStart.isoformat()
+                    if project.estConstructionStart
+                    else ""
+                ),
+                (
+                    schedule.construction_end
+                    if schedule.construction_end is not None
+                    else ""
+                ),
+                "",
+                "",
+                "",
+                "skipped_no_schedule",
+            ]
+        )
+
+    def _log_summary(self, *, report: "_Report", apply_changes: bool) -> None:
+        verb = "Zeroed" if apply_changes else "Would zero"
+        message = (
+            f"{verb} {report.haamulukuja} haamulukua "
+            f"totaling {report.total_value} € across "
+            f"{len(report.affected_project_ids)} project(s); "
+            f"skipped {report.skipped_projects} project(s) with incomplete schedule."
+        )
+        logger.info(message)
+        # stderr so the CSV on stdout stays machine-readable
+        self.stderr.write(message)
+
+
+@dataclass
+class _Report:
+    haamulukuja: int = 0
+    total_value: Decimal = Decimal("0")
+    skipped_projects: int = 0
+    affected_project_ids: set = field(default_factory=set)

--- a/infraohjelmointi_api/tests/__init__.py
+++ b/infraohjelmointi_api/tests/__init__.py
@@ -3,3 +3,4 @@ from .test_Notes import NoteTestCase
 from .management.commands.test_managehierarchies import ManageHierarchiesCommandTestCase
 from .management.commands.test_responsiblepersons import ResponsiblePersonsCommandTestCase
 from .management.commands.test_programmerimporter import ProgrammerImporterCommandTestCase
+from .management.commands.test_find_out_of_schedule_finances import FindOutOfScheduleFinancesTestCase

--- a/infraohjelmointi_api/tests/management/commands/test_find_out_of_schedule_finances.py
+++ b/infraohjelmointi_api/tests/management/commands/test_find_out_of_schedule_finances.py
@@ -11,6 +11,7 @@ from decimal import Decimal
 from io import StringIO
 
 from django.core.management import call_command
+from django.core.management.base import CommandError
 from django.test import TestCase
 
 from infraohjelmointi_api.models import Project, ProjectFinancial
@@ -210,6 +211,12 @@ class FindOutOfScheduleFinancesTestCase(TestCase):
             line for line in output.splitlines() if "would_zero" in line
         ]
         self.assertEqual(len(haamuluku_lines), 1)
+
+    def test_non_positive_limit_is_rejected(self) -> None:
+        for value in ("0", "-1"):
+            with self.subTest(value=value):
+                with self.assertRaises(CommandError):
+                    _run("--limit", value)
 
     def test_summary_log_line_emitted_to_stderr(self) -> None:
         project = _create_project()

--- a/infraohjelmointi_api/tests/management/commands/test_find_out_of_schedule_finances.py
+++ b/infraohjelmointi_api/tests/management/commands/test_find_out_of_schedule_finances.py
@@ -1,0 +1,234 @@
+"""Tests for the IO-841 ``find_out_of_schedule_finances`` management command.
+
+Each test sets up a single ``Project`` (or two) with a controlled
+schedule and a handful of ``ProjectFinancial`` rows, then runs the
+command in either dry-run or ``--apply`` mode and asserts on stdout
+(the CSV report) and on the database.
+"""
+
+from datetime import date
+from decimal import Decimal
+from io import StringIO
+
+from django.core.management import call_command
+from django.test import TestCase
+
+from infraohjelmointi_api.models import Project, ProjectFinancial
+
+
+def _create_project(
+    *,
+    name: str = "Test project",
+    planning_start_year: int | None = 2024,
+    est_planning_end: date | None = date(2025, 6, 30),
+    est_construction_start: date | None = date(2026, 1, 1),
+    construction_end_year: int | None = 2028,
+) -> Project:
+    return Project.objects.create(
+        name=name,
+        description="-",
+        planningStartYear=planning_start_year,
+        estPlanningEnd=est_planning_end,
+        estConstructionStart=est_construction_start,
+        constructionEndYear=construction_end_year,
+    )
+
+
+def _create_finance(
+    project: Project,
+    *,
+    year: int,
+    value: str | Decimal,
+    for_frame_view: bool = False,
+) -> ProjectFinancial:
+    return ProjectFinancial.objects.create(
+        project=project,
+        year=year,
+        value=Decimal(value),
+        forFrameView=for_frame_view,
+    )
+
+
+def _run(*args: str) -> str:
+    out = StringIO()
+    err = StringIO()
+    call_command("find_out_of_schedule_finances", *args, stdout=out, stderr=err)
+    return out.getvalue()
+
+
+class FindOutOfScheduleFinancesTestCase(TestCase):
+    """The schedule for these tests is planning 2024-2025 + construction 2026-2028.
+
+    That means in-schedule years are {2024, 2025, 2026, 2027, 2028} and
+    everything else (e.g. 2023, 2029, 2030, …) is a haamuluku candidate.
+    """
+
+    def test_in_schedule_years_are_left_alone(self) -> None:
+        project = _create_project()
+        for year in (2024, 2025, 2026, 2027, 2028):
+            _create_finance(project, year=year, value="100.00")
+
+        output = _run()
+
+        self.assertNotIn("would_zero", output)
+        self.assertNotIn("zeroed", output)
+        for fin in ProjectFinancial.objects.filter(project=project):
+            self.assertEqual(fin.value, Decimal("100.00"))
+
+    def test_dry_run_reports_haamuluku_without_writing(self) -> None:
+        project = _create_project()
+        haamu = _create_finance(project, year=2030, value="2000.00")
+        keep = _create_finance(project, year=2025, value="500.00")
+
+        output = _run()
+
+        self.assertIn("would_zero", output)
+        self.assertIn(str(project.id), output)
+        self.assertIn("2030", output)
+        haamu.refresh_from_db()
+        keep.refresh_from_db()
+        self.assertEqual(haamu.value, Decimal("2000.00"))
+        self.assertEqual(keep.value, Decimal("500.00"))
+
+    def test_apply_zeroes_only_haamuluvut(self) -> None:
+        project = _create_project()
+        haamu = _create_finance(project, year=2030, value="2000.00")
+        keep = _create_finance(project, year=2025, value="500.00")
+
+        output = _run("--apply")
+
+        self.assertIn("zeroed", output)
+        haamu.refresh_from_db()
+        keep.refresh_from_db()
+        self.assertEqual(haamu.value, Decimal("0"))
+        self.assertEqual(keep.value, Decimal("500.00"))
+
+    def test_negative_values_are_treated_as_haamulukuja(self) -> None:
+        project = _create_project()
+        haamu = _create_finance(project, year=2030, value="-50.00")
+
+        _run("--apply")
+
+        haamu.refresh_from_db()
+        self.assertEqual(haamu.value, Decimal("0"))
+
+    def test_zero_valued_rows_are_not_touched(self) -> None:
+        project = _create_project()
+        zero = _create_finance(project, year=2030, value="0.00")
+
+        output = _run("--apply")
+
+        self.assertNotIn("would_zero", output)
+        self.assertNotIn("zeroed", output)
+        zero.refresh_from_db()
+        self.assertEqual(zero.value, Decimal("0.00"))
+
+    def test_overlapping_planning_and_construction_keeps_overlap_year(self) -> None:
+        project = _create_project(
+            est_planning_end=date(2026, 6, 30),
+            est_construction_start=date(2026, 1, 1),
+        )
+        overlap = _create_finance(project, year=2026, value="999.00")
+
+        _run("--apply")
+
+        overlap.refresh_from_db()
+        self.assertEqual(overlap.value, Decimal("999.00"))
+
+    def test_inverted_planning_dates_treat_planning_phase_as_empty(self) -> None:
+        project = _create_project(
+            planning_start_year=2025,
+            est_planning_end=date(2024, 6, 30),
+        )
+        in_construction = _create_finance(project, year=2027, value="100.00")
+        haamu_in_inverted_planning = _create_finance(
+            project, year=2024, value="50.00"
+        )
+
+        _run("--apply")
+
+        in_construction.refresh_from_db()
+        haamu_in_inverted_planning.refresh_from_db()
+        self.assertEqual(in_construction.value, Decimal("100.00"))
+        self.assertEqual(haamu_in_inverted_planning.value, Decimal("0"))
+
+    def test_project_with_null_schedule_field_is_skipped(self) -> None:
+        project = _create_project(est_planning_end=None)
+        suspect = _create_finance(project, year=2030, value="2000.00")
+
+        output = _run("--apply")
+
+        self.assertIn("skipped_no_schedule", output)
+        suspect.refresh_from_db()
+        self.assertEqual(suspect.value, Decimal("2000.00"))
+
+    def test_frame_view_row_is_not_touched_by_default(self) -> None:
+        project = _create_project()
+        frame_haamu = _create_finance(
+            project, year=2030, value="123.00", for_frame_view=True
+        )
+        regular_haamu = _create_finance(project, year=2030, value="456.00")
+
+        _run("--apply")
+
+        frame_haamu.refresh_from_db()
+        regular_haamu.refresh_from_db()
+        self.assertEqual(frame_haamu.value, Decimal("123.00"))
+        self.assertEqual(regular_haamu.value, Decimal("0"))
+
+    def test_include_frame_view_flag_zeroes_both(self) -> None:
+        project = _create_project()
+        frame_haamu = _create_finance(
+            project, year=2030, value="123.00", for_frame_view=True
+        )
+        regular_haamu = _create_finance(project, year=2030, value="456.00")
+
+        _run("--apply", "--include-frame-view")
+
+        frame_haamu.refresh_from_db()
+        regular_haamu.refresh_from_db()
+        self.assertEqual(frame_haamu.value, Decimal("0"))
+        self.assertEqual(regular_haamu.value, Decimal("0"))
+
+    def test_csv_header_present_unless_quiet(self) -> None:
+        _create_project()
+
+        with_header = _run()
+        without_header = _run("--quiet")
+
+        self.assertIn("projectId", with_header.splitlines()[0])
+        self.assertNotIn("projectId", without_header)
+
+    def test_limit_caps_processed_projects(self) -> None:
+        for i in range(3):
+            project = _create_project(name=f"P{i}")
+            _create_finance(project, year=2030, value="10.00")
+
+        output = _run("--limit", "1")
+
+        haamuluku_lines = [
+            line for line in output.splitlines() if "would_zero" in line
+        ]
+        self.assertEqual(len(haamuluku_lines), 1)
+
+    def test_summary_log_line_emitted_to_stderr(self) -> None:
+        project = _create_project()
+        _create_finance(project, year=2030, value="2000.00")
+        out = StringIO()
+        err = StringIO()
+        call_command(
+            "find_out_of_schedule_finances", stdout=out, stderr=err
+        )
+
+        self.assertIn("Would zero", err.getvalue())
+        self.assertIn("haamuluk", err.getvalue())
+
+    def test_apply_updates_updated_date(self) -> None:
+        project = _create_project()
+        haamu = _create_finance(project, year=2030, value="2000.00")
+        original_updated = haamu.updatedDate
+
+        _run("--apply")
+
+        haamu.refresh_from_db()
+        self.assertGreater(haamu.updatedDate, original_updated)


### PR DESCRIPTION
* Adds find_out_of_schedule_finances command that finds ProjectFinancial rows with a non-zero value in a year that falls outside the project's planning and construction schedule (haamuluvut)
* Dry-run by default, pass --apply to actually zero the rows
* Uses instance.save() inside per-project atomic transactions so existing cache-invalidation and event-stream signals fire correctly