### PR TITLE
feat: IO-887 Add status transitions endpoint for Construction handover

### DIFF
--- a/infraohjelmointi_api/permissions.py
+++ b/infraohjelmointi_api/permissions.py
@@ -195,6 +195,7 @@ PROJECT_GROUP_ALL_ACTIONS = [*PROJECT_GROUP_ALL_GET_ACTIONS]
 
 #### Construction handover custom actions ####
 CONSTRUCTION_HANDOVER_GET_ACTIONS = ["get_construction_handovers"]
+CONSTRUCTION_HANDOVER_POST_ACTIONS = ["transitions"]
 
 #### Project change-history custom actions (IO-879) ####
 # Per-project audit-log history powering the "Näytä muutoshistoria" UI.
@@ -305,6 +306,7 @@ class IsCoordinator(permissions.BasePermission):
                 *PROJECT_NOTE_ALL_ACTIONS,
                 *CONSTRUCTION_HANDOVER_GET_ACTIONS,
                 *PROJECT_HISTORY_GET_ACTIONS,
+                *CONSTRUCTION_HANDOVER_POST_ACTIONS,
             ]
         ):
             return True
@@ -344,6 +346,7 @@ class IsPlanner(permissions.BasePermission):
                 *PROJECT_NOTE_ALL_ACTIONS,
                 *CONSTRUCTION_HANDOVER_GET_ACTIONS,
                 *PROJECT_HISTORY_GET_ACTIONS,
+                *CONSTRUCTION_HANDOVER_POST_ACTIONS,
             ]
         ):
             return True
@@ -385,6 +388,7 @@ class IsProjectManager(permissions.BasePermission):
                 *PROJECT_NOTE_ALL_ACTIONS,
                 *CONSTRUCTION_HANDOVER_GET_ACTIONS,
                 *PROJECT_HISTORY_GET_ACTIONS,
+                *CONSTRUCTION_HANDOVER_POST_ACTIONS,
             ]
         ):
             return True
@@ -540,6 +544,7 @@ class IsAdmin(permissions.BasePermission):
                 *PROJECT_FORCED_TO_FRAME_PATCH,
                 *CONSTRUCTION_HANDOVER_GET_ACTIONS,
                 *PROJECT_HISTORY_GET_ACTIONS,
+                *CONSTRUCTION_HANDOVER_POST_ACTIONS,
             ]
         ):
             return True
@@ -657,3 +662,59 @@ class IsClassProgrammer(permissions.BasePermission):
         return self._target_path_matches_assigned_paths(
             target_class_path, assigned_paths
         )
+    
+class IsConstructionManagementLead(permissions.BasePermission):
+    """Permission class for construction management leads (Rakennuttamisen esihenkilöt)."""
+
+    CONSTRUCTION_HANDOVER_BASENAME = "constructionHandovers"
+
+    def user_in_construction_management_lead_group(self, request):
+        if (
+            "sg_kymp_sso_io_rakennuttamisen_esihenkilot"
+            in request.user.ad_groups.all().values_list("name", flat=True)
+        ):
+            return True
+
+    def _is_construction_handover_view(self, view):
+        return getattr(view, "basename", None) == self.CONSTRUCTION_HANDOVER_BASENAME
+
+    def has_permission(self, request, view):
+        if not request.user.is_authenticated:
+            return False
+
+        if not self.user_in_construction_management_lead_group(request=request):
+            return False
+
+        if request.method not in SAFE_METHODS:
+            return False
+
+        # Allow read rights for all resources this role can view.
+        if request.method == GET and view.action in [
+            *DJANGO_BASE_READ_ONLY_ACTIONS,
+            *PROJECT_CLASS_ALL_GET_ACTIONS,
+            *PROJECT_LOCATION_ALL_GET_ACTIONS,
+            *PROJECT_GROUP_ALL_GET_ACTIONS,
+            *PROJECT_FINANCES_ALL_GET_ACTIONS,
+            *PROJECT_ALL_GET_ACTIONS,
+            *SAP_COST_ALL_GET_ACTIONS,
+            *CONSTRUCTION_HANDOVER_GET_ACTIONS,
+        ]:
+            return True
+
+        # Strict write rights: only update/transition actions on construction handovers.
+        if self._is_construction_handover_view(view) and view.action in [
+            *DJANGO_BASE_UPDATE_ONLY_ACTIONS,
+            *CONSTRUCTION_HANDOVER_POST_ACTIONS,
+        ]:
+            return True
+
+        return False
+
+    def has_object_permission(self, request, view, obj):
+        if request.method == GET:
+            return True
+
+        if self._is_construction_handover_view(view):
+            return True
+
+        return False

--- a/infraohjelmointi_api/permissions.py
+++ b/infraohjelmointi_api/permissions.py
@@ -674,6 +674,8 @@ class IsConstructionManagementLead(permissions.BasePermission):
             in request.user.ad_groups.all().values_list("name", flat=True)
         ):
             return True
+        else:
+            return False
 
     def _is_construction_handover_view(self, view):
         return getattr(view, "basename", None) == self.CONSTRUCTION_HANDOVER_BASENAME

--- a/infraohjelmointi_api/serializers/ConstructionHandoverGetSerializer.py
+++ b/infraohjelmointi_api/serializers/ConstructionHandoverGetSerializer.py
@@ -10,6 +10,7 @@ class ConstructionHandoverGetSerializer(serializers.ModelSerializer):
     personPlanning = PersonSerializer(read_only=True)
     personFinancing = ProjectProgrammerSerializer(read_only=True)
     constructionProcurementMethod = ConstructionProcurementMethodSerializer(read_only=True)
+    constructionProjectManager = PersonSerializer(read_only=True)
 
     class Meta:
         model = ConstructionHandover

