### PR TITLE
fix: IO-890 Make SSE/cache pipeline more reliable

### DIFF
--- a/infraohjelmointi_api/signals.py
+++ b/infraohjelmointi_api/signals.py
@@ -228,11 +228,24 @@ def get_notified_financial_sums(sender, instance, created, **kwargs):
         logger.debug("Signal Triggered: {} Object was created".format(_type))
     logger.debug("Signal Triggered: {} Object was updated".format(_type))
     year = getattr(instance, "finance_year", date.today().year)
-    send_event(
-        "finance",
-        "finance-update",
-        get_financial_sums(instance=instance, _type=_type, finance_year=year),
-    )
+    instance_id = getattr(instance, "pk", None)
+    try:
+        send_event(
+            "finance",
+            "finance-update",
+            get_financial_sums(instance=instance, _type=_type, finance_year=year),
+        )
+        logger.info(
+            "finance-update event sent (type=%s, id=%s, year=%s)",
+            _type, instance_id, year,
+        )
+    except Exception:
+        # IO-890: surface SSE delivery failures. Without this the event is
+        # silently dropped and the UI never sees the update.
+        logger.exception(
+            "send_event failed for finance-update (type=%s, id=%s, year=%s)",
+            _type, instance_id, year,
+        )
 
 
 @receiver(post_save, sender=Project)
@@ -247,31 +260,46 @@ def get_notified_project(sender, instance, created, update_fields, **kwargs):
         # It gets added to the project instance before .save() is called
         forcedToFrame = getattr(instance, "forcedToFrame", False)
         year = getattr(instance, "finance_year", date.today().year)
-        send_event(
-            "project",
-            "project-update",
-            {
-                "project": ProjectGetSerializer(
-                    instance,
-                    context={
-                        "get_pw_link": True,
-                        "forcedToFrame": forcedToFrame,
-                        "for_coordinator": forcedToFrame == True,
-                        "finance_year": year,
-                    },
-                ).data,
-            },
-        )
+        try:
+            send_event(
+                "project",
+                "project-update",
+                {
+                    "project": ProjectGetSerializer(
+                        instance,
+                        context={
+                            "get_pw_link": True,
+                            "forcedToFrame": forcedToFrame,
+                            "for_coordinator": forcedToFrame == True,
+                            "finance_year": year,
+                        },
+                    ).data,
+                },
+            )
+            logger.info(
+                "project-update event sent (id=%s, year=%s, forcedToFrame=%s)",
+                instance.pk, year, forcedToFrame,
+            )
+        except Exception:
+            # IO-890: surface SSE delivery failures.
+            logger.exception(
+                "send_event failed for project-update (id=%s, year=%s)",
+                instance.pk, year,
+            )
         logger.debug("Signal Triggered: Project was updated")
 
 
 @receiver(post_save, sender=ProjectFinancial)
 @receiver(post_delete, sender=ProjectFinancial)
+@on_transaction_commit
 def invalidate_project_financial_cache(sender, instance, **kwargs):
     """
-    Invalidate cache when ProjectFinancial is saved or deleted
+    Invalidate cache when ProjectFinancial is saved or deleted.
 
-    This ensures that financial calculations are refreshed when data changes.
+    Deferred to ``transaction.on_commit`` to avoid the race where a concurrent
+    request reads (and re-populates) the cache between INVALIDATE and COMMIT,
+    repopulating it with the still-uncommitted, soon-to-be-stale value. This
+    matches the pattern used by ``_invalidate_cached_lookup`` below.
     """
     try:
         project = instance.project
@@ -317,9 +345,13 @@ def invalidate_project_financial_cache(sender, instance, **kwargs):
 
 @receiver(post_save, sender=ClassFinancial)
 @receiver(post_delete, sender=ClassFinancial)
+@on_transaction_commit
 def invalidate_class_financial_cache(sender, instance, **kwargs):
     """
-    Invalidate cache when ClassFinancial is saved or deleted
+    Invalidate cache when ClassFinancial is saved or deleted.
+
+    Deferred to ``transaction.on_commit`` to avoid a read/repopulate race
+    between INVALIDATE and COMMIT.
     """
     try:
         class_relation = instance.classRelation
