### PR TITLE
IO-845 Ship audit logs to Platta Elastic Cloud via django-resilient-logger

### DIFF
--- a/.env.template
+++ b/.env.template
@@ -83,3 +83,16 @@ SAP_COMMITMENTS_ENDPOINT="CommitmentLinesSet?saml2=disabled&$format=json&$filter
 SAP_USERNAME=
 SAP_PASSWORD=
 WORKERS_AMOUNT_FOR_UVICORN=2
+
+# Audit logging to Plata Elastic Cloud (IO-845).
+# AUDIT_LOG_ENV is the environment label included in every entry (e.g. development,
+# test, staging, production). The remaining AUDIT_LOG_ES_* values are provided by
+# Plata via their Ansible-generated DevOps PR; AUDIT_LOG_ES_PASSWORD comes from the
+# application's Azure Key Vault. When AUDIT_LOG_ES_URL is unset (e.g. local dev),
+# audit entries still queue into the local ResilientLogEntry table; the cron-driven
+# submit_unsent_entries command becomes a no-op until the target is configured.
+AUDIT_LOG_ENV=development
+#AUDIT_LOG_ES_URL=
+#AUDIT_LOG_ES_USERNAME=
+#AUDIT_LOG_ES_PASSWORD=
+#AUDIT_LOG_ES_INDEX=

--- a/.env.template
+++ b/.env.template
@@ -84,10 +84,10 @@ SAP_USERNAME=
 SAP_PASSWORD=
 WORKERS_AMOUNT_FOR_UVICORN=2
 
-# Audit logging to Plata Elastic Cloud (IO-845).
+# Audit logging to Platta Elastic Cloud (IO-845).
 # AUDIT_LOG_ENV is the environment label included in every entry (e.g. development,
 # test, staging, production). The remaining AUDIT_LOG_ES_* values are provided by
-# Plata via their Ansible-generated DevOps PR; AUDIT_LOG_ES_PASSWORD comes from the
+# Platta via their Ansible-generated DevOps PR; AUDIT_LOG_ES_PASSWORD comes from the
 # application's Azure Key Vault. When AUDIT_LOG_ES_URL is unset (e.g. local dev),
 # audit entries still queue into the local ResilientLogEntry table; the cron-driven
 # submit_unsent_entries command becomes a no-op until the target is configured.

--- a/README.md
+++ b/README.md
@@ -306,6 +306,41 @@ The Redis deployment is handled by the pipeline (`devops/redis-deployment.yml`).
 - A circuit breaker disables cache operations after repeated failures to prevent cascading issues
 - Cache is automatically re-enabled when Redis becomes available again
 