--- a/infraohjelmointi_api/serializers/WhoAmISerializer.py
+++ b/infraohjelmointi_api/serializers/WhoAmISerializer.py
@@ -15,6 +15,7 @@ class WhoAmISerializer(serializers.ModelSerializer):
         "az_kymp_asgd_u_infraohjelmointi_ulkopuoliset": "952da398-75b3-404a-b274-c8f351d7f5a7",
         "952da398-75b3-404a-b274-c8f351d7f5a7": "952da398-75b3-404a-b274-c8f351d7f5a7",
         "sg_kymp_sso_io_admin": "sg_kymp_sso_io_admin",
+        "sg_kymp_sso_io_rakennuttamisen_esihenkilot": "9d22d98e-5cc6-4a91-9fec-1a288a67290e"
     }
 
     class Meta:

--- a/infraohjelmointi_api/services/ConstructionHandoverTransitionPermissionService.py
+++ b/infraohjelmointi_api/services/ConstructionHandoverTransitionPermissionService.py
@@ -1,0 +1,38 @@
+from .ProjectPersonAuthorizationService import ProjectPersonAuthorizationService
+
+
+class ConstructionHandoverTransitionPermissionService:
+    @staticmethod
+    def is_transition_allowed(
+        requested_status,
+        user,
+        project,
+        is_project_manager,
+        is_programmer,
+        is_construction_management_lead,
+    ):
+        if requested_status == "SUBMITTED_TO_PROGRAMMER":
+            return (
+                is_project_manager
+                and ProjectPersonAuthorizationService.is_person_planning_for_project(
+                    user=user,
+                    project=project,
+                )
+            )
+
+        if requested_status == "SUBMITTED_TO_CONSTRUCTION":
+            return is_programmer
+
+        if requested_status == "PROJECT_MANAGER_NAMED":
+            return is_construction_management_lead
+
+        if requested_status == "MOVED_TO_CONSTRUCTION_PREPARATION":
+            return (
+                is_project_manager
+                and ProjectPersonAuthorizationService.is_person_construction_for_project(
+                    user=user,
+                    project=project,
+                )
+            )
+
+        return True

--- a/infraohjelmointi_api/services/ProjectPersonAuthorizationService.py
+++ b/infraohjelmointi_api/services/ProjectPersonAuthorizationService.py
@@ -1,0 +1,24 @@
+class ProjectPersonAuthorizationService:
+    @staticmethod
+    def is_matching_project_person_email(user, person):
+        if not user or not getattr(user, "is_authenticated", False):
+            return False
+        if not person:
+            return False
+
+        user_email = (getattr(user, "email", "") or "").strip().lower()
+        person_email = (getattr(person, "email", "") or "").strip().lower()
+        if not user_email or not person_email:
+            return False
+
+        return user_email == person_email
+
+    @classmethod
+    def is_person_planning_for_project(cls, user, project):
+        project_person_planning = getattr(project, "personPlanning", None)
+        return cls.is_matching_project_person_email(user, project_person_planning)
+
+    @classmethod
+    def is_person_construction_for_project(cls, user, project):
+        project_person_construction = getattr(project, "personConstruction", None)
+        return cls.is_matching_project_person_email(user, project_person_construction)

--- a/infraohjelmointi_api/services/__init__.py
+++ b/infraohjelmointi_api/services/__init__.py
@@ -23,3 +23,7 @@ from .SapCostService import SapCostService
 from .AppStateValueService import AppStateValueService
 from .CacheService import CacheService
 from .TalpaExcelService import TalpaExcelService
+from .ProjectPersonAuthorizationService import ProjectPersonAuthorizationService
+from .ConstructionHandoverTransitionPermissionService import (
+	ConstructionHandoverTransitionPermissionService,
+)

--- a/infraohjelmointi_api/tests/test_ConstructionHandoverViewSet.py
+++ b/infraohjelmointi_api/tests/test_ConstructionHandoverViewSet.py
@@ -5,6 +5,7 @@ from django.contrib.auth import get_user_model
 from django.test import TestCase
 from rest_framework import status
 from rest_framework.test import APIClient
+from helusers.models import ADGroup
 
 from infraohjelmointi_api.models import (
     ConstructionHandover,
@@ -71,8 +72,20 @@ class ConstructionHandoverViewSetTestCase(TestCase):
             username="handover_user_2",
             first_name="Handover",
             last_name="User Two",
-            email="handover2@example.com",
+            email=self.person_planning.email,
         )
+        self.user_3 = User.objects.create(
+            username="handover_user_3",
+            first_name="Handover",
+            last_name="User Three",
+            email=self.person_construction.email,
+        )
+        self.project_manager_group = ADGroup.objects.create(
+            name="sg_kymp_sso_io_projektipaallikot",
+            display_name="Project Managers",
+        )
+        self.user_2.ad_groups.add(self.project_manager_group)
+        self.user_3.ad_groups.add(self.project_manager_group)
 
     def test_get_serializer_class_by_action(self):
         viewset = ConstructionHandoverViewSet()
@@ -350,3 +363,349 @@ class ConstructionHandoverViewSetTestCase(TestCase):
 
         self.assertEqual(response.status_code, status.HTTP_204_NO_CONTENT)
         self.assertFalse(ConstructionHandover.objects.filter(id=handover.id).exists())
