### PR TITLE
IO-865 Show stable error code when PW project is missing

### DIFF
--- a/infraohjelmointi_api/management/commands/find_pw_orphans.py
+++ b/infraohjelmointi_api/management/commands/find_pw_orphans.py
@@ -1,0 +1,84 @@
+"""IO-865: list programmed projects whose hkrId is missing from ProjectWise.
+
+CSV columns on stdout: id,name,hkrId,reason
+Reason is "not_found" or "pw_response_error".
+Exit code 1 if any orphans were found (so it can drive periodic alerts).
+"""
+
+import csv
+import logging
+import sys
+
+from django.core.management.base import BaseCommand
+
+from infraohjelmointi_api.models import Project
+from infraohjelmointi_api.services import ProjectWiseService
+from infraohjelmointi_api.services.ProjectWiseService import (
+    PWProjectNotFoundError,
+    PWProjectResponseError,
+)
+
+logger = logging.getLogger("infraohjelmointi_api")
+
+
+class Command(BaseCommand):
+    help = (
+        "List programmed projects whose hkrId is missing from ProjectWise "
+        "(IO-851)."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--limit",
+            type=int,
+            default=None,
+            help="Only check the first N candidate projects.",
+        )
+
+    def handle(self, *args, **options):
+        limit = options.get("limit")
+
+        candidates = (
+            Project.objects.filter(programmed=True)
+            .exclude(hkrId__isnull=True)
+            .order_by("name")
+        )
+        if limit is not None:
+            candidates = candidates[:limit]
+
+        pw_service = ProjectWiseService()
+
+        writer = csv.writer(self.stdout)
+        writer.writerow(["id", "name", "hkrId", "reason"])
+
+        ok_count = 0
+        orphan_count = 0
+        error_count = 0
+
+        for project in candidates.iterator():
+            try:
+                pw_service.get_project_from_pw(project.hkrId)
+                ok_count += 1
+            except PWProjectNotFoundError:
+                orphan_count += 1
+                writer.writerow([project.id, project.name, project.hkrId, "not_found"])
+            except PWProjectResponseError as exc:
+                error_count += 1
+                writer.writerow(
+                    [project.id, project.name, project.hkrId, "pw_response_error"]
+                )
+                logger.warning(
+                    "find_pw_orphans: PW response error for %s (HKR %s): %s",
+                    project.name,
+                    project.hkrId,
+                    exc,
+                )
+
+        summary = (
+            f"# checked={ok_count + orphan_count + error_count} "
+            f"ok={ok_count} orphans={orphan_count} pw_errors={error_count}"
+        )
+        self.stderr.write(summary)
+
+        if orphan_count > 0:
+            sys.exit(1)

--- a/infraohjelmointi_api/management/commands/find_pw_orphans.py
+++ b/infraohjelmointi_api/management/commands/find_pw_orphans.py
@@ -2,9 +2,19 @@
 
 CSV columns on stdout: id,name,hkrId,reason
 Reason is "not_found" or "pw_response_error".