@@ -357,9 +389,13 @@ def invalidate_class_financial_cache(sender, instance, **kwargs):
 
 @receiver(post_save, sender=LocationFinancial)
 @receiver(post_delete, sender=LocationFinancial)
+@on_transaction_commit
 def invalidate_location_financial_cache(sender, instance, **kwargs):
     """
-    Invalidate cache when LocationFinancial is saved or deleted
+    Invalidate cache when LocationFinancial is saved or deleted.
+
+    Deferred to ``transaction.on_commit`` to avoid a read/repopulate race
+    between INVALIDATE and COMMIT.
     """
     try:
         location_relation = instance.locationRelation
@@ -396,9 +432,13 @@ def invalidate_location_financial_cache(sender, instance, **kwargs):
 
 
 @receiver(post_save, sender=Project)
+@on_transaction_commit
 def invalidate_project_cache(sender, instance, created, **kwargs):
     """
-    Invalidate cache when Project is saved (programmed status or relationships change)
+    Invalidate cache when Project is saved (programmed status or relationships change).
+
+    Deferred to ``transaction.on_commit`` so a concurrent reader cannot
+    repopulate the cache with pre-commit data.
     """
     try:
         # Only invalidate if relevant fields changed

--- a/infraohjelmointi_api/signals.py
+++ b/infraohjelmointi_api/signals.py
@@ -228,23 +228,22 @@ def get_notified_financial_sums(sender, instance, created, **kwargs):
         logger.debug("Signal Triggered: {} Object was created".format(_type))
     logger.debug("Signal Triggered: {} Object was updated".format(_type))
     year = getattr(instance, "finance_year", date.today().year)
-    instance_id = getattr(instance, "pk", None)
+    # Build the payload outside the try block so serialization bugs in
+    # get_financial_sums raise loudly instead of being silently logged as
+    # "send_event failed"
+    payload = get_financial_sums(instance=instance, _type=_type, finance_year=year)
     try:
-        send_event(
-            "finance",
-            "finance-update",
-            get_financial_sums(instance=instance, _type=_type, finance_year=year),
-        )
-        logger.info(
+        send_event("finance", "finance-update", payload)
+        logger.debug(
             "finance-update event sent (type=%s, id=%s, year=%s)",
-            _type, instance_id, year,
+            _type, instance.pk, year,
         )
     except Exception:
         # IO-890: surface SSE delivery failures. Without this the event is
         # silently dropped and the UI never sees the update.
         logger.exception(
             "send_event failed for finance-update (type=%s, id=%s, year=%s)",
-            _type, instance_id, year,
+            _type, instance.pk, year,
         )
 
 
@@ -260,23 +259,20 @@ def get_notified_project(sender, instance, created, update_fields, **kwargs):
         # It gets added to the project instance before .save() is called
         forcedToFrame = getattr(instance, "forcedToFrame", False)
         year = getattr(instance, "finance_year", date.today().year)
-        try:
-            send_event(
-                "project",
-                "project-update",
-                {
-                    "project": ProjectGetSerializer(
-                        instance,
-                        context={
-                            "get_pw_link": True,
-                            "forcedToFrame": forcedToFrame,
-                            "for_coordinator": forcedToFrame == True,
-                            "finance_year": year,
-                        },
-                    ).data,
+        payload = {
+            "project": ProjectGetSerializer(
+                instance,
+                context={
+                    "get_pw_link": True,
+                    "forcedToFrame": forcedToFrame,
+                    "for_coordinator": forcedToFrame == True,
+                    "finance_year": year,
                 },
-            )
-            logger.info(
+            ).data,
+        }
+        try:
+            send_event("project", "project-update", payload)
+            logger.debug(
                 "project-update event sent (id=%s, year=%s, forcedToFrame=%s)",
                 instance.pk, year, forcedToFrame,
             )
@@ -286,7 +282,6 @@ def get_notified_project(sender, instance, created, update_fields, **kwargs):
                 "send_event failed for project-update (id=%s, year=%s)",
                 instance.pk, year,
             )
-        logger.debug("Signal Triggered: Project was updated")
 
 
 @receiver(post_save, sender=ProjectFinancial)
@@ -550,7 +545,7 @@ def on_project_phase_change(sender, instance, **kwargs):
 def _is_valid_sap_project(value: str | None) -> bool:
     """
     Check if a sapProject value is valid (not empty, null, or "0").
-    
+
     IO-777: Users may set sapProject to "0" as a workaround when they can't delete it.
     We treat "0" as an invalid/empty value.
     """
@@ -625,7 +620,7 @@ _connect_cached_lookup_invalidation()
 def capture_old_sap_project(sender, instance, **kwargs):
     """
     Capture the old sapProject value before save so we can detect changes.
-    
+
     IO-777: This is needed to clean up SAP cost records when sapProject changes.
     """
     if instance.pk:
@@ -642,12 +637,12 @@ def capture_old_sap_project(sender, instance, **kwargs):
 def cleanup_sap_costs_on_sap_project_change(sender, instance, created, **kwargs):
     """
     Delete SapCost and SapCurrentYear records when sapProject is changed or removed.
-    
+
     IO-777: When a project's sapProject number is changed, the old SAP cost records
     become stale (they contain data from the old SAP project number) and should be
     deleted. New records will be created on the next SAP sync if the new sapProject
     is valid.
-    
+
     Scenarios handled:
     - sapProject changed from valid value to null/empty/"0" -> delete records
     - sapProject changed from one valid value to another -> delete records
@@ -657,14 +652,14 @@ def cleanup_sap_costs_on_sap_project_change(sender, instance, created, **kwargs)
     if created:
         # New project, no old records to clean up
         return
-    
+
     old_sap_project = getattr(instance, '_old_sap_project', None)
     new_sap_project = instance.sapProject
-    
+
     # Check if sapProject actually changed
     old_valid = _is_valid_sap_project(old_sap_project)
     new_valid = _is_valid_sap_project(new_sap_project)
-    
+
     # If old value was valid and either:
     # 1. New value is invalid (removed/cleared)
     # 2. New value is different (changed to another project number)
@@ -672,7 +667,7 @@ def cleanup_sap_costs_on_sap_project_change(sender, instance, created, **kwargs)
     if old_valid and (not new_valid or old_sap_project != new_sap_project):
         deleted_sap_cost = SapCost.objects.filter(project=instance).delete()
         deleted_sap_current_year = SapCurrentYear.objects.filter(project=instance).delete()
-        
+
         logger.info(
             f"Cleaned up SAP cost records for project {instance.id} due to sapProject change "
             f"from '{old_sap_project}' to '{new_sap_project}': "

--- a/infraohjelmointi_api/tests/helpers.py
+++ b/infraohjelmointi_api/tests/helpers.py
@@ -1,0 +1,42 @@
+"""Shared test helpers."""
+
+from django.core.cache import cache
+
+
+class CacheClearingMixin:
+    """
+    Clear the process-global Django cache before each test.
+
+    IO-890: cache invalidation signals (see ``signals.invalidate_*_cache``)
+    are deferred to ``transaction.on_commit``. Inside Django's ``TestCase``
+    the surrounding transaction is rolled back rather than committed, so
+    those callbacks never fire. Without an explicit clear, financial-sum
+    and frame-budget cache entries written by one test persist into the
+    next test's process and appear as stale data keyed by the previous
+    test's instance IDs.
+
+    Mix this in for any test class that exercises a code path through
+    ``CacheService`` (directly or via signals firing on
+    ``ClassFinancial`` / ``LocationFinancial`` / ``ProjectFinancial`` /
+    ``Project`` saves).
+
+    Usage::
+
+        class MyTest(CacheClearingMixin, TestCase):
+            def setUp(self):
+                super().setUp()
+                ...
+
+    Two ordering rules apply, and both fail silently if violated:
+
+    * List ``CacheClearingMixin`` **before** ``TestCase`` in the bases.
+      Python resolves MRO left-to-right and Django's ``TestCase.setUp``
+      does not chain to ``super()``, so the reverse order skips the
+      mixin entirely.
+    * Subclasses that override ``setUp`` **must** call
+      ``super().setUp()`` for the clear to run.
+    """
+
+    def setUp(self):
+        cache.clear()
+        super().setUp()

--- a/infraohjelmointi_api/tests/test_Api.py
+++ b/infraohjelmointi_api/tests/test_Api.py
@@ -9,6 +9,7 @@ from rest_framework.authtoken.models import Token
 from rest_framework.test import APIClient
 from infraohjelmointi_api.models import Project, ProjectClass, ProjectDistrict, ProjectFinancial, ProjectGroup, ProjectLocation, ProjectHashTag, User
 from infraohjelmointi_api.serializers import ProjectClassSerializer, ProjectDistrictSerializer, ProjectGetSerializer, ProjectGroupSerializer, ProjectLocationSerializer, ProjectHashtagSerializer
+from infraohjelmointi_api.tests.helpers import CacheClearingMixin
 from infraohjelmointi_api.views import BaseViewSet
 from project.extensions.CustomTokenAuth import CustomTokenAuth
 from asgiref.sync import sync_to_async
@@ -79,7 +80,7 @@ def perform_shared_api_setup(cls):
 
 
 @patch.object(BaseViewSet, "authentication_classes", new=[])
-class ApiTestCase(TestCase):
+class ApiTestCase(CacheClearingMixin, TestCase):
     project_district_id = uuid.UUID("a729e919-4556-4e2d-866b-dfaba470459e")
     project_id = uuid.UUID("5d82c31b-4dee-4e48-be7c-b417e6c5bb9e")
     project_group_id = uuid.UUID("bbba45f2-b0d4-4297-b0e2-4e60f8fa8412")
@@ -235,7 +236,7 @@ class ApiTestCase(TestCase):
 
 
 @patch.object(BaseViewSet, "authentication_classes", new=[])
-class AsyncApiTestCase(TestCase):
+class AsyncApiTestCase(CacheClearingMixin, TestCase):
     client_class = AsyncClient
 
     @classmethod

--- a/infraohjelmointi_api/tests/test_BalkSums.py
+++ b/infraohjelmointi_api/tests/test_BalkSums.py
@@ -1,4 +1,5 @@
 from datetime import date
+from django.core.cache import cache
 from django.test import TestCase
 from infraohjelmointi_api.models import (
     Project,
@@ -70,6 +71,13 @@ class BalkSumTestCase(TestCase):
     coordinatorCollectiveSubLevel_1_Id = uuid.UUID(
         "b7b88072-d6c7-4831-9c0c-25cd84307a08"
     )
+
+    def setUp(self):
+        # IO-890: cache invalidation signals are deferred to transaction.on_commit,
+        # which never fires inside TestCase (transactions are rolled back). Clear
+        # the process-global cache explicitly so financial-sum entries from earlier
+        # tests in the run don't leak into this one's cache-hit path.
+        cache.clear()
 
     # Helper function to test values
     def runFinancesAssertTests(self, response, index, name, values):

--- a/infraohjelmointi_api/tests/test_BalkSums.py
+++ b/infraohjelmointi_api/tests/test_BalkSums.py
@@ -1,5 +1,4 @@
 from datetime import date
-from django.core.cache import cache
 from django.test import TestCase
 from infraohjelmointi_api.models import (
     Project,
@@ -11,6 +10,7 @@ from infraohjelmointi_api.models import (
 
 import uuid
 from infraohjelmointi_api.models.AppStateValueModel import AppStateValue
+from infraohjelmointi_api.tests.helpers import CacheClearingMixin
 from overrides import override
 
 from infraohjelmointi_api.views import BaseViewSet
@@ -19,7 +19,7 @@ from unittest.mock import patch
 
 @patch.object(BaseViewSet, "authentication_classes", new=[])
 @patch.object(BaseViewSet, "permission_classes", new=[])
-class BalkSumTestCase(TestCase):
+class BalkSumTestCase(CacheClearingMixin, TestCase):
     project_1_Id = uuid.UUID("d6e03aa6-1ffa-4603-86ff-0d22dccf702d")
     project_2_Id = uuid.UUID("d27bbbcc-22de-48c6-b96a-899d8cf3e3da")
     project_3_Id = uuid.UUID("fee7ce1c-ac73-474f-95d6-3b021c7c267d")
@@ -71,13 +71,6 @@ class BalkSumTestCase(TestCase):
     coordinatorCollectiveSubLevel_1_Id = uuid.UUID(
         "b7b88072-d6c7-4831-9c0c-25cd84307a08"
     )
-
-    def setUp(self):
-        # IO-890: cache invalidation signals are deferred to transaction.on_commit,
-        # which never fires inside TestCase (transactions are rolled back). Clear
-        # the process-global cache explicitly so financial-sum entries from earlier
-        # tests in the run don't leak into this one's cache-hit path.
-        cache.clear()
 
     # Helper function to test values
     def runFinancesAssertTests(self, response, index, name, values):

--- a/infraohjelmointi_api/tests/test_BaseClassLocationViewSet.py
+++ b/infraohjelmointi_api/tests/test_BaseClassLocationViewSet.py
@@ -4,13 +4,14 @@ Tests for BaseClassLocationViewSet functionality including frame_budgets context
 
 from datetime import date
 from collections import defaultdict
+from django.core.cache import cache
 from django.test import TestCase
 from rest_framework.test import APIRequestFactory
 from rest_framework.request import Request
 from unittest.mock import Mock, patch
 
 from infraohjelmointi_api.models import (
-    ProjectClass, 
+    ProjectClass,
     ProjectLocation,
     ClassFinancial,
     LocationFinancial,
@@ -21,9 +22,14 @@ from infraohjelmointi_api.views.BaseClassLocationViewSet import BaseClassLocatio
 
 class BaseClassLocationViewSetTestCase(TestCase):
     """Test BaseClassLocationViewSet methods"""
-    
+
     def setUp(self):
         """Set up test data"""
+        # IO-890: cache invalidation signals are deferred to transaction.on_commit,
+        # which never fires inside TestCase (transactions are rolled back). Clear
+        # the process-global cache explicitly so stale entries from previous tests
+        # don't leak into this one.
+        cache.clear()
         self.year = date.today().year
         self.user = User.objects.create(
             first_name='Test', 

--- a/infraohjelmointi_api/tests/test_BaseClassLocationViewSet.py
+++ b/infraohjelmointi_api/tests/test_BaseClassLocationViewSet.py
@@ -4,7 +4,6 @@ Tests for BaseClassLocationViewSet functionality including frame_budgets context
 
 from datetime import date
 from collections import defaultdict
-from django.core.cache import cache
 from django.test import TestCase
 from rest_framework.test import APIRequestFactory
 from rest_framework.request import Request
@@ -17,19 +16,16 @@ from infraohjelmointi_api.models import (
     LocationFinancial,
     User
 )
+from infraohjelmointi_api.tests.helpers import CacheClearingMixin
 from infraohjelmointi_api.views.BaseClassLocationViewSet import BaseClassLocationViewSet
 
 
-class BaseClassLocationViewSetTestCase(TestCase):
+class BaseClassLocationViewSetTestCase(CacheClearingMixin, TestCase):
     """Test BaseClassLocationViewSet methods"""
 
     def setUp(self):
         """Set up test data"""
-        # IO-890: cache invalidation signals are deferred to transaction.on_commit,
-        # which never fires inside TestCase (transactions are rolled back). Clear
-        # the process-global cache explicitly so stale entries from previous tests
-        # don't leak into this one.
-        cache.clear()
+        super().setUp()
         self.year = date.today().year
         self.user = User.objects.create(
             first_name='Test', 

--- a/infraohjelmointi_api/tests/test_BudgetOverlapConsistency.py
+++ b/infraohjelmointi_api/tests/test_BudgetOverlapConsistency.py
@@ -5,6 +5,7 @@ coordination and programming views after IO-743 consistency fix.
 
 from datetime import date
 from collections import defaultdict
+from django.core.cache import cache
 from django.test import TestCase
 from rest_framework.test import APIClient
 from infraohjelmointi_api.models import (
@@ -31,6 +32,11 @@ class BudgetOverlapConsistencyTestCase(TestCase):
 
     def setUp(self):
         """Set up test data with specific budget overlap scenarios"""
+        # IO-890: cache invalidation signals are deferred to transaction.on_commit,
+        # which never fires inside TestCase (transactions are rolled back). Clear
+        # the process-global cache explicitly so stale entries from previous tests
+        # don't leak into this one.
+        cache.clear()
         self.year = date.today().year
         self.user = User.objects.create(
             first_name='Test',
@@ -155,6 +161,8 @@ class ViewEndpointConsistencyTestCase(TestCase):
     """Test that actual API endpoints return consistent data"""
 
     def setUp(self):
+        # IO-890: see BudgetOverlapConsistencyTestCase.setUp for rationale.
+        cache.clear()
         self.user = User.objects.create(
             first_name='Test',
             last_name='User',
@@ -236,7 +244,7 @@ class ViewEndpointConsistencyTestCase(TestCase):
 
 class FrameBudgetsContextTestCase(TestCase):
     """Test the frame_budgets context building logic specifically"""
-    
+
     # Test scenario constants for clarity and DRY
     TSE_2028_PARENT_BUDGET = 58000  # TSE-2028 scenario from IO-743
     TSE_2028_CHILD1_BUDGET = 30000
@@ -247,6 +255,8 @@ class FrameBudgetsContextTestCase(TestCase):
     OVERLAP_CHILD2_BUDGET = 28000   # 30k + 28k = 58k > 50k
 
     def setUp(self):
+        # IO-890: see BudgetOverlapConsistencyTestCase.setUp for rationale.
+        cache.clear()
         self.year = date.today().year
 
         # Create test classes

--- a/infraohjelmointi_api/tests/test_BudgetOverlapConsistency.py
+++ b/infraohjelmointi_api/tests/test_BudgetOverlapConsistency.py
@@ -5,7 +5,6 @@ coordination and programming views after IO-743 consistency fix.
 
 from datetime import date
 from collections import defaultdict
-from django.core.cache import cache
 from django.test import TestCase
 from rest_framework.test import APIClient
 from infraohjelmointi_api.models import (
@@ -16,9 +15,10 @@ from infraohjelmointi_api.models import (
     User
 )
 from infraohjelmointi_api.serializers import ProjectClassSerializer
+from infraohjelmointi_api.tests.helpers import CacheClearingMixin
 
 
-class BudgetOverlapConsistencyTestCase(TestCase):
+class BudgetOverlapConsistencyTestCase(CacheClearingMixin, TestCase):
     """Test that coordination and programming views show identical budget overlap warnings"""
 
     # Test scenario constants for clarity and DRY
@@ -32,11 +32,7 @@ class BudgetOverlapConsistencyTestCase(TestCase):
 
     def setUp(self):
         """Set up test data with specific budget overlap scenarios"""
-        # IO-890: cache invalidation signals are deferred to transaction.on_commit,
-        # which never fires inside TestCase (transactions are rolled back). Clear
-        # the process-global cache explicitly so stale entries from previous tests
-        # don't leak into this one.
-        cache.clear()
+        super().setUp()
         self.year = date.today().year
         self.user = User.objects.create(
             first_name='Test',
@@ -157,12 +153,11 @@ class BudgetOverlapConsistencyTestCase(TestCase):
         return frame_budgets
 
 
-class ViewEndpointConsistencyTestCase(TestCase):
+class ViewEndpointConsistencyTestCase(CacheClearingMixin, TestCase):
     """Test that actual API endpoints return consistent data"""
 
     def setUp(self):
-        # IO-890: see BudgetOverlapConsistencyTestCase.setUp for rationale.
-        cache.clear()
+        super().setUp()
         self.user = User.objects.create(
             first_name='Test',
             last_name='User',
@@ -242,7 +237,7 @@ class ViewEndpointConsistencyTestCase(TestCase):
         # This confirms the refactored fix is in place
 
 
-class FrameBudgetsContextTestCase(TestCase):
+class FrameBudgetsContextTestCase(CacheClearingMixin, TestCase):
     """Test the frame_budgets context building logic specifically"""
 
     # Test scenario constants for clarity and DRY
@@ -255,8 +250,7 @@ class FrameBudgetsContextTestCase(TestCase):
     OVERLAP_CHILD2_BUDGET = 28000   # 30k + 28k = 58k > 50k
 
     def setUp(self):
-        # IO-890: see BudgetOverlapConsistencyTestCase.setUp for rationale.
-        cache.clear()
+        super().setUp()
         self.year = date.today().year
 
         # Create test classes

--- a/infraohjelmointi_api/tests/test_EventStreamConfig.py
+++ b/infraohjelmointi_api/tests/test_EventStreamConfig.py
@@ -1,0 +1,38 @@
+"""Tests that pin django-eventstream's runtime configuration.
+
+These tests are intentionally tiny — they exist to lock in the choice we
+documented in IO-890 so that a future settings refactor, dependency bump, or
+copy-paste accident doesn't silently regress us back to in-memory storage
+(which would resurrect the IO-725 / IO-890 cross-pod event-loss bug).
+"""
+
+from django.test import TestCase
+
+from django_eventstream.storage import DjangoModelStorage
+from django_eventstream.utils import get_storage
+
+
+class EventStreamStorageConfigTest(TestCase):
+    """django-eventstream must use a persisted storage backend.
+
+    IO-890: ``django-eventstream==4.5.x`` has no Redis backend; persisted
+    storage is the only mechanism by which an SSE client reconnecting to a
+    different pod can replay events fired on another pod (via the standard
+    ``Last-Event-ID`` header). Without storage every event lives only in the
+    in-process listener queue of the pod that handled the write.
+    """
+
+    def test_storage_is_django_model_storage(self):
+        storage = get_storage()
+        self.assertIsNotNone(
+            storage,
+            "EVENTSTREAM_STORAGE_CLASS must be set (IO-890); without it, "
+            "django-eventstream falls back to in-memory storage and SSE "
+            "events do not survive a client reconnect or reach other pods.",
+        )
+        self.assertIsInstance(
+            storage,
+            DjangoModelStorage,
+            "Storage backend must be DjangoModelStorage. EVENTSTREAM_REDIS is "
+            "silently ignored by django-eventstream 4.5.x.",
+        )

--- a/infraohjelmointi_api/tests/test_FinancialSumSerializer.py
+++ b/infraohjelmointi_api/tests/test_FinancialSumSerializer.py
@@ -12,13 +12,15 @@ from infraohjelmointi_api.models import (
     ProjectFinancial,
 )
 from infraohjelmointi_api.serializers.FinancialSumSerializer import FinancialSumSerializer
+from infraohjelmointi_api.tests.helpers import CacheClearingMixin
 
 
-class FinancialSumSerializerTestCase(TestCase):
+class FinancialSumSerializerTestCase(CacheClearingMixin, TestCase):
     """Test cases for FinancialSumSerializer budget overlap calculation consistency"""
 
     def setUp(self):
         """Set up test data that reproduces the TSE 2028 issue"""
+        super().setUp()
         # Create coordinator classes hierarchy: TSE -> TSE 2028
         self.tse_master = ProjectClass.objects.create(
             id=uuid.uuid4(),

--- a/infraohjelmointi_api/tests/test_Projects.py
+++ b/infraohjelmointi_api/tests/test_Projects.py
@@ -38,6 +38,7 @@ from ..serializers import (
     ProjectCreateSerializer,
 )
 
+from infraohjelmointi_api.tests.helpers import CacheClearingMixin
 from infraohjelmointi_api.views import BaseViewSet
 
 
@@ -72,7 +73,7 @@ def mock_projectwise_create_service(func):
 
 @patch.object(BaseViewSet, "authentication_classes", new=[])
 @patch.object(BaseViewSet, "permission_classes", new=[])
-class ProjectTestCase(TestCase):
+class ProjectTestCase(CacheClearingMixin, TestCase):
     project_1_Id = uuid.UUID("33814e76-7bdc-47c2-bf08-7ed43a96e042")
     project_2_Id = uuid.UUID("5d82c31b-4dee-4e48-be7c-b417e6c5bb9e")
     project_3_Id = uuid.UUID("fdc89f56-b631-4109-a137-45b950de6b10")
@@ -4082,7 +4083,7 @@ class ProjectTestCase(TestCase):
         )
 
 
-class ProjectCreateSerializerHierarchicalProgrammerTestCase(TestCase):
+class ProjectCreateSerializerHierarchicalProgrammerTestCase(CacheClearingMixin, TestCase):
     """Test hierarchical programmer fallback in project creation/update (IO-411)"""
 
     @classmethod

--- a/project/settings.py
+++ b/project/settings.py
@@ -435,29 +435,6 @@ if REDIS_URL:
         }
     }
 
-    # Configure django-eventstream to use Redis for SSE event storage (fixes IO-725)
-    # EVENTSTREAM_REDIS is the correct way to configure Redis for django-eventstream
-    # This enables multi-pod event sharing via Redis
-    # Only configure EVENTSTREAM_REDIS if Redis is actually available at startup
-    # If not available, django-eventstream will fall back to in-memory storage
-    # Note: If Redis goes down after startup, EVENTSTREAM_REDIS will still be set,
-    # but django-eventstream should handle connection failures gracefully by falling back
-    # to in-memory storage (events won't be shared across pods, but app will work)
-    if REDIS_AVAILABLE:
-        redis_config = parse_redis_url(REDIS_URL)
-        EVENTSTREAM_REDIS = {
-            'host': redis_config['host'],
-            'port': redis_config['port'],
-            'db': redis_config['db'],
-        }
-        if 'password' in redis_config:
-            EVENTSTREAM_REDIS['password'] = redis_config['password']
-        logger.info("django-eventstream configured to use Redis for multi-pod event sharing")
-    else:
-        # Don't set EVENTSTREAM_REDIS - django-eventstream will use in-memory storage
-        # This allows the app to work without Redis (events won't be shared across pods, but that's OK)
-        logger.info("Redis not available - django-eventstream will use in-memory storage (single-pod only)")
-    
     safe_url = REDIS_URL.split('@')[-1] if '@' in REDIS_URL else REDIS_URL
     logger.info("Redis cache configured: %s", safe_url)
     if not REDIS_AVAILABLE:
@@ -469,6 +446,20 @@ else:
         }
     }
     logger.info("Redis not configured - cache disabled (development/local)")
+
+# IO-890: django-eventstream 4.5.x does NOT read EVENTSTREAM_REDIS (that
+# setting was introduced in 5.x). On this version the only cross-pod
+# mechanism is persisted storage: ``send_event`` writes a DB row and
+# ``get_events`` lets a reconnecting SSE client replay missed events via the
+# standard ``Last-Event-ID`` header. Without storage, every event the signals
+# fired existed only in the in-process listener queue of the pod that handled
+# the write — which is exactly what IO-725 / IO-890 describe.
+#
+# DjangoModelStorage auto-trims rows older than 24h on every insert (see
+# django_eventstream/storage.py: EVENT_TIMEOUT = 60 * 24). True real-time
+# cross-pod push would require either Pushpin/GRIP or upgrading to
+# django-eventstream >=5; defer that until traffic warrants it.
+EVENTSTREAM_STORAGE_CLASS = "django_eventstream.storage.DjangoModelStorage"
 
 # GRIP proxy configuration (optional - not needed for your scale)
 GRIP_URL = env('GRIP_URL', default=None)

--- a/project/settings.py
+++ b/project/settings.py
@@ -362,18 +362,6 @@ def check_redis_availability(redis_url: str, max_retries: int = 5, initial_delay
     return False
 
 
-def parse_redis_url(redis_url: str) -> dict:
-    parsed = urlparse(redis_url)
-    config = {
-        'host': parsed.hostname or 'localhost',
-        'port': parsed.port or 6379,
-        'db': int(parsed.path.lstrip('/') or 0) if parsed.path else 0,
-    }
-    if parsed.password:
-        config['password'] = parsed.password
-    return config
-
-
 # Configure Redis if URL is provided
 # Skip Redis check for management commands that don't need it (e.g., makemigrations, migrate)
 _skip_redis_check_commands = ['makemigrations', 'migrate', 'showmigrations', 'sqlmigrate', 'sqlflush', 'inspectdb', 'collectstatic', 'check']


### PR DESCRIPTION
* Configure DjangoModelStorage for django-eventstream so events persist and reconnecting SSE clients replay missed updates across pods (4.5.x ignores EVENTSTREAM_REDIS; cross-pod push requires storage)
* Defer financial/project cache invalidation to transaction.on_commit so concurrent readers can't repopulate the cache with pre-commit values
* Add INFO/exception logging around send_event so future event-loss triage has signal instead of silence
* Clear cache in setUp for tests that relied on synchronous invalidation via signal side-effects