+
+    def test_transitions_allows_submitted_to_programmer_for_project_manager(self):
+        self.client.force_authenticate(user=self.user_2)
+
+        handover = ConstructionHandover.objects.create(
+            project=self.project,
+            status="DRAFT",
+            updatedBy=self.user_1,
+        )
+
+        response = self.client.post(
+            f"/construction-handovers/{handover.id}/transitions/",
+            {"to": "SUBMITTED_TO_PROGRAMMER"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["currentStatus"], "SUBMITTED_TO_PROGRAMMER")
+        self.assertEqual(response.data["possibleTransitions"], ["SUBMITTED_TO_CONSTRUCTION"])
+
+        handover.refresh_from_db()
+        self.assertEqual(handover.status, "SUBMITTED_TO_PROGRAMMER")
+        self.assertEqual(handover.updatedBy_id, self.user_2.uuid)
+
+    def test_transitions_denies_submitted_to_programmer_for_non_project_manager(self):
+        self.client.force_authenticate(user=self.user_1)
+
+        handover = ConstructionHandover.objects.create(
+            project=self.project,
+            status="DRAFT",
+        )
+
+        response = self.client.post(
+            f"/construction-handovers/{handover.id}/transitions/",
+            {"to": "SUBMITTED_TO_PROGRAMMER"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        handover.refresh_from_db()
+        self.assertEqual(handover.status, "DRAFT")
+
+    @patch("infraohjelmointi_api.views.ConstructionHandoverViewSet.IsPlanner.user_in_planner_group", return_value=True)
+    def test_transitions_allows_submitted_to_construction_for_programmer(self, _mock_is_programmer):
+        self.client.force_authenticate(user=self.user_1)
+
+        handover = ConstructionHandover.objects.create(
+            project=self.project,
+            status="SUBMITTED_TO_PROGRAMMER",
+        )
+
+        response = self.client.post(
+            f"/construction-handovers/{handover.id}/transitions/",
+            {"to": "SUBMITTED_TO_CONSTRUCTION"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        handover.refresh_from_db()
+        self.assertEqual(handover.status, "SUBMITTED_TO_CONSTRUCTION")
+
+    @patch("infraohjelmointi_api.views.ConstructionHandoverViewSet.IsPlanner.user_in_planner_group", return_value=False)
+    def test_transitions_denies_submitted_to_construction_for_non_programmer(self, _mock_is_programmer):
+        self.client.force_authenticate(user=self.user_1)
+
+        handover = ConstructionHandover.objects.create(
+            project=self.project,
+            status="SUBMITTED_TO_PROGRAMMER",
+        )
+
+        response = self.client.post(
+            f"/construction-handovers/{handover.id}/transitions/",
+            {"to": "SUBMITTED_TO_CONSTRUCTION"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        handover.refresh_from_db()
+        self.assertEqual(handover.status, "SUBMITTED_TO_PROGRAMMER")
+
+    @patch("infraohjelmointi_api.views.ConstructionHandoverViewSet.IsConstructionManagementLead.user_in_construction_management_lead_group", return_value=True)
+    def test_transitions_allows_project_manager_named_for_construction_management_lead(self, _mock_is_construction_management_lead):
+        self.client.force_authenticate(user=self.user_1)
+
+        handover = ConstructionHandover.objects.create(
+            project=self.project,
+            status="SUBMITTED_TO_CONSTRUCTION",
+            constructionProjectManager=self.person_construction,
+        )
+
+        response = self.client.post(
+            f"/construction-handovers/{handover.id}/transitions/",
+            {"to": "PROJECT_MANAGER_NAMED"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        handover.refresh_from_db()
+        self.assertEqual(handover.status, "PROJECT_MANAGER_NAMED")
+
+    @patch("infraohjelmointi_api.views.ConstructionHandoverViewSet.IsConstructionManagementLead.user_in_construction_management_lead_group", return_value=False)
+    def test_transitions_denies_project_manager_named_for_non_construction_management_lead(self, _mock_is_construction_management_lead):
+        self.client.force_authenticate(user=self.user_1)
+
+        handover = ConstructionHandover.objects.create(
+            project=self.project,
+            status="SUBMITTED_TO_CONSTRUCTION",
+            constructionProjectManager=self.person_construction,
+        )
+
+        response = self.client.post(
+            f"/construction-handovers/{handover.id}/transitions/",
+            {"to": "PROJECT_MANAGER_NAMED"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        handover.refresh_from_db()
+        self.assertEqual(handover.status, "SUBMITTED_TO_CONSTRUCTION")
+
+    @patch("infraohjelmointi_api.views.ConstructionHandoverViewSet.IsConstructionManagementLead.user_in_construction_management_lead_group", return_value=True)
+    def test_transitions_denies_project_manager_named_when_construction_project_manager_missing(self, _mock_is_construction_management_lead):
+        self.client.force_authenticate(user=self.user_1)
+
+        handover = ConstructionHandover.objects.create(
+            project=self.project,
+            status="SUBMITTED_TO_CONSTRUCTION",
+            constructionProjectManager=None,
+        )
+
+        response = self.client.post(
+            f"/construction-handovers/{handover.id}/transitions/",
+            {"to": "PROJECT_MANAGER_NAMED"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_409_CONFLICT)
+        self.assertEqual(
+            response.data["detail"],
+            "constructionProjectManager is required for this transition.",
+        )
+
+        handover.refresh_from_db()
+        self.assertEqual(handover.status, "SUBMITTED_TO_CONSTRUCTION")
+
+    def test_transitions_allows_moved_to_construction_preparation_for_matching_project_manager(self):
+        self.client.force_authenticate(user=self.user_3)
+
+        handover = ConstructionHandover.objects.create(
+            project=self.project,
+            status="PROJECT_MANAGER_NAMED",
+            constructionProcurementMethod=self.construction_procurement_method,
+        )
+
+        response = self.client.post(
+            f"/construction-handovers/{handover.id}/transitions/",
+            {"to": "MOVED_TO_CONSTRUCTION_PREPARATION"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        handover.refresh_from_db()
+        self.assertEqual(handover.status, "MOVED_TO_CONSTRUCTION_PREPARATION")
+
+    def test_transitions_denies_moved_to_construction_preparation_for_non_matching_project_manager(self):
+        self.client.force_authenticate(user=self.user_2)
+
+        handover = ConstructionHandover.objects.create(
+            project=self.project,
+            status="PROJECT_MANAGER_NAMED",
+            constructionProcurementMethod=self.construction_procurement_method,
+        )
+
+        response = self.client.post(
+            f"/construction-handovers/{handover.id}/transitions/",
+            {"to": "MOVED_TO_CONSTRUCTION_PREPARATION"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        handover.refresh_from_db()
+        self.assertEqual(handover.status, "PROJECT_MANAGER_NAMED")
+
+    def test_transitions_returns_400_when_target_status_missing(self):
+        handover = ConstructionHandover.objects.create(
+            project=self.project,
+            status="DRAFT",
+        )
+
+        response = self.client.post(
+            f"/construction-handovers/{handover.id}/transitions/",
+            {},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data["detail"], "Field 'to' is required.")
+        self.assertEqual(response.data["currentStatus"], "DRAFT")
+        self.assertEqual(response.data["possibleTransitions"], ["SUBMITTED_TO_PROGRAMMER"])
+
+    def test_transitions_rejects_skipping_status(self):
+        handover = ConstructionHandover.objects.create(
+            project=self.project,
+            status="DRAFT",
+            constructionProjectManager=self.person_construction,
+        )
+
+        response = self.client.post(
+            f"/construction-handovers/{handover.id}/transitions/",
+            {"to": "SUBMITTED_TO_CONSTRUCTION"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_409_CONFLICT)
+        self.assertEqual(response.data["detail"], "Invalid status transition.")
+        self.assertEqual(response.data["possibleTransitions"], ["SUBMITTED_TO_PROGRAMMER"])
+
+        handover.refresh_from_db()
+        self.assertEqual(handover.status, "DRAFT")
+
+    def test_transitions_rejects_unknown_status(self):
+        handover = ConstructionHandover.objects.create(
+            project=self.project,
+            status="DRAFT",
+            constructionProjectManager=self.person_construction,
+        )
+
+        response = self.client.post(
+            f"/construction-handovers/{handover.id}/transitions/",
+            {"to": "INVALID_STATUS"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data["detail"], "Invalid status 'INVALID_STATUS'.")
+
+    @patch("infraohjelmointi_api.views.ConstructionHandoverViewSet.IsConstructionManagementLead.user_in_construction_management_lead_group", return_value=True)
+    def test_partial_update_auto_transitions_to_project_manager_named_when_trigger_fields_are_updated(self, _mock_is_construction_management_lead):
+        self.client.force_authenticate(user=self.user_1)
+
+        updated_procurement_method = ConstructionProcurementMethod.objects.create(
+            value="Yhteistoiminnalliset",
+        )
+
+        handover = ConstructionHandover.objects.create(
+            project=self.project,
+            status="SUBMITTED_TO_CONSTRUCTION",
+            constructionProjectManager=self.person_construction,
+            constructionProcurementMethod=self.construction_procurement_method,
+        )
+
+        response = self.client.patch(
+            f"/construction-handovers/{handover.id}/",
+            {
+                "constructionProjectManager": str(self.person_planning.id),
+                "constructionProcurementMethod": str(updated_procurement_method.id),
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        handover.refresh_from_db()
+        self.assertEqual(handover.status, "PROJECT_MANAGER_NAMED")
+        self.assertEqual(handover.constructionProjectManager_id, self.person_planning.id)
+        self.assertEqual(
+            handover.constructionProcurementMethod_id,
+            updated_procurement_method.id,
+        )
+
+    @patch("infraohjelmointi_api.views.ConstructionHandoverViewSet.IsConstructionManagementLead.user_in_construction_management_lead_group", return_value=False)
+    def test_partial_update_auto_transition_returns_403_for_non_construction_management_lead(self, _mock_is_construction_management_lead):
+        self.client.force_authenticate(user=self.user_1)
+
+        handover = ConstructionHandover.objects.create(
+            project=self.project,
+            status="SUBMITTED_TO_CONSTRUCTION",
+            constructionProjectManager=self.person_construction,
+        )
+
+        response = self.client.patch(
+            f"/construction-handovers/{handover.id}/",
+            {"constructionProjectManager": str(self.person_planning.id)},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+        handover.refresh_from_db()
+        self.assertEqual(handover.status, "SUBMITTED_TO_CONSTRUCTION")
+        self.assertEqual(handover.constructionProjectManager_id, self.person_construction.id)
+
+    def test_partial_update_auto_transitions_to_moved_to_construction_preparation_when_only_procurement_method_is_updated(self):
+        self.client.force_authenticate(user=self.user_3)
+
+        updated_procurement_method = ConstructionProcurementMethod.objects.create(
+            value="Kilpailutus",
+        )
+
+        handover = ConstructionHandover.objects.create(
+            project=self.project,
+            status="PROJECT_MANAGER_NAMED",
+            constructionProcurementMethod=self.construction_procurement_method,
+        )
+
+        response = self.client.patch(
+            f"/construction-handovers/{handover.id}/",
+            {"constructionProcurementMethod": str(updated_procurement_method.id)},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        handover.refresh_from_db()
+        self.assertEqual(handover.status, "MOVED_TO_CONSTRUCTION_PREPARATION")
+        self.assertEqual(
+            handover.constructionProcurementMethod_id,
+            updated_procurement_method.id,
+        )
+
+    def test_partial_update_does_not_auto_transition_to_moved_to_construction_preparation_when_extra_fields_are_present(self):
+        self.client.force_authenticate(user=self.user_3)
+
+        handover = ConstructionHandover.objects.create(
+            project=self.project,
+            status="PROJECT_MANAGER_NAMED",
+            constructionProcurementMethod=self.construction_procurement_method,
+        )
+
+        response = self.client.patch(
+            f"/construction-handovers/{handover.id}/",
+            {
+                "constructionProcurementMethod": str(self.construction_procurement_method.id),
+                "otherTimelineNotes": "extra update",
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_409_CONFLICT)
+        self.assertEqual(
+            response.data["detail"],
+            "Only construction handovers in DRAFT status can be edited.",
+        )
+
+        handover.refresh_from_db()
+        self.assertEqual(handover.status, "PROJECT_MANAGER_NAMED")

--- a/infraohjelmointi_api/tests/test_ConstructionHandoverViewSet.py
+++ b/infraohjelmointi_api/tests/test_ConstructionHandoverViewSet.py
@@ -2,6 +2,7 @@ from unittest.mock import patch
 from datetime import date
 
 from django.contrib.auth import get_user_model
+from django.conf import settings
 from django.test import TestCase
 from rest_framework import status
 from rest_framework.test import APIClient
@@ -84,8 +85,32 @@ class ConstructionHandoverViewSetTestCase(TestCase):
             name="sg_kymp_sso_io_projektipaallikot",
             display_name="Project Managers",
         )
+        self.programmer_group = ADGroup.objects.create(
+            name="sg_kymp_sso_io_ohjelmoijat",
+            display_name="Programmers",
+        )
+        self.construction_management_lead_group = ADGroup.objects.create(
+            name="sg_kymp_sso_io_rakennuttamisen_esihenkilot",
+            display_name="Construction Management Leads",
+        )
         self.user_2.ad_groups.add(self.project_manager_group)
         self.user_3.ad_groups.add(self.project_manager_group)
+
+        self.user_4 = User.objects.create(
+            username="handover_user_4",
+            first_name="Handover",
+            last_name="User Four",
+            email="handover4@example.com",
+        )
+        self.user_4.ad_groups.add(self.programmer_group)
+
+        self.user_5 = User.objects.create(
+            username="handover_user_6",
+            first_name="Handover",
+            last_name="User Six",
+            email="handover6@example.com",
+        )
+        self.user_5.ad_groups.add(self.construction_management_lead_group)
 
     def test_get_serializer_class_by_action(self):
         viewset = ConstructionHandoverViewSet()
@@ -405,9 +430,8 @@ class ConstructionHandoverViewSetTestCase(TestCase):
         handover.refresh_from_db()
         self.assertEqual(handover.status, "DRAFT")
 
-    @patch("infraohjelmointi_api.views.ConstructionHandoverViewSet.IsPlanner.user_in_planner_group", return_value=True)
-    def test_transitions_allows_submitted_to_construction_for_programmer(self, _mock_is_programmer):
-        self.client.force_authenticate(user=self.user_1)
+    def test_transitions_allows_submitted_to_construction_for_programmer(self):
+        self.client.force_authenticate(user=self.user_4)
 
         handover = ConstructionHandover.objects.create(
             project=self.project,
@@ -424,8 +448,7 @@ class ConstructionHandoverViewSetTestCase(TestCase):
         handover.refresh_from_db()
         self.assertEqual(handover.status, "SUBMITTED_TO_CONSTRUCTION")
 
-    @patch("infraohjelmointi_api.views.ConstructionHandoverViewSet.IsPlanner.user_in_planner_group", return_value=False)
-    def test_transitions_denies_submitted_to_construction_for_non_programmer(self, _mock_is_programmer):
+    def test_transitions_denies_submitted_to_construction_for_non_programmer(self):
         self.client.force_authenticate(user=self.user_1)
 
         handover = ConstructionHandover.objects.create(
@@ -443,9 +466,8 @@ class ConstructionHandoverViewSetTestCase(TestCase):
         handover.refresh_from_db()
         self.assertEqual(handover.status, "SUBMITTED_TO_PROGRAMMER")
 
-    @patch("infraohjelmointi_api.views.ConstructionHandoverViewSet.IsConstructionManagementLead.user_in_construction_management_lead_group", return_value=True)
-    def test_transitions_allows_project_manager_named_for_construction_management_lead(self, _mock_is_construction_management_lead):
-        self.client.force_authenticate(user=self.user_1)
+    def test_transitions_allows_project_manager_named_for_construction_management_lead(self):
+        self.client.force_authenticate(user=self.user_5)
 
         handover = ConstructionHandover.objects.create(
             project=self.project,
@@ -463,8 +485,7 @@ class ConstructionHandoverViewSetTestCase(TestCase):
         handover.refresh_from_db()
         self.assertEqual(handover.status, "PROJECT_MANAGER_NAMED")
 
-    @patch("infraohjelmointi_api.views.ConstructionHandoverViewSet.IsConstructionManagementLead.user_in_construction_management_lead_group", return_value=False)
-    def test_transitions_denies_project_manager_named_for_non_construction_management_lead(self, _mock_is_construction_management_lead):
+    def test_transitions_denies_project_manager_named_for_non_construction_management_lead(self):
         self.client.force_authenticate(user=self.user_1)
 
         handover = ConstructionHandover.objects.create(
@@ -483,9 +504,8 @@ class ConstructionHandoverViewSetTestCase(TestCase):
         handover.refresh_from_db()
         self.assertEqual(handover.status, "SUBMITTED_TO_CONSTRUCTION")
 
-    @patch("infraohjelmointi_api.views.ConstructionHandoverViewSet.IsConstructionManagementLead.user_in_construction_management_lead_group", return_value=True)
-    def test_transitions_denies_project_manager_named_when_construction_project_manager_missing(self, _mock_is_construction_management_lead):
-        self.client.force_authenticate(user=self.user_1)
+    def test_transitions_denies_project_manager_named_when_construction_project_manager_missing(self):
+        self.client.force_authenticate(user=self.user_5)
 
         handover = ConstructionHandover.objects.create(
             project=self.project,
@@ -599,9 +619,8 @@ class ConstructionHandoverViewSetTestCase(TestCase):
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(response.data["detail"], "Invalid status 'INVALID_STATUS'.")
 
-    @patch("infraohjelmointi_api.views.ConstructionHandoverViewSet.IsConstructionManagementLead.user_in_construction_management_lead_group", return_value=True)
-    def test_partial_update_auto_transitions_to_project_manager_named_when_trigger_fields_are_updated(self, _mock_is_construction_management_lead):
-        self.client.force_authenticate(user=self.user_1)
+    def test_partial_update_auto_transitions_to_project_manager_named_when_trigger_fields_are_updated(self):
+        self.client.force_authenticate(user=self.user_5)
 
         updated_procurement_method = ConstructionProcurementMethod.objects.create(
             value="Yhteistoiminnalliset",
@@ -629,9 +648,8 @@ class ConstructionHandoverViewSetTestCase(TestCase):
         self.assertEqual(handover.status, "PROJECT_MANAGER_NAMED")
         self.assertEqual(handover.constructionProjectManager_id, self.person_planning.id)
 
-    @patch("infraohjelmointi_api.views.ConstructionHandoverViewSet.IsConstructionManagementLead.user_in_construction_management_lead_group", return_value=True)
-    def test_partial_update_does_not_auto_transition_to_project_manager_named_when_only_procurement_method_is_updated(self, _mock_is_construction_management_lead):
-        self.client.force_authenticate(user=self.user_1)
+    def test_partial_update_does_not_auto_transition_to_project_manager_named_when_only_procurement_method_is_updated(self):
+        self.client.force_authenticate(user=self.user_5)
 
         updated_procurement_method = ConstructionProcurementMethod.objects.create(
             value="Yhteistoiminnalliset",
@@ -665,8 +683,7 @@ class ConstructionHandoverViewSetTestCase(TestCase):
             self.construction_procurement_method.id,
         )
 
-    @patch("infraohjelmointi_api.views.ConstructionHandoverViewSet.IsConstructionManagementLead.user_in_construction_management_lead_group", return_value=False)
-    def test_partial_update_auto_transition_returns_403_for_non_construction_management_lead(self, _mock_is_construction_management_lead):
+    def test_partial_update_auto_transition_returns_403_for_non_construction_management_lead(self):
         self.client.force_authenticate(user=self.user_1)
 
         handover = ConstructionHandover.objects.create(

--- a/infraohjelmointi_api/tests/test_ConstructionHandoverViewSet.py
+++ b/infraohjelmointi_api/tests/test_ConstructionHandoverViewSet.py
@@ -628,9 +628,41 @@ class ConstructionHandoverViewSetTestCase(TestCase):
         handover.refresh_from_db()
         self.assertEqual(handover.status, "PROJECT_MANAGER_NAMED")
         self.assertEqual(handover.constructionProjectManager_id, self.person_planning.id)
+
+    @patch("infraohjelmointi_api.views.ConstructionHandoverViewSet.IsConstructionManagementLead.user_in_construction_management_lead_group", return_value=True)
+    def test_partial_update_does_not_auto_transition_to_project_manager_named_when_only_procurement_method_is_updated(self, _mock_is_construction_management_lead):
+        self.client.force_authenticate(user=self.user_1)
+
+        updated_procurement_method = ConstructionProcurementMethod.objects.create(
+            value="Yhteistoiminnalliset",
+        )
+
+        handover = ConstructionHandover.objects.create(
+            project=self.project,
+            status="SUBMITTED_TO_CONSTRUCTION",
+            constructionProjectManager=self.person_construction,
+            constructionProcurementMethod=self.construction_procurement_method,
+        )
+
+        response = self.client.patch(
+            f"/construction-handovers/{handover.id}/",
+            {
+                "constructionProcurementMethod": str(updated_procurement_method.id),
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_409_CONFLICT)
+        self.assertEqual(
+            response.data["detail"],
+            "Only construction handovers in DRAFT status can be edited.",
+        )
+
+        handover.refresh_from_db()
+        self.assertEqual(handover.status, "SUBMITTED_TO_CONSTRUCTION")
         self.assertEqual(
             handover.constructionProcurementMethod_id,
-            updated_procurement_method.id,
+            self.construction_procurement_method.id,
         )
 
     @patch("infraohjelmointi_api.views.ConstructionHandoverViewSet.IsConstructionManagementLead.user_in_construction_management_lead_group", return_value=False)

--- a/infraohjelmointi_api/tests/test_ProjectPersonAuthorizationService.py
+++ b/infraohjelmointi_api/tests/test_ProjectPersonAuthorizationService.py
@@ -1,0 +1,65 @@
+from types import SimpleNamespace
+
+from django.test import SimpleTestCase
+
+from infraohjelmointi_api.services.ProjectPersonAuthorizationService import (
+    ProjectPersonAuthorizationService,
+)
+
+
+class ProjectPersonAuthorizationServiceTestCase(SimpleTestCase):
+    def setUp(self):
+        self.auth_user = SimpleNamespace(
+            is_authenticated=True,
+            email="User@Example.com ",
+        )
+        self.unauth_user = SimpleNamespace(
+            is_authenticated=False,
+            email="user@example.com",
+        )
+        self.person_match = SimpleNamespace(email=" user@example.com")
+        self.person_other = SimpleNamespace(email="other@example.com")
+
+    def test_is_matching_project_person_email_returns_true_for_case_and_space_insensitive_match(self):
+        result = ProjectPersonAuthorizationService.is_matching_project_person_email(
+            user=self.auth_user,
+            person=self.person_match,
+        )
+
+        self.assertTrue(result)
+
+    def test_is_matching_project_person_email_returns_false_for_unauthenticated_user(self):
+        result = ProjectPersonAuthorizationService.is_matching_project_person_email(
+            user=self.unauth_user,
+            person=self.person_match,
+        )
+
+        self.assertFalse(result)
+
+    def test_is_matching_project_person_email_returns_false_for_non_matching_email(self):
+        result = ProjectPersonAuthorizationService.is_matching_project_person_email(
+            user=self.auth_user,
+            person=self.person_other,
+        )
+
+        self.assertFalse(result)
+
+    def test_is_person_planning_for_project_uses_project_person_planning(self):
+        project = SimpleNamespace(personPlanning=self.person_match)
+
+        result = ProjectPersonAuthorizationService.is_person_planning_for_project(
+            user=self.auth_user,
+            project=project,
+        )
+
+        self.assertTrue(result)
+
+    def test_is_person_construction_for_project_uses_project_person_construction(self):
+        project = SimpleNamespace(personConstruction=self.person_match)
+
+        result = ProjectPersonAuthorizationService.is_person_construction_for_project(
+            user=self.auth_user,
+            project=project,
+        )
+
+        self.assertTrue(result)

--- a/infraohjelmointi_api/views/BaseViewSet.py
+++ b/infraohjelmointi_api/views/BaseViewSet.py
@@ -20,6 +20,7 @@ class BaseViewSet(viewsets.ModelViewSet):
             | IsProjectManager
             | IsViewer
             | IsAdmin
+            | IsConstructionManagementLead
         )
     ]
     authentication_classes = [ApiTokenAuthentication, SessionAuthentication]

--- a/infraohjelmointi_api/views/ConstructionHandoverViewSet.py
+++ b/infraohjelmointi_api/views/ConstructionHandoverViewSet.py
@@ -1,10 +1,16 @@
 from overrides import override
+from django.db import transaction
 from rest_framework.response import Response
 from rest_framework import status
+from rest_framework.decorators import action
 
 from infraohjelmointi_api.models import ConstructionHandover
 
 from .BaseViewSet import BaseViewSet
+from ..permissions import IsConstructionManagementLead, IsPlanner, IsProjectManager
+from ..services.ConstructionHandoverTransitionPermissionService import (
+    ConstructionHandoverTransitionPermissionService,
+)
 from infraohjelmointi_api.serializers import (
     ConstructionHandoverGetSerializer,
     ConstructionHandoverCreateSerializer,
@@ -12,6 +18,18 @@ from infraohjelmointi_api.serializers import (
 )
 
 class ConstructionHandoverViewSet(BaseViewSet):
+    ALLOWED_STATUS_TRANSITIONS = {
+        "DRAFT": ["SUBMITTED_TO_PROGRAMMER"],
+        "SUBMITTED_TO_PROGRAMMER": ["SUBMITTED_TO_CONSTRUCTION"],
+        "SUBMITTED_TO_CONSTRUCTION": ["PROJECT_MANAGER_NAMED"],
+        "PROJECT_MANAGER_NAMED": ["MOVED_TO_CONSTRUCTION_PREPARATION"],
+        "MOVED_TO_CONSTRUCTION_PREPARATION": [],
+    }
+
+    AUTO_TRANSITION_TRIGGER_FIELDS = {
+        "constructionProjectManager",
+        "constructionProcurementMethod",
+    }
     
     """
     API endpoint that allows construction handovers to be viewed or edited.
@@ -71,12 +89,36 @@ class ConstructionHandoverViewSet(BaseViewSet):
         Overriden ModelViewSet class method to prevent updates if the handover is locked (not in DRAFT status)
         """
         instance = self.get_object()
-        if instance.is_locked:
+        auto_transition_target_status = self._get_auto_transition_target_status(
+            request=request,
+            instance=instance,
+        )
+        should_auto_transition = auto_transition_target_status is not None
+
+        if instance.is_locked and not should_auto_transition:
             return Response(
                 {"detail": "Only construction handovers in DRAFT status can be edited."},
                 status=status.HTTP_409_CONFLICT,
             )
-        return super().partial_update(request, *args, **kwargs)
+
+        with transaction.atomic():
+            response = super().partial_update(request, *args, **kwargs)
+            if response.status_code != status.HTTP_200_OK or not should_auto_transition:
+                return response
+
+            instance.refresh_from_db()
+            transition_error_response = self._transition_to_status(
+                request=request,
+                instance=instance,
+                requested_status=auto_transition_target_status,
+            )
+            if transition_error_response:
+                # Keep update+transition atomic: if transition fails, revert PATCH changes.
+                transaction.set_rollback(True)
+                return transition_error_response
+
+            serializer = self.get_serializer(instance)
+            return Response(serializer.data, status=status.HTTP_200_OK)
     
     @override
     def destroy(self, request, *args, **kwargs):
@@ -90,3 +132,151 @@ class ConstructionHandoverViewSet(BaseViewSet):
                 status=status.HTTP_409_CONFLICT,
             )
         return super().destroy(request, *args, **kwargs)
+
+    def _get_possible_status_transitions(self, current_status):
+        return self.ALLOWED_STATUS_TRANSITIONS.get(current_status, [])
+
+    def _is_project_manager(self, request):
+        return IsProjectManager().user_in_project_manager_group(request=request)
+    
+    def _is_programmer(self, request):
+        return IsPlanner().user_in_planner_group(request=request)
+    
+    def _is_construction_management_lead(self, request):
+        return IsConstructionManagementLead().user_in_construction_management_lead_group(request=request)
+
+    def _get_incoming_patch_fields(self, request):
+        return set(getattr(request.data, "keys", lambda: [])())
+
+    def _get_auto_transition_target_status(self, request, instance):
+        if self._should_auto_transition_to_project_manager_named(request=request, instance=instance):
+            return "PROJECT_MANAGER_NAMED"
+
+        if self._should_auto_transition_to_moved_to_construction_preparation(
+            request=request,
+            instance=instance,
+        ):
+            return "MOVED_TO_CONSTRUCTION_PREPARATION"
+
+        return None
+    
+    def _should_auto_transition_to_project_manager_named(self, request, instance):
+        if instance.status != "SUBMITTED_TO_CONSTRUCTION":
+            return False
+
+        incoming_fields = self._get_incoming_patch_fields(request)
+        return bool(incoming_fields & self.AUTO_TRANSITION_TRIGGER_FIELDS)
+
+    def _should_auto_transition_to_moved_to_construction_preparation(self, request, instance):
+        if instance.status != "PROJECT_MANAGER_NAMED":
+            return False
+
+        incoming_fields = self._get_incoming_patch_fields(request)
+        return incoming_fields == {"constructionProcurementMethod"}
+
+    def _transition_to_status(self, request, instance, requested_status):
+        possible_statuses = self._get_possible_status_transitions(instance.status)
+
+        valid_statuses = {choice[0] for choice in instance.STATUS_CHOICES}
+        if requested_status not in valid_statuses:
+            return Response(
+                {
+                    "detail": f"Invalid status '{requested_status}'.",
+                    "currentStatus": instance.status,
+                    "possibleTransitions": possible_statuses,
+                },
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        if requested_status not in possible_statuses:
+            return Response(
+                {
+                    "detail": "Invalid status transition.",
+                    "currentStatus": instance.status,
+                    "possibleTransitions": possible_statuses,
+                },
+                status=status.HTTP_409_CONFLICT,
+            )
+
+        if (
+            requested_status == "PROJECT_MANAGER_NAMED"
+            and instance.constructionProjectManager_id in (None, "")
+        ):
+            return Response(
+                {
+                    "detail": "constructionProjectManager is required for this transition.",
+                    "currentStatus": instance.status,
+                    "possibleTransitions": possible_statuses,
+                },
+                status=status.HTTP_409_CONFLICT,
+            )
+
+        if (
+            requested_status == "MOVED_TO_CONSTRUCTION_PREPARATION"
+            and instance.constructionProcurementMethod_id in (None, "")
+        ):
+            return Response(
+                {
+                    "detail": "constructionProcurementMethod is required for this transition.",
+                    "currentStatus": instance.status,
+                    "possibleTransitions": possible_statuses,
+                },
+                status=status.HTTP_409_CONFLICT,
+            )
+        
+        if not ConstructionHandoverTransitionPermissionService.is_transition_allowed(
+            requested_status=requested_status,
+            user=self._get_authenticated_user(request),
+            project=instance.project,
+            is_project_manager=self._is_project_manager(request),
+            is_programmer=self._is_programmer(request),
+            is_construction_management_lead=self._is_construction_management_lead(request),
+        ):
+            return Response(
+                {
+                    "detail": "You do not have permission to perform this transition.",
+                    "currentStatus": instance.status,
+                    "possibleTransitions": possible_statuses,
+                },
+                status=status.HTTP_403_FORBIDDEN,
+            )
+
+        user = self._get_authenticated_user(request)
+        instance.status = requested_status
+        if user:
+            instance.updatedBy = user
+        instance.save()
+
+        return None
+    
+    @action(methods=["post"], detail=True, url_path=r"transitions")
+    def transitions(self, request, pk=None):
+        instance = self.get_object()
+        possible_statuses = self._get_possible_status_transitions(instance.status)
+        requested_status = request.data.get("to")
+
+        if requested_status is None:
+            return Response(
+                {
+                    "detail": "Field 'to' is required.",
+                    "currentStatus": instance.status,
+                    "possibleTransitions": possible_statuses,
+                },
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        transition_error_response = self._transition_to_status(
+            request=request,
+            instance=instance,
+            requested_status=requested_status,
+        )
+        if transition_error_response:
+            return transition_error_response
+
+        return Response(
+            {
+                "currentStatus": instance.status,
+                "possibleTransitions": self._get_possible_status_transitions(instance.status),
+            },
+            status=status.HTTP_200_OK,
+        )

--- a/infraohjelmointi_api/views/ConstructionHandoverViewSet.py
+++ b/infraohjelmointi_api/views/ConstructionHandoverViewSet.py
@@ -25,11 +25,6 @@ class ConstructionHandoverViewSet(BaseViewSet):
         "PROJECT_MANAGER_NAMED": ["MOVED_TO_CONSTRUCTION_PREPARATION"],
         "MOVED_TO_CONSTRUCTION_PREPARATION": [],
     }
-
-    AUTO_TRANSITION_TRIGGER_FIELDS = {
-        "constructionProjectManager",
-        "constructionProcurementMethod",
-    }
     
     """
     API endpoint that allows construction handovers to be viewed or edited.
@@ -165,7 +160,7 @@ class ConstructionHandoverViewSet(BaseViewSet):
             return False
 
         incoming_fields = self._get_incoming_patch_fields(request)
-        return bool(incoming_fields & self.AUTO_TRANSITION_TRIGGER_FIELDS)
+        return bool(incoming_fields & {"constructionProjectManager"})
 
     def _should_auto_transition_to_moved_to_construction_preparation(self, request, instance):
         if instance.status != "PROJECT_MANAGER_NAMED":


### PR DESCRIPTION
Add /construction-handovers/{id}/transitions/ endpoint for making status transitions on Construction handover.

Restrictions for making transitions:
- For SUBMITTED_TO_PROGRAMMER user has to be in project managers group (projektipaallikot)
and be personPlanning for related project
- For SUBMITTED_TO_CONSTRUCTION user has to be in planner group (ohjelmoijat)
- For PROJECT_MANAGER_NAMED user has to be in construction management lead group (rakennuttamisen esihenkilot)
- For MOVED_TO_CONSTRUCTION_PREPARATION user has to be in project managers group and be personConstruction for related project

Auto transition to PROJECT_MANAGER_NAMED status
when updating handover with status SUBMITTED_TO_CONSTRUCTION and constructionProjectManager and constructionProcurementMethod fields in the request.

Auto transition to MOVED_TO_CONSTRUCTION_PREPARATION status when updating handover with status PROJECT_MANAGER_NAMED and constructionProcurementMethod field in the request.

Also implement IO-867 to add support for construction management lead group.