-Exit code 1 if any orphans were found (so it can drive periodic alerts).
+
+Exit code is a bitmask so monitoring can tell a data issue from a PW outage:
+
+  0  clean
+  1  one or more orphans found (data action needed)
+  2  one or more PW response errors (PW outage / infra alert)
+  3  both of the above
+
+Schedulers can therefore page on "exit_code & 2" for infra and on
+"exit_code & 1" for data-cleanup workflows.
 """
 
+import argparse
 import csv
 import logging
 import sys
@@ -21,18 +31,31 @@ from infraohjelmointi_api.services.ProjectWiseService import (
 logger = logging.getLogger("infraohjelmointi_api")
 
 
+EXIT_ORPHANS_FOUND = 1
+EXIT_PW_ERRORS = 2
+
+
+def _positive_int(value: str) -> int:
+    ivalue = int(value)
+    if ivalue < 1:
+        raise argparse.ArgumentTypeError(
+            f"--limit must be a positive integer (got {ivalue})"
+        )
+    return ivalue
+
+
 class Command(BaseCommand):
     help = (
         "List programmed projects whose hkrId is missing from ProjectWise "
-        "(IO-851)."
+        "(IO-865). Exit code: 1=orphans, 2=PW errors, 3=both."
     )
 
     def add_arguments(self, parser):
         parser.add_argument(
             "--limit",
-            type=int,
+            type=_positive_int,
             default=None,
-            help="Only check the first N candidate projects.",
+            help="Only check the first N candidate projects. Must be >= 1.",
         )
 
     def handle(self, *args, **options):
@@ -80,5 +103,10 @@ class Command(BaseCommand):
         )
         self.stderr.write(summary)
 
+        exit_code = 0
         if orphan_count > 0:
-            sys.exit(1)
+            exit_code |= EXIT_ORPHANS_FOUND
+        if error_count > 0:
+            exit_code |= EXIT_PW_ERRORS
+        if exit_code:
+            sys.exit(exit_code)

--- a/infraohjelmointi_api/management/commands/find_pw_orphans.py
+++ b/infraohjelmointi_api/management/commands/find_pw_orphans.py
@@ -1,0 +1,112 @@
+"""IO-865: list programmed projects whose hkrId is missing from ProjectWise.
+
+CSV columns on stdout: id,name,hkrId,reason
+Reason is "not_found" or "pw_response_error".
+
+Exit code is a bitmask so monitoring can tell a data issue from a PW outage:
+
+  0  clean
+  1  one or more orphans found (data action needed)
+  2  one or more PW response errors (PW outage / infra alert)
+  3  both of the above
+
+Schedulers can therefore page on "exit_code & 2" for infra and on
+"exit_code & 1" for data-cleanup workflows.
+"""
+
+import argparse
+import csv
+import logging
+import sys
+
+from django.core.management.base import BaseCommand
+
+from infraohjelmointi_api.models import Project
+from infraohjelmointi_api.services import ProjectWiseService
+from infraohjelmointi_api.services.ProjectWiseService import (
+    PWProjectNotFoundError,
+    PWProjectResponseError,
+)
+
+logger = logging.getLogger("infraohjelmointi_api")
+
+
+EXIT_ORPHANS_FOUND = 1
+EXIT_PW_ERRORS = 2
+
+
+def _positive_int(value: str) -> int:
+    ivalue = int(value)
+    if ivalue < 1:
+        raise argparse.ArgumentTypeError(
+            f"--limit must be a positive integer (got {ivalue})"
+        )
+    return ivalue
+
+
+class Command(BaseCommand):
+    help = (
+        "List programmed projects whose hkrId is missing from ProjectWise "
+        "(IO-865). Exit code: 1=orphans, 2=PW errors, 3=both."
+    )
+
+    def add_arguments(self, parser):
+        parser.add_argument(
+            "--limit",
+            type=_positive_int,
+            default=None,
+            help="Only check the first N candidate projects. Must be >= 1.",
+        )
+
+    def handle(self, *args, **options):
+        limit = options.get("limit")
+
+        candidates = (
+            Project.objects.filter(programmed=True)
+            .exclude(hkrId__isnull=True)
+            .order_by("name")
+        )
+        if limit is not None:
+            candidates = candidates[:limit]
+
+        pw_service = ProjectWiseService()
+
+        writer = csv.writer(self.stdout)
+        writer.writerow(["id", "name", "hkrId", "reason"])
+
+        ok_count = 0
+        orphan_count = 0
+        error_count = 0
+
+        for project in candidates.iterator():
+            try:
+                pw_service.get_project_from_pw(project.hkrId)
+                ok_count += 1
+            except PWProjectNotFoundError:
+                orphan_count += 1
+                writer.writerow([project.id, project.name, project.hkrId, "not_found"])
+            except PWProjectResponseError as exc:
+                error_count += 1
+                writer.writerow(
+                    [project.id, project.name, project.hkrId, "pw_response_error"]
+                )
+                logger.warning(
+                    "find_pw_orphans: PW response error for %s (HKR %s): %s",
+                    project.name,
+                    project.hkrId,
+                    exc,
+                )
+
+        summary = (
+            f"# checked={ok_count + orphan_count + error_count} "
+            f"ok={ok_count} orphans={orphan_count} pw_errors={error_count}"
+        )
+        self.stderr.write(summary)
+
+        exit_code = 0
+        if orphan_count > 0:
+            exit_code |= EXIT_ORPHANS_FOUND
+        if error_count > 0:
+            exit_code |= EXIT_PW_ERRORS
+        if exit_code:
+            sys.exit(exit_code)

--- a/infraohjelmointi_api/tests/__init__.py
+++ b/infraohjelmointi_api/tests/__init__.py
@@ -3,3 +3,4 @@ from .test_Notes import NoteTestCase
 from .management.commands.test_managehierarchies import ManageHierarchiesCommandTestCase
 from .management.commands.test_responsiblepersons import ResponsiblePersonsCommandTestCase
 from .management.commands.test_programmerimporter import ProgrammerImporterCommandTestCase
+from .management.commands.test_find_pw_orphans import FindPwOrphansCommandTestCase

--- a/infraohjelmointi_api/tests/__init__.py
+++ b/infraohjelmointi_api/tests/__init__.py
@@ -4,3 +4,4 @@ from .management.commands.test_managehierarchies import ManageHierarchiesCommand
 from .management.commands.test_responsiblepersons import ResponsiblePersonsCommandTestCase
 from .management.commands.test_programmerimporter import ProgrammerImporterCommandTestCase
 from .management.commands.test_find_out_of_schedule_finances import FindOutOfScheduleFinancesTestCase
+from .management.commands.test_find_pw_orphans import FindPwOrphansCommandTestCase

--- a/infraohjelmointi_api/tests/management/commands/test_find_pw_orphans.py
+++ b/infraohjelmointi_api/tests/management/commands/test_find_pw_orphans.py
@@ -1,0 +1,124 @@
+"""Tests for the IO-865 ``find_pw_orphans`` management command.
+
+The command iterates programmed projects with an ``hkrId`` and asks
+ProjectWise for each one. Projects that PW reports as missing are
+listed as orphans on stdout (CSV); PW response errors are listed as
+``pw_response_error`` rows. The command exits with code 1 if any
+orphan was found.
+"""
+
+from io import StringIO
+from unittest.mock import patch
+
+from django.core.management import call_command
+from django.test import TestCase
+
+from infraohjelmointi_api.models import Project
+from infraohjelmointi_api.services.ProjectWiseService import (
+    PWProjectNotFoundError,
+    PWProjectResponseError,
+)
+
+
+def _make_project(name: str, *, hkr_id: int | None, programmed: bool = True) -> Project:
+    return Project.objects.create(
+        name=name,
+        description="-",
+        hkrId=hkr_id,
+        programmed=programmed,
+    )
+
+
+def _run(*args: str):
+    """Run the command and return (stdout, stderr, exit_code).
+
+    ``exit_code`` is ``None`` when the command completed normally.
+    """
+    out = StringIO()
+    err = StringIO()
+    exit_code: int | None = None
+    try:
+        call_command("find_pw_orphans", *args, stdout=out, stderr=err)
+    except SystemExit as exc:
+        exit_code = int(exc.code) if exc.code is not None else 0
+    return out.getvalue(), err.getvalue(), exit_code
+
+
+@patch("infraohjelmointi_api.management.commands.find_pw_orphans.ProjectWiseService")
+class FindPwOrphansCommandTestCase(TestCase):
+    def test_no_candidates_exits_cleanly(self, mock_pw_cls):
+        # Project that should not be checked: not programmed.
+        _make_project("Not programmed", hkr_id=111, programmed=False)
+        # Project that should not be checked: no hkrId.
+        _make_project("No hkrId", hkr_id=None, programmed=True)
+
+        stdout, stderr, exit_code = _run()
+
+        mock_pw_cls.return_value.get_project_from_pw.assert_not_called()
+        self.assertIn("id,name,hkrId,reason", stdout)
+        self.assertIn("checked=0 ok=0 orphans=0 pw_errors=0", stderr)
+        self.assertIsNone(exit_code)
+
+    def test_all_projects_ok_exits_cleanly(self, mock_pw_cls):
+        _make_project("A", hkr_id=1)
+        _make_project("B", hkr_id=2)
+        mock_pw_cls.return_value.get_project_from_pw.return_value = {"ok": True}
+
+        stdout, stderr, exit_code = _run()
+
+        self.assertEqual(
+            mock_pw_cls.return_value.get_project_from_pw.call_count, 2
+        )
+        # Only the header row, no orphan/error rows.
+        self.assertEqual(stdout.strip().splitlines(), ["id,name,hkrId,reason"])
+        self.assertIn("checked=2 ok=2 orphans=0 pw_errors=0", stderr)
+        self.assertIsNone(exit_code)
+
+    def test_orphan_is_reported_and_exits_with_code_1(self, mock_pw_cls):
+        ok_project = _make_project("Ok", hkr_id=10)
+        orphan = _make_project("Orphan", hkr_id=20)
+
+        def fake_get(hkr_id):
+            if hkr_id == orphan.hkrId:
+                raise PWProjectNotFoundError(
+                    f"No project found from PW with given id '{hkr_id}'"
+                )
+            return {"ok": True}
+
+        mock_pw_cls.return_value.get_project_from_pw.side_effect = fake_get
+
+        stdout, stderr, exit_code = _run()
+
+        self.assertIn(f"{orphan.id},Orphan,20,not_found", stdout)
+        self.assertNotIn(str(ok_project.id), stdout)
+        self.assertIn("checked=2 ok=1 orphans=1 pw_errors=0", stderr)
+        self.assertEqual(exit_code, 1)
+
+    def test_pw_response_error_is_reported_without_failing(self, mock_pw_cls):
+        broken = _make_project("Broken", hkr_id=30)
+        mock_pw_cls.return_value.get_project_from_pw.side_effect = (
+            PWProjectResponseError("PW returned 500")
+        )
+
+        stdout, stderr, exit_code = _run()
+
+        self.assertIn(f"{broken.id},Broken,30,pw_response_error", stdout)
+        self.assertIn("checked=1 ok=0 orphans=0 pw_errors=1", stderr)
+        # Response errors are reported but should not flip the exit code.
+        self.assertIsNone(exit_code)
+
+    def test_limit_option_caps_number_of_checks(self, mock_pw_cls):
+        # Names are ordered alphabetically by the command (.order_by("name")),
+        # so only the first one ("A") should be checked when --limit 1.
+        _make_project("A", hkr_id=1)
+        _make_project("B", hkr_id=2)
+        _make_project("C", hkr_id=3)
+        mock_pw_cls.return_value.get_project_from_pw.return_value = {"ok": True}
+
+        _, stderr, _ = _run("--limit", "1")
+
+        self.assertEqual(
+            mock_pw_cls.return_value.get_project_from_pw.call_count, 1
+        )
+        mock_pw_cls.return_value.get_project_from_pw.assert_called_with(1)
+        self.assertIn("checked=1 ok=1 orphans=0 pw_errors=0", stderr)

--- a/infraohjelmointi_api/tests/management/commands/test_find_pw_orphans.py
+++ b/infraohjelmointi_api/tests/management/commands/test_find_pw_orphans.py
@@ -11,6 +11,7 @@ from io import StringIO
 from unittest.mock import patch
 
 from django.core.management import call_command
+from django.core.management.base import CommandError
 from django.test import TestCase
 
 from infraohjelmointi_api.models import Project
@@ -94,7 +95,7 @@ class FindPwOrphansCommandTestCase(TestCase):
         self.assertIn("checked=2 ok=1 orphans=1 pw_errors=0", stderr)
         self.assertEqual(exit_code, 1)
 
-    def test_pw_response_error_is_reported_without_failing(self, mock_pw_cls):
+    def test_pw_response_error_exits_with_code_2(self, mock_pw_cls):
         broken = _make_project("Broken", hkr_id=30)
         mock_pw_cls.return_value.get_project_from_pw.side_effect = (
             PWProjectResponseError("PW returned 500")
@@ -104,8 +105,24 @@ class FindPwOrphansCommandTestCase(TestCase):
 
         self.assertIn(f"{broken.id},Broken,30,pw_response_error", stdout)
         self.assertIn("checked=1 ok=0 orphans=0 pw_errors=1", stderr)
-        # Response errors are reported but should not flip the exit code.
-        self.assertIsNone(exit_code)
+        # 2 = "PW outage" branch of the bitmask, distinct from 1 ("orphans
+        # found") so monitoring can tell an infra outage from a data issue.
+        self.assertEqual(exit_code, 2)
+
+    def test_orphans_plus_pw_errors_exits_with_code_3(self, mock_pw_cls):
+        orphan = _make_project("Orphan", hkr_id=10)
+        broken = _make_project("Broken", hkr_id=20)
+
+        def fake_get(hkr_id):
+            if hkr_id == orphan.hkrId:
+                raise PWProjectNotFoundError("missing")
+            raise PWProjectResponseError("PW 500")
+
+        mock_pw_cls.return_value.get_project_from_pw.side_effect = fake_get
+
+        _, _, exit_code = _run()
+
+        self.assertEqual(exit_code, 3)
 
     def test_limit_option_caps_number_of_checks(self, mock_pw_cls):
         # Names are ordered alphabetically by the command (.order_by("name")),
@@ -122,3 +139,10 @@ class FindPwOrphansCommandTestCase(TestCase):
         )
         mock_pw_cls.return_value.get_project_from_pw.assert_called_with(1)
         self.assertIn("checked=1 ok=1 orphans=0 pw_errors=0", stderr)
+
+    def test_non_positive_limit_is_rejected(self, mock_pw_cls):
+        for value in ("0", "-1"):
+            with self.subTest(value=value):
+                with self.assertRaises(CommandError):
+                    _run(*("--limit", value))
+        mock_pw_cls.return_value.get_project_from_pw.assert_not_called()

--- a/infraohjelmointi_api/tests/management/commands/test_find_pw_orphans.py
+++ b/infraohjelmointi_api/tests/management/commands/test_find_pw_orphans.py
@@ -1,0 +1,148 @@
+"""Tests for the IO-865 ``find_pw_orphans`` management command.
+
+The command iterates programmed projects with an ``hkrId`` and asks
+ProjectWise for each one. Projects that PW reports as missing are
+listed as orphans on stdout (CSV); PW response errors are listed as
+``pw_response_error`` rows. The command exits with code 1 if any
+orphan was found.
+"""
+
+from io import StringIO
+from unittest.mock import patch
+
+from django.core.management import call_command
+from django.core.management.base import CommandError
+from django.test import TestCase
+
+from infraohjelmointi_api.models import Project
+from infraohjelmointi_api.services.ProjectWiseService import (
+    PWProjectNotFoundError,
+    PWProjectResponseError,
+)
+
+
+def _make_project(name: str, *, hkr_id: int | None, programmed: bool = True) -> Project:
+    return Project.objects.create(
+        name=name,
+        description="-",
+        hkrId=hkr_id,
+        programmed=programmed,
+    )
+
+
+def _run(*args: str):
+    """Run the command and return (stdout, stderr, exit_code).
+
+    ``exit_code`` is ``None`` when the command completed normally.
+    """
+    out = StringIO()
+    err = StringIO()
+    exit_code: int | None = None
+    try:
+        call_command("find_pw_orphans", *args, stdout=out, stderr=err)
+    except SystemExit as exc:
+        exit_code = int(exc.code) if exc.code is not None else 0
+    return out.getvalue(), err.getvalue(), exit_code
+
+
+@patch("infraohjelmointi_api.management.commands.find_pw_orphans.ProjectWiseService")
+class FindPwOrphansCommandTestCase(TestCase):
+    def test_no_candidates_exits_cleanly(self, mock_pw_cls):
+        # Project that should not be checked: not programmed.
+        _make_project("Not programmed", hkr_id=111, programmed=False)
+        # Project that should not be checked: no hkrId.
+        _make_project("No hkrId", hkr_id=None, programmed=True)
+
+        stdout, stderr, exit_code = _run()
+
+        mock_pw_cls.return_value.get_project_from_pw.assert_not_called()
+        self.assertIn("id,name,hkrId,reason", stdout)
+        self.assertIn("checked=0 ok=0 orphans=0 pw_errors=0", stderr)
+        self.assertIsNone(exit_code)
+
+    def test_all_projects_ok_exits_cleanly(self, mock_pw_cls):
+        _make_project("A", hkr_id=1)
+        _make_project("B", hkr_id=2)
+        mock_pw_cls.return_value.get_project_from_pw.return_value = {"ok": True}
+
+        stdout, stderr, exit_code = _run()
+
+        self.assertEqual(
+            mock_pw_cls.return_value.get_project_from_pw.call_count, 2
+        )
+        # Only the header row, no orphan/error rows.
+        self.assertEqual(stdout.strip().splitlines(), ["id,name,hkrId,reason"])
+        self.assertIn("checked=2 ok=2 orphans=0 pw_errors=0", stderr)
+        self.assertIsNone(exit_code)
+
+    def test_orphan_is_reported_and_exits_with_code_1(self, mock_pw_cls):
+        ok_project = _make_project("Ok", hkr_id=10)
+        orphan = _make_project("Orphan", hkr_id=20)
+
+        def fake_get(hkr_id):
+            if hkr_id == orphan.hkrId:
+                raise PWProjectNotFoundError(
+                    f"No project found from PW with given id '{hkr_id}'"
+                )
+            return {"ok": True}
+
+        mock_pw_cls.return_value.get_project_from_pw.side_effect = fake_get
+
+        stdout, stderr, exit_code = _run()
+
+        self.assertIn(f"{orphan.id},Orphan,20,not_found", stdout)
+        self.assertNotIn(str(ok_project.id), stdout)
+        self.assertIn("checked=2 ok=1 orphans=1 pw_errors=0", stderr)
+        self.assertEqual(exit_code, 1)
+
+    def test_pw_response_error_exits_with_code_2(self, mock_pw_cls):
+        broken = _make_project("Broken", hkr_id=30)
+        mock_pw_cls.return_value.get_project_from_pw.side_effect = (
+            PWProjectResponseError("PW returned 500")
+        )
+
+        stdout, stderr, exit_code = _run()
+
+        self.assertIn(f"{broken.id},Broken,30,pw_response_error", stdout)
+        self.assertIn("checked=1 ok=0 orphans=0 pw_errors=1", stderr)
+        # 2 = "PW outage" branch of the bitmask, distinct from 1 ("orphans
+        # found") so monitoring can tell an infra outage from a data issue.
+        self.assertEqual(exit_code, 2)
+
+    def test_orphans_plus_pw_errors_exits_with_code_3(self, mock_pw_cls):
+        orphan = _make_project("Orphan", hkr_id=10)
+        broken = _make_project("Broken", hkr_id=20)
+
+        def fake_get(hkr_id):
+            if hkr_id == orphan.hkrId:
+                raise PWProjectNotFoundError("missing")
+            raise PWProjectResponseError("PW 500")
+
+        mock_pw_cls.return_value.get_project_from_pw.side_effect = fake_get
+
+        _, _, exit_code = _run()
+
+        self.assertEqual(exit_code, 3)
+
+    def test_limit_option_caps_number_of_checks(self, mock_pw_cls):
+        # Names are ordered alphabetically by the command (.order_by("name")),
+        # so only the first one ("A") should be checked when --limit 1.
+        _make_project("A", hkr_id=1)
+        _make_project("B", hkr_id=2)
+        _make_project("C", hkr_id=3)
+        mock_pw_cls.return_value.get_project_from_pw.return_value = {"ok": True}
+
+        _, stderr, _ = _run("--limit", "1")
+
+        self.assertEqual(
+            mock_pw_cls.return_value.get_project_from_pw.call_count, 1
+        )
+        mock_pw_cls.return_value.get_project_from_pw.assert_called_with(1)
+        self.assertIn("checked=1 ok=1 orphans=0 pw_errors=0", stderr)
+
+    def test_non_positive_limit_is_rejected(self, mock_pw_cls):
+        for value in ("0", "-1"):
+            with self.subTest(value=value):
+                with self.assertRaises(CommandError):
+                    _run(*("--limit", value))
+        mock_pw_cls.return_value.get_project_from_pw.assert_not_called()

--- a/infraohjelmointi_api/tests/test_ProjectViewSet.py
+++ b/infraohjelmointi_api/tests/test_ProjectViewSet.py
@@ -3,6 +3,10 @@ from unittest.mock import patch
 from django.test import TestCase
 
 from ..models import Project, ProjectClass, ProjectType, ProjectPhase, ProjectCategory
+from ..services.ProjectWiseService import (
+    PWProjectNotFoundError,
+    PWProjectResponseError,
+)
 from ..views import BaseViewSet
 
 
@@ -260,3 +264,108 @@ class ProjectViewSetPWIntegrationTestCase(TestCase):
         self.assertIn('name', result)
         self.assertIn('description', result)
         self.assertEqual(result['name'], "Project With Nones")
+
+
+@patch.object(BaseViewSet, "authentication_classes", new=[])
+@patch.object(BaseViewSet, "permission_classes", new=[])
+class ProjectViewSetPWSyncErrorTestCase(TestCase):
+    """IO-865: PW sync error mapping in the project PATCH endpoint."""
+
+    def setUp(self):
+        self.project_class, _ = ProjectClass.objects.get_or_create(
+            name="PW Error Test Class",
+            defaults={'path': "PW/Error/Test/Class"},
+        )
+        self.project_type, _ = ProjectType.objects.get_or_create(value="park")
+        self.project_phase, _ = ProjectPhase.objects.get_or_create(value="programming")
+        self.project_category, _ = ProjectCategory.objects.get_or_create(value="basic")
+
+        # planningStartYear/constructionEndYear are required when phase is
+        # `programming`; set them so PATCH gets past serializer validation
+        # and reaches the sync step under test.
+        self.project_with_hkr = Project.objects.create(
+            id=uuid.uuid4(),
+            name="PW Orphan Project",
+            description="Original description",
+            hkrId=2167,
+            programmed=True,
+            planningStartYear=2024,
+            constructionEndYear=2030,
+            projectClass=self.project_class,
+            type=self.project_type,
+            phase=self.project_phase,
+            category=self.project_category,
+        )
+
+        self.project_without_hkr = Project.objects.create(
+            id=uuid.uuid4(),
+            name="No HKR Project",
+            description="Original description",
+            hkrId=None,
+            programmed=True,
+            planningStartYear=2024,
+            constructionEndYear=2030,
+            projectClass=self.project_class,
+            type=self.project_type,
+            phase=self.project_phase,
+            category=self.project_category,
+        )
+
+    @patch(
+        "infraohjelmointi_api.views.ProjectViewSet.ProjectWiseService.sync_project_to_pw"
+    )
+    def test_patch_returns_pw_project_not_found_code_when_pw_missing(self, mock_sync):
+        mock_sync.side_effect = PWProjectNotFoundError(
+            "No project found from PW with given id '2167'"
+        )
+
+        response = self.client.patch(
+            f"/projects/{self.project_with_hkr.id}/",
+            {"description": "Edited description"},
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 400, msg=response.content)
+        self.assertEqual(response.json(), {"hkrId": ["PW_PROJECT_NOT_FOUND"]})
+
+        # @transaction.atomic on partial_update must roll back the local save.
+        self.project_with_hkr.refresh_from_db()
+        self.assertEqual(self.project_with_hkr.description, "Original description")
+
+    @patch(
+        "infraohjelmointi_api.views.ProjectViewSet.ProjectWiseService.sync_project_to_pw"
+    )
+    def test_patch_returns_generic_error_for_other_pw_failures(self, mock_sync):
+        mock_sync.side_effect = PWProjectResponseError(
+            "PW responded with status code '500' and reason 'Server Error'"
+        )
+
+        response = self.client.patch(
+            f"/projects/{self.project_with_hkr.id}/",
+            {"description": "Edited description"},
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 400, msg=response.content)
+        body = response.json()
+        self.assertIn("hkrId", body)
+        hkr_payload = body["hkrId"]
+        if isinstance(hkr_payload, list):
+            self.assertNotIn("PW_PROJECT_NOT_FOUND", hkr_payload)
+        else:
+            self.assertNotEqual(hkr_payload, "PW_PROJECT_NOT_FOUND")
+
+    @patch(
+        "infraohjelmointi_api.views.ProjectViewSet.ProjectWiseService.sync_project_to_pw"
+    )
+    def test_patch_without_hkr_id_does_not_call_pw_sync(self, mock_sync):
+        response = self.client.patch(
+            f"/projects/{self.project_without_hkr.id}/",
+            {"description": "Edited description"},
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 200, msg=response.content)
+        mock_sync.assert_not_called()
+        self.project_without_hkr.refresh_from_db()
+        self.assertEqual(self.project_without_hkr.description, "Edited description")

--- a/infraohjelmointi_api/tests/test_ProjectViewSet.py
+++ b/infraohjelmointi_api/tests/test_ProjectViewSet.py
@@ -3,7 +3,10 @@ from unittest.mock import patch
 from django.test import TestCase
 
 from ..models import Project, ProjectClass, ProjectType, ProjectPhase, ProjectCategory
-from ..services.ProjectWiseService import PWProjectResponseError
+from ..services.ProjectWiseService import (
+    PWProjectNotFoundError,
+    PWProjectResponseError,
+)
 from ..views import BaseViewSet
 
 
@@ -261,6 +264,94 @@ class ProjectViewSetPWIntegrationTestCase(TestCase):
         self.assertIn('name', result)
         self.assertIn('description', result)
         self.assertEqual(result['name'], "Project With Nones")
+
+
+@patch.object(BaseViewSet, "authentication_classes", new=[])
+@patch.object(BaseViewSet, "permission_classes", new=[])
+class ProjectViewSetPWSyncErrorTestCase(TestCase):
+    """IO-865: PW sync error mapping in the project PATCH endpoint."""
+
+    def setUp(self):
+        self.project_class, _ = ProjectClass.objects.get_or_create(
+            name="PW Error Test Class",
+            defaults={'path': "PW/Error/Test/Class"},
+        )
+        self.project_type, _ = ProjectType.objects.get_or_create(value="park")
+        self.project_phase, _ = ProjectPhase.objects.get_or_create(value="programming")
+        self.project_category, _ = ProjectCategory.objects.get_or_create(value="basic")
+
+        # planningStartYear/constructionEndYear are required when phase is
+        # `programming`; set them so PATCH gets past serializer validation
+        # and reaches the sync step under test.
+        self.project_with_hkr = Project.objects.create(
+            id=uuid.uuid4(),
+            name="PW Orphan Project",
+            description="Original description",
+            hkrId=2167,
+            programmed=True,
+            planningStartYear=2024,
+            constructionEndYear=2030,
+            projectClass=self.project_class,
+            type=self.project_type,
+            phase=self.project_phase,
+            category=self.project_category,
+        )
+
+        self.project_without_hkr = Project.objects.create(
+            id=uuid.uuid4(),
+            name="No HKR Project",
+            description="Original description",
+            hkrId=None,
+            programmed=True,
+            planningStartYear=2024,
+            constructionEndYear=2030,
+            projectClass=self.project_class,
+            type=self.project_type,
+            phase=self.project_phase,
+            category=self.project_category,
+        )
+
+    @patch(
+        "infraohjelmointi_api.views.ProjectViewSet.ProjectWiseService.sync_project_to_pw"
+    )
+    def test_patch_returns_pw_project_not_found_code_when_pw_missing(self, mock_sync):
+        mock_sync.side_effect = PWProjectNotFoundError(
+            "No project found from PW with given id '2167'"
+        )
+
+        response = self.client.patch(
+            f"/projects/{self.project_with_hkr.id}/",
+            {"description": "Edited description"},
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 400, msg=response.content)
+        self.assertEqual(response.json(), {"hkrId": ["PW_PROJECT_NOT_FOUND"]})
+
+        # @transaction.atomic on partial_update must roll back the local save.
+        self.project_with_hkr.refresh_from_db()
+        self.assertEqual(self.project_with_hkr.description, "Original description")
+
+    # NOTE: an earlier draft of IO-865 also asserted that a PWProjectResponseError
+    # returns 400 with a non-PW_PROJECT_NOT_FOUND body. After merging IO-851's
+    # soft-fail behaviour, PWProjectResponseError commits the local edit and
+    # returns 200 instead, so that assertion is no longer correct. The soft-fail
+    # path is covered by ProjectViewSetPWOutageTestCase below.
+
+    @patch(
+        "infraohjelmointi_api.views.ProjectViewSet.ProjectWiseService.sync_project_to_pw"
+    )
+    def test_patch_without_hkr_id_does_not_call_pw_sync(self, mock_sync):
+        response = self.client.patch(
+            f"/projects/{self.project_without_hkr.id}/",
+            {"description": "Edited description"},
+            content_type="application/json",
+        )
+
+        self.assertEqual(response.status_code, 200, msg=response.content)
+        mock_sync.assert_not_called()
+        self.project_without_hkr.refresh_from_db()
+        self.assertEqual(self.project_without_hkr.description, "Edited description")
 
 
 @patch.object(BaseViewSet, "authentication_classes", new=[])

--- a/infraohjelmointi_api/views/ProjectViewSet.py
+++ b/infraohjelmointi_api/views/ProjectViewSet.py
@@ -34,6 +34,7 @@ from infraohjelmointi_api.services import (
     ProjectFinancialService,
     ProjectClassService,
 )
+from infraohjelmointi_api.services.ProjectWiseService import PWProjectNotFoundError
 from infraohjelmointi_api.services.utils import create_comprehensive_project_data
 from infraohjelmointi_api.permissions import (
     user_in_restricted_programmer_group,
@@ -1883,6 +1884,13 @@ class ProjectViewSet(BaseViewSet):
 
             logger.info(f"Automatic PW sync completed successfully for project '{updated_project.name}'")
 
+        except PWProjectNotFoundError:
+            # IO-865: stable error code so the UI can show a targeted toast.
+            logger.warning(
+                f"PW sync blocked for project '{updated_project.name}' "
+                f"(HKR ID: {updated_project.hkrId}): PW project not found"
+            )
+            raise ValidationError({"hkrId": ["PW_PROJECT_NOT_FOUND"]})
         except Exception as e:
             # Log detailed error but don't break the update
             logger.error(f"Automatic PW sync failed for project '{updated_project.name}' (HKR ID: {updated_project.hkrId})")

--- a/infraohjelmointi_api/views/ProjectViewSet.py
+++ b/infraohjelmointi_api/views/ProjectViewSet.py
@@ -35,7 +35,10 @@ from infraohjelmointi_api.services import (
     ProjectFinancialService,
     ProjectClassService,
 )
-from infraohjelmointi_api.services.ProjectWiseService import PWProjectResponseError
+from infraohjelmointi_api.services.ProjectWiseService import (
+    PWProjectNotFoundError,
+    PWProjectResponseError,
+)
 from infraohjelmointi_api.services.utils import create_comprehensive_project_data
 from infraohjelmointi_api.permissions import (
     user_in_restricted_programmer_group,
@@ -1884,6 +1887,16 @@ class ProjectViewSet(BaseViewSet):
             )
 
             logger.info(f"Automatic PW sync completed successfully for project '{updated_project.name}'")
+
+        except PWProjectNotFoundError:
+            # IO-865: stable error code so the UI can show a targeted toast.
+            # The PATCH is rolled back by @transaction.atomic on partial_update,
+            # so the user can fix or remove the hkrId and retry.
+            logger.warning(
+                f"PW sync blocked for project '{updated_project.name}' "
+                f"(HKR ID: {updated_project.hkrId}): PW project not found"
+            )
+            raise ValidationError({"hkrId": ["PW_PROJECT_NOT_FOUND"]})
 
         except PWProjectResponseError as e:
             # IO-851: PW outage / non-200 — let the local edit through


### PR DESCRIPTION
* Add PWProjectNotFoundError branch before generic except in _sync_project_to_projectwise -> raises ValidationError with {"hkrId": ["PW_PROJECT_NOT_FOUND"]}
* Existing @transaction.atomic on partial_update rolls back the local DB write automatically
* Add find_pw_orphans management command for monitoring