+## Audit logging
+
+Changes to project cards (field edits, financial figure edits, and project
+deletions) are recorded as audit log entries. Each event is written in two
+places (dual-write):
+
+- the local `AuditLog` table, served by the `/audit-logs/` endpoint (the IO-404
+  admin UI)
+- a `ResilientLogEntry` queue (from
+  [django-resilient-logger](https://github.com/City-of-Helsinki/django-resilient-logger))
+  that a Platta cron job ships to their Elastic Cloud audit index
+
+### Local development
+
+No configuration needed. Without the `AUDIT_LOG_ES_*` variables the Elastic
+target is not registered, so entries simply queue locally in `ResilientLogEntry`
+and are never shipped — this is expected and harmless.
+
+### Production
+
+The Elastic Cloud target is enabled by these variables (added to the Azure
+DevOps pipeline by Platta's automation):
+
+| Variable | Notes |
+|----------|-------|
+| `AUDIT_LOG_ENV` | environment name, e.g. `production` |
+| `AUDIT_LOG_ES_URL` | Elastic Cloud endpoint |
+| `AUDIT_LOG_ES_INDEX` | per-app, per-env index |
+| `AUDIT_LOG_ES_USERNAME` | logger user |
+| `AUDIT_LOG_ES_PASSWORD` | from Azure Key Vault (`AUDIT-LOG-ES-PASSWORD`) |
+
+The `X-Request-Id` request header is captured into each entry for traceability.
+
+More documentation on [Confluence](https://helsinkisolutionoffice.atlassian.net/wiki/spaces/IO/pages/8131444804/Infraohjelmointi+API+-sovellus#Logitus).
+
 ## External data sources
 
 Infra tool project data and financial data can be imported from external sources.

--- a/infraohjelmointi_api/migrations/0108_migrate_auditlog_to_resilient_logger.py
+++ b/infraohjelmointi_api/migrations/0108_migrate_auditlog_to_resilient_logger.py
@@ -1,0 +1,93 @@
+"""IO-845 — copy historical AuditLog rows into ResilientLogEntry.
+
+Once Plata's submit_unsent_entries cron runs, this backfilled history will be
+shipped to Elastic Cloud alongside fresh entries written by ProjectViewSet's
+dual-write. The context shape mirrors the live emit so historical and live
+entries are indistinguishable in Elastic, except that migrated rows carry
+``orig_entry_id`` / ``orig_created_at`` markers that point back to the old
+AuditLog row.
+"""
+import logging
+from datetime import timezone
+
+from django.apps.registry import Apps
+from django.db import migrations
+
+
+BATCH_SIZE = 1000
+
+
+def _actor_dict(actor):
+    if not actor:
+        return {}
+    full_name = f"{actor.first_name} {actor.last_name}".strip()
+    return {
+        "name": full_name or actor.username,
+        "email": actor.email,
+    }
+
+
+def _target_dict(project):
+    if not project:
+        return {}
+    return {
+        "type": "project",
+        "id": str(project.id),
+        "name": project.name,
+    }
+
+
+def migrate_auditlog_to_resilient_logger(apps: Apps, schema_editor):
+    AuditLog = apps.get_model("infraohjelmointi_api", "AuditLog")
+    ResilientLogEntry = apps.get_model("resilient_logger", "ResilientLogEntry")
+
+    queryset = AuditLog.objects.select_related("actor", "project").order_by("createdDate")
+
+    batch = []
+    for entry in queryset.iterator(chunk_size=BATCH_SIZE):
+        actor = entry.actor
+        project = entry.project
+        target_data = _target_dict(project)
+
+        batch.append(
+            ResilientLogEntry(
+                is_sent=False,
+                level=logging.INFO,
+                message=f"{entry.operation} on {target_data.get('name', 'unknown')}",
+                context={
+                    "actor": _actor_dict(actor),
+                    "operation": entry.operation,
+                    "target": target_data,
+                    "status": entry.status,
+                    "old_values": entry.old_values,
+                    "new_values": entry.new_values,
+                    "endpoint": entry.endpoint,
+                    "orig_entry_id": str(entry.id),
+                    "orig_created_at": entry.createdDate.astimezone(timezone.utc)
+                    .isoformat(timespec="milliseconds")
+                    .replace("+00:00", "Z"),
+                },
+            )
+        )
+
+        if len(batch) >= BATCH_SIZE:
+            ResilientLogEntry.objects.bulk_create(batch)
+            batch = []
+
+    if batch:
+        ResilientLogEntry.objects.bulk_create(batch)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("infraohjelmointi_api", "0107_constructionhandoverfinancing"),
+        ("resilient_logger", "0004_remove_explicit_id"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            migrate_auditlog_to_resilient_logger,
+            migrations.RunPython.noop,
+        ),
+    ]

--- a/infraohjelmointi_api/migrations/0108_migrate_auditlog_to_resilient_logger.py
+++ b/infraohjelmointi_api/migrations/0108_migrate_auditlog_to_resilient_logger.py
@@ -1,6 +1,6 @@
 """IO-845 — copy historical AuditLog rows into ResilientLogEntry.
 
-Once Plata's submit_unsent_entries cron runs, this backfilled history will be
+Once Platta's submit_unsent_entries cron runs, this backfilled history will be
 shipped to Elastic Cloud alongside fresh entries written by ProjectViewSet's
 dual-write. The context shape mirrors the live emit so historical and live
 entries are indistinguishable in Elastic, except that migrated rows carry

--- a/infraohjelmointi_api/tests/test_resilient_audit_logging.py
+++ b/infraohjelmointi_api/tests/test_resilient_audit_logging.py
@@ -1,0 +1,286 @@
+"""IO-845 — tests for the resilient_logger dual-write audit pipeline.
+
+Covers:
+- The ``audit_log_project_card_changes`` helper writes a row to *both*
+  ``AuditLog`` (legacy local table that powers /audit-logs/) and
+  ``ResilientLogEntry`` (queue picked up by Plata's submit_unsent_entries
+  cron and shipped to Elastic Cloud).
+- The X-Request-Id header captured in ``initialize_request`` flows through
+  to the resilient log entry's context as ``x_request_id``, and is omitted
+  when the header is absent.
+- The 0105 data migration callable copies historical AuditLog rows into
+  ResilientLogEntry with the same context shape used by live writes.
+"""
+import importlib
+import logging
+import uuid
+from unittest.mock import patch
+
+from django.apps import apps as django_apps
+from django.test import TestCase
+from rest_framework.test import APIRequestFactory
+from resilient_logger.models import ResilientLogEntry
+
+from infraohjelmointi_api.models import AuditLog, Project, User
+from infraohjelmointi_api.views.ProjectViewSet import ProjectViewSet
+
+
+# Sentinel so callers can pass user=None explicitly and have it forwarded.
+_UNSET = object()
+
+
+@patch.object(ProjectViewSet, "authentication_classes", new=[])
+@patch.object(ProjectViewSet, "permission_classes", new=[])
+class AuditLogDualWriteTestCase(TestCase):
+    """Helper-level dual-write behavior."""
+
+    def setUp(self):
+        self.factory = APIRequestFactory()
+
+        self.user = User.objects.create(
+            first_name="Audit",
+            last_name="Tester",
+            username="audit_tester",
+            email="audit.tester@example.com",
+        )
+        self.project = Project.objects.create(
+            id=uuid.uuid4(),
+            name="Audit Test Project",
+            description="for IO-845 tests",
+            hkrId=99001,
+        )
+
+        self.viewset = ProjectViewSet()
+        # action_map is normally populated by DRF's as_view() routing; supply
+        # it manually so initialize_request() can resolve self.action.
+        self.viewset.action_map = {"patch": "partial_update", "delete": "destroy"}
+        self.viewset.request = self.factory.patch("/projects/")
+        self.viewset.request._audit_request_id = None
+
+    def _call_helper(self, *, operation, project, old_values, new_values, user=_UNSET, url="/projects/x/"):
+        self.viewset.audit_log_project_card_changes(
+            old_values,
+            new_values,
+            project,
+            self.user if user is _UNSET else user,
+            url,
+            operation,
+        )
+
+    def test_update_writes_to_both_auditlog_and_resilient_log(self):
+        self._call_helper(
+            operation="UPDATE",
+            project=self.project,
+            old_values={"name": "Old"},
+            new_values={"name": "New"},
+        )
+
+        self.assertEqual(AuditLog.objects.count(), 1)
+        self.assertEqual(ResilientLogEntry.objects.count(), 1)
+
+        audit = AuditLog.objects.get()
+        self.assertEqual(audit.operation, "UPDATE")
+        self.assertEqual(audit.actor_id, self.user.id)
+        self.assertEqual(audit.project_id, self.project.id)
+        self.assertEqual(audit.old_values, {"name": "Old"})
+        self.assertEqual(audit.new_values, {"name": "New"})
+
+        entry = ResilientLogEntry.objects.get()
+        self.assertEqual(entry.level, logging.INFO)
+        self.assertEqual(entry.message, f"UPDATE on {self.project.name}")
+        self.assertEqual(entry.is_sent, False)
+        self.assertEqual(entry.context["operation"], "UPDATE")
+        self.assertEqual(entry.context["status"], "SUCCESS")
+        self.assertEqual(entry.context["old_values"], {"name": "Old"})
+        self.assertEqual(entry.context["new_values"], {"name": "New"})
+        self.assertEqual(
+            entry.context["target"],
+            {"type": "project", "id": str(self.project.id), "name": self.project.name},
+        )
+        self.assertEqual(
+            entry.context["actor"],
+            {"name": "Audit Tester", "email": "audit.tester@example.com"},
+        )
+        self.assertNotIn("x_request_id", entry.context)
+
+    def test_delete_carries_target_when_project_already_gone(self):
+        # Mirror destroy() flow: project is deleted, helper is called with project=None.
+        self._call_helper(
+            operation="DELETE",
+            project=None,
+            old_values={"name": "Disappeared"},
+            new_values={},
+        )
+
+        entry = ResilientLogEntry.objects.get()
+        self.assertEqual(entry.context["operation"], "DELETE")
+        self.assertEqual(entry.context["target"], {})
+        self.assertEqual(entry.message, "DELETE on unknown")
+
+    def test_finance_update_is_logged_like_a_regular_update(self):
+        self._call_helper(
+            operation="UPDATE",
+            project=self.project,
+            old_values={2026: "100.00"},
+            new_values={2026: 250.0},
+        )
+
+        entry = ResilientLogEntry.objects.get()
+        self.assertEqual(entry.context["operation"], "UPDATE")
+        self.assertEqual(entry.context["old_values"], {"2026": "100.00"})
+        self.assertEqual(entry.context["new_values"], {"2026": 250.0})
+
+    def test_actor_omitted_when_no_user(self):
+        self._call_helper(
+            operation="UPDATE",
+            project=self.project,
+            old_values={},
+            new_values={},
+            user=None,
+        )
+
+        audit = AuditLog.objects.get()
+        self.assertIsNone(audit.actor_id)
+
+        entry = ResilientLogEntry.objects.get()
+        self.assertEqual(entry.context["actor"], {})
+
+    def test_actor_falls_back_to_username_when_name_blank(self):
+        anon = User.objects.create(username="just_a_username", email="a@b.c")
+        self._call_helper(
+            operation="UPDATE",
+            project=self.project,
+            old_values={},
+            new_values={},
+            user=anon,
+        )
+
+        entry = ResilientLogEntry.objects.get()
+        self.assertEqual(
+            entry.context["actor"],
+            {"name": "just_a_username", "email": "a@b.c"},
+        )
+
+    def test_x_request_id_captured_when_header_present(self):
+        request = self.factory.patch("/projects/", HTTP_X_REQUEST_ID="trace-abc-123")
+        drf_request = self.viewset.initialize_request(request)
+        self.viewset.request = drf_request
+
+        self._call_helper(
+            operation="UPDATE",
+            project=self.project,
+            old_values={},
+            new_values={},
+        )
+
+        entry = ResilientLogEntry.objects.get()
+        self.assertEqual(entry.context["x_request_id"], "trace-abc-123")
+
+    def test_x_request_id_omitted_when_header_absent(self):
+        request = self.factory.patch("/projects/")
+        drf_request = self.viewset.initialize_request(request)
+        self.viewset.request = drf_request
+
+        self._call_helper(
+            operation="UPDATE",
+            project=self.project,
+            old_values={},
+            new_values={},
+        )
+
+        entry = ResilientLogEntry.objects.get()
+        self.assertNotIn("x_request_id", entry.context)
+
+
+class AuditLogDataMigrationTestCase(TestCase):
+    """The 0105 migration callable backfills ResilientLogEntry from AuditLog."""
+
+    def setUp(self):
+        self.user = User.objects.create(
+            first_name="Hist",
+            last_name="Orical",
+            username="historical",
+            email="hist@example.com",
+        )
+        self.project = Project.objects.create(
+            id=uuid.uuid4(),
+            name="Historical Project",
+            description="historical project for migration test",
+            hkrId=88001,
+        )
+
+        self.legacy_a = AuditLog.objects.create(
+            actor=self.user,
+            operation="UPDATE",
+            log_level="INFO",
+            origin="infrahankkeiden_ohjelmointi",
+            status="SUCCESS",
+            project=self.project,
+            old_values={"name": "A0"},
+            new_values={"name": "A1"},
+            endpoint="/projects/a/",
+        )
+        self.legacy_b = AuditLog.objects.create(
+            actor=None,
+            operation="DELETE",
+            log_level="INFO",
+            origin="infrahankkeiden_ohjelmointi",
+            status="SUCCESS",
+            project=None,
+            old_values={"name": "B"},
+            new_values={},
+            endpoint="/projects/b/",
+        )
+
+    def _get_migration_module(self):
+        # Migration filename starts with a digit, so we can't `from x import y`
+        # — go through importlib.
+        return importlib.import_module(
+            "infraohjelmointi_api.migrations.0108_migrate_auditlog_to_resilient_logger"
+        )
+
+    def test_migration_copies_historical_rows_into_resilient_log(self):
+        module = self._get_migration_module()
+
+        module.migrate_auditlog_to_resilient_logger(django_apps, schema_editor=None)
+
+        self.assertEqual(ResilientLogEntry.objects.count(), 2)
+
+        a_copy = ResilientLogEntry.objects.get(
+            context__orig_entry_id=str(self.legacy_a.id)
+        )
+        self.assertEqual(a_copy.is_sent, False)
+        self.assertEqual(a_copy.level, logging.INFO)
+        self.assertEqual(a_copy.message, "UPDATE on Historical Project")
+        self.assertEqual(a_copy.context["operation"], "UPDATE")
+        self.assertEqual(a_copy.context["status"], "SUCCESS")
+        self.assertEqual(a_copy.context["old_values"], {"name": "A0"})
+        self.assertEqual(a_copy.context["new_values"], {"name": "A1"})
+        self.assertEqual(a_copy.context["endpoint"], "/projects/a/")
+        self.assertEqual(
+            a_copy.context["target"],
+            {"type": "project", "id": str(self.project.id), "name": self.project.name},
+        )
+        self.assertEqual(
+            a_copy.context["actor"],
+            {"name": "Hist Orical", "email": "hist@example.com"},
+        )
+        self.assertIn("orig_created_at", a_copy.context)
+        self.assertTrue(a_copy.context["orig_created_at"].endswith("Z"))
+
+        b_copy = ResilientLogEntry.objects.get(
+            context__orig_entry_id=str(self.legacy_b.id)
+        )
+        self.assertEqual(b_copy.message, "DELETE on unknown")
+        self.assertEqual(b_copy.context["target"], {})
+        self.assertEqual(b_copy.context["actor"], {})
+
+    def test_migration_is_idempotent_only_in_the_sense_that_reverse_is_a_noop(self):
+        # The forward migration intentionally does not de-dupe — running it
+        # twice would duplicate the backfill. This test pins that contract so
+        # nobody flips it accidentally without thinking through the cron.
+        module = self._get_migration_module()
+        module.migrate_auditlog_to_resilient_logger(django_apps, schema_editor=None)
+        module.migrate_auditlog_to_resilient_logger(django_apps, schema_editor=None)
+
+        self.assertEqual(ResilientLogEntry.objects.count(), 4)

--- a/infraohjelmointi_api/tests/test_resilient_audit_logging.py
+++ b/infraohjelmointi_api/tests/test_resilient_audit_logging.py
@@ -3,12 +3,12 @@
 Covers:
 - The ``audit_log_project_card_changes`` helper writes a row to *both*
   ``AuditLog`` (legacy local table that powers /audit-logs/) and
-  ``ResilientLogEntry`` (queue picked up by Plata's submit_unsent_entries
+  ``ResilientLogEntry`` (queue picked up by Platta's submit_unsent_entries
   cron and shipped to Elastic Cloud).
 - The X-Request-Id header captured in ``initialize_request`` flows through
   to the resilient log entry's context as ``x_request_id``, and is omitted
   when the header is absent.
-- The 0105 data migration callable copies historical AuditLog rows into
+- The 0108 data migration callable copies historical AuditLog rows into
   ResilientLogEntry with the same context shape used by live writes.
 """
 import importlib
@@ -193,7 +193,7 @@ class AuditLogDualWriteTestCase(TestCase):
 
 
 class AuditLogDataMigrationTestCase(TestCase):
-    """The 0105 migration callable backfills ResilientLogEntry from AuditLog."""
+    """The 0108 migration callable backfills ResilientLogEntry from AuditLog."""
 
     def setUp(self):
         self.user = User.objects.create(

--- a/infraohjelmointi_api/views/ProjectViewSet.py
+++ b/infraohjelmointi_api/views/ProjectViewSet.py
@@ -66,6 +66,7 @@ from collections import defaultdict
 from dateutil.relativedelta import relativedelta
 
 logger = logging.getLogger("infraohjelmointi_api")
+audit_logger = logging.getLogger("audit")
 
 
 class ProjectFilter(django_filters.FilterSet):
@@ -110,6 +111,15 @@ class ProjectViewSet(BaseViewSet):
     filter_backends = [DjangoFilterBackend]
     filterset_class = ProjectFilter
     serializer_class = ProjectGetSerializer
+
+    @override
+    def initialize_request(self, request, *args, **kwargs):
+        # Capture the X-Request-Id header (set by Plata at the OpenShift route
+        # level) so that audit log entries can be correlated with HTTP traces.
+        # IO-845.
+        drf_request = super().initialize_request(request, *args, **kwargs)
+        drf_request._audit_request_id = request.META.get("HTTP_X_REQUEST_ID")
+        return drf_request
 
     @override
     def destroy(self, request, *args, **kwargs):
@@ -341,6 +351,8 @@ class ProjectViewSet(BaseViewSet):
         return date
 
     def audit_log_project_card_changes(self, old_values, new_values, project, user, url, operation):
+        # Existing local AuditLog write — kept so /audit-logs/ (used by the
+        # IO-404 admin UI) keeps serving rows. IO-845 dual-write.
         audit_log = AuditLog(
             actor=user if isinstance(user, User) else None,
             operation=operation,
@@ -353,6 +365,40 @@ class ProjectViewSet(BaseViewSet):
             endpoint=url,
         )
         audit_log.save()
+
+        # IO-845: also emit through the "audit" logger so the
+        # ResilientLogHandler queues the entry into ResilientLogEntry, from
+        # where Plata's submit_unsent_entries cron ships it to Elastic Cloud.
+        actor_data = {}
+        if isinstance(user, User):
+            actor_data = {
+                "name": f"{user.first_name} {user.last_name}".strip() or user.username,
+                "email": user.email,
+            }
+
+        target_data = {}
+        if project:
+            target_data = {
+                "type": "project",
+                "id": str(project.id),
+                "name": project.name,
+            }
+
+        request_id = getattr(self.request, "_audit_request_id", None)
+
+        audit_logger.info(
+            f"{operation} on {target_data.get('name', 'unknown')}",
+            extra={
+                "actor": actor_data,
+                "operation": operation,
+                "target": target_data,
+                "status": "SUCCESS",
+                "old_values": old_values,
+                "new_values": new_values,
+                "endpoint": url,
+                **({"x_request_id": request_id} if request_id else {}),
+            },
+        )
 
     def create_updated_finance_instances(self, finances, project, forced_to_frame, year):
         finance_instances = []

--- a/infraohjelmointi_api/views/ProjectViewSet.py
+++ b/infraohjelmointi_api/views/ProjectViewSet.py
@@ -114,7 +114,7 @@ class ProjectViewSet(BaseViewSet):
 
     @override
     def initialize_request(self, request, *args, **kwargs):
-        # Capture the X-Request-Id header (set by Plata at the OpenShift route
+        # Capture the X-Request-Id header (set by Platta at the OpenShift route
         # level) so that audit log entries can be correlated with HTTP traces.
         # IO-845.
         drf_request = super().initialize_request(request, *args, **kwargs)
@@ -368,7 +368,7 @@ class ProjectViewSet(BaseViewSet):
 
         # IO-845: also emit through the "audit" logger so the
         # ResilientLogHandler queues the entry into ResilientLogEntry, from
-        # where Plata's submit_unsent_entries cron ships it to Elastic Cloud.
+        # where Platta's submit_unsent_entries cron ships it to Elastic Cloud.
         actor_data = {}
         if isinstance(user, User):
             actor_data = {

--- a/project/settings.py
+++ b/project/settings.py
@@ -125,6 +125,7 @@ INSTALLED_APPS = [
     "django_eventstream",
     "social_django",
     "infraohjelmointi_api",
+    "resilient_logger",
     'drf_yasg',
 ]
 
@@ -267,6 +268,35 @@ REST_FRAMEWORK = {
 
 DRF_STANDARDIZED_ERRORS = {"ENABLE_IN_DEBUG_FOR_UNHANDLED_EXCEPTIONS": False}
 
+# IO-845: Audit logs are shipped to Plata's Elastic Cloud via django-resilient-logger.
+# The ResilientLogHandler writes log records to the local ResilientLogEntry table; the
+# `submit_unsent_entries` management command (run by Plata's cron) then pushes them to
+# the Elasticsearch target below. The ES target is registered only when AUDIT_LOG_ES_URL
+# is set, so dev/test/build environments without the env vars (e.g. Dockerfile
+# collectstatic) stay safe.
+RESILIENT_LOGGER = {
+    "origin": "infrahankkeiden_ohjelmointi",
+    "environment": env("AUDIT_LOG_ENV", default="development"),
+    "sources": [
+        {"class": "resilient_logger.sources.ResilientLogSource"},
+    ],
+    "targets": [],
+    "batch_limit": 5000,
+    "chunk_size": 500,
+    "submit_unsent_entries": True,
+    "clear_sent_entries": True,
+}
+
+if env("AUDIT_LOG_ES_URL", default=None):
+    RESILIENT_LOGGER["targets"].append({
+        "class": "resilient_logger.targets.ElasticsearchLogTarget",
+        "es_url": env("AUDIT_LOG_ES_URL"),
+        "es_username": env("AUDIT_LOG_ES_USERNAME"),
+        "es_password": env("AUDIT_LOG_ES_PASSWORD"),
+        "es_index": env("AUDIT_LOG_ES_INDEX"),
+        "required": True,
+    })
+
 LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,
@@ -279,6 +309,7 @@ LOGGING = {
     },
     "handlers": {
         "console": {"class": "logging.StreamHandler", "formatter": "console"},
+        "resilient": {"class": "resilient_logger.handlers.ResilientLogHandler"},
     },
     "root": {
         "handlers": ["console"],
@@ -288,6 +319,11 @@ LOGGING = {
         "infraohjelmointi_api": {
             "handlers": ["console"],
             "level": 1,
+            "propagate": False,
+        },
+        "audit": {
+            "handlers": ["resilient"],
+            "level": "DEBUG",
             "propagate": False,
         },
     },

--- a/project/settings.py
+++ b/project/settings.py
@@ -268,9 +268,9 @@ REST_FRAMEWORK = {
 
 DRF_STANDARDIZED_ERRORS = {"ENABLE_IN_DEBUG_FOR_UNHANDLED_EXCEPTIONS": False}
 
-# IO-845: Audit logs are shipped to Plata's Elastic Cloud via django-resilient-logger.
+# IO-845: Audit logs are shipped to Platta's Elastic Cloud via django-resilient-logger.
 # The ResilientLogHandler writes log records to the local ResilientLogEntry table; the
-# `submit_unsent_entries` management command (run by Plata's cron) then pushes them to
+# `submit_unsent_entries` management command (run by Platta's cron) then pushes them to
 # the Elasticsearch target below. The ES target is registered only when AUDIT_LOG_ES_URL
 # is set, so dev/test/build environments without the env vars (e.g. Dockerfile
 # collectstatic) stay safe.

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,3 +30,4 @@ urllib3>=2.5.0                                 # not directly required, pinned b
 h11>=0.16.0                                    # not directly required, pinned by Snyk to avoid a vulnerability
 django-redis==6.0.0                            # Redis cache backend for Django
 redis>=5.0.0                                   # Redis client (for django-eventstream)
+django-resilient-logger>=2.1.0                 # Ship audit logs to Plata's Elastic Cloud (IO-845)

--- a/requirements.txt
+++ b/requirements.txt
@@ -30,4 +30,4 @@ urllib3>=2.5.0                                 # not directly required, pinned b
 h11>=0.16.0                                    # not directly required, pinned by Snyk to avoid a vulnerability
 django-redis==6.0.0                            # Redis cache backend for Django
 redis>=5.0.0                                   # Redis client (for django-eventstream)
-django-resilient-logger>=2.1.0                 # Ship audit logs to Plata's Elastic Cloud (IO-845)
+django-resilient-logger>=2.1.0                 # Ship audit logs to Platta's Elastic Cloud (IO-845)


### PR DESCRIPTION
feat: IO-845 Ship audit logs to Platta Elastic Cloud via django-resilient-logger

* Add django-resilient-logger 2.1.0 to requirements and INSTALLED_APPS; the RESILIENT_LOGGER config registers the Elastic target only when AUDIT_LOG_ES_URL is set, so dev/CI stay safe until Platta's pipeline lands the env vars.
* Dual-write in audit_log_project_card_changes: the existing AuditLog DB write is preserved (keeps /audit-logs/ serving the IO-404 admin UI and the IO-879 Muutoshistoria read path) while a new audit_logger.info emit queues entries in
  ResilientLogEntry for Platta's cron.
* Capture HTTP_X_REQUEST_ID in initialize_request so entries carry the OpenShift Application Gateway trace ID once Platta wires it to our route.