### PR TITLE
fix: IO-901 get correct frozen sap entry from db when syncing projects from sap

### DIFF
--- a/infraohjelmointi_api/services/SapApiService.py
+++ b/infraohjelmointi_api/services/SapApiService.py
@@ -148,7 +148,11 @@ class SapApiService:
             frozen_commitments = {"project_task": Decimal(0.000), "production_task": Decimal(0.000)}
             
             db_sap_costs = SapCostService.get_by_sap_id(id)
-            frozen_entry = next((item for item in db_sap_costs if item.year == self.sap_freeze_year), None)
+            frozen_entry = self.__select_frozen_entry_with_highest_cost(
+                db_sap_costs=db_sap_costs,
+                year=self.sap_freeze_year,
+                sap_id=id,
+            )
             
             if frozen_entry:
                 frozen_costs["project_task"] = frozen_entry.project_task_costs
@@ -222,9 +226,11 @@ class SapApiService:
             
             # 2. Get frozen 2025 costs from DB
             db_sap_costs = SapCostService.get_by_sap_id(id)
-            # Find the entry for the freeze year (2025)
-            # Note: DB might have multiple entries if grouped, but valid ones should have same amounts
-            frozen_entry = next((item for item in db_sap_costs if item.year == self.sap_freeze_year), None)
+            frozen_entry = self.__select_frozen_entry_with_highest_cost(
+                db_sap_costs=db_sap_costs,
+                year=self.sap_freeze_year,
+                sap_id=id,
+            )
             
             if frozen_entry:
                 frozen_costs["project_task"] = frozen_entry.project_task_costs
@@ -249,6 +255,28 @@ class SapApiService:
             grouped_costs_and_commitments_all["costs"]["production_task"] += frozen_costs["production_task"]
 
         return grouped_costs_and_commitments_all
+
+    def __select_frozen_entry_with_highest_cost(self, db_sap_costs, year: int, sap_id: str):
+        """Pick deterministic frozen DB row for a SAP id and year.
+
+        SAP ID can have multiple DB rows (project + group rows). We use the
+        year-matching row with the highest total costs to avoid selecting a
+        group row that may have incorrect project/production task costs.
+        """
+        year_entries = [item for item in db_sap_costs if item.year == year]
+        if not year_entries:
+            return None
+
+        selected = max(
+            year_entries,
+            key=lambda item: (item.project_task_costs + item.production_task_costs),
+        )
+        selected_total = selected.project_task_costs + selected.production_task_costs
+        logger.debug(
+            f"Selected frozen entry for {sap_id}/{year} with highest total costs={selected_total} "
+            f"(project_task={selected.project_task_costs}, production_task={selected.production_task_costs})"
+        )
+        return selected
 
     def __fetch_costs_and_commitments_from_sap(
             self,

--- a/infraohjelmointi_api/tests/test_SAP_freeze.py
+++ b/infraohjelmointi_api/tests/test_SAP_freeze.py
@@ -63,7 +63,9 @@ class TestSAPServiceFreeze(TestCase):
         
         # 1. Setup Frozen Data in DB (2025)
         # Note: In real app, SapCost stores exact values.
-        frozen_sap_cost = SapCost(
+        # There might be multiple rows for same SAP ID (project vs group rows).
+        # We want to ensure the service selects the correct one.
+        frozen_sap_cost_lower = SapCost(
             year=2025,
             sap_id=self.sapProjectId,
             project_task_costs=Decimal('500.000'), # Frozen cost
@@ -71,10 +73,19 @@ class TestSAPServiceFreeze(TestCase):
             project_task_commitments=Decimal('0.000'), 
             production_task_commitments=Decimal('0.000')
         )
-        mock_get_by_sap_id.return_value = [frozen_sap_cost]
+        frozen_sap_cost_higher = SapCost(
+            year=2025,
+            sap_id=self.sapProjectId,
+            project_task_costs=Decimal('600.000'),
+            production_task_costs=Decimal('100.000'),
+            project_task_commitments=Decimal('30.000'),
+            production_task_commitments=Decimal('20.000')
+        )
+        mock_get_by_sap_id.return_value = [frozen_sap_cost_lower, frozen_sap_cost_higher]
         
         # 2. Setup New SAP Data (2026)
         # This is what __fetch... returns. It simulates fetching ONLY 2026 data.
+        # 2026 data should be combined with frozen highest-cost row.
         mock_fetch.return_value = {
             "costs": [{"Posid": f"{self.sapProjectId}.01", "Wkgbtr": Decimal('100.000')}], # New cost
             "commitments": [{"Posid": f"{self.sapProjectId}.01", "Wkgbtr": Decimal('50.000')}] # All commitments
@@ -93,8 +104,8 @@ class TestSAPServiceFreeze(TestCase):
         self.assertEqual(kwargs['budat_start_commitments'].year, 2017)
         
         # 4. Verify Final Result Summing
-        # Should be Frozen(500) + New(100) = 600
-        self.assertEqual(result['costs']['project_task'], Decimal('600.000'))
+        # Should be Frozen(600) + New(100) = 700
+        self.assertEqual(result['costs']['project_task'], Decimal('700.000'))
         self.assertEqual(result['commitments']['project_task'], Decimal('50.000'))
 
     @patch('infraohjelmointi_api.services.SapCostService.SapCostService.get_by_sap_id')


### PR DESCRIPTION
There might be multiple rows for the same sap id and frozen year (2025) that are from the old sap in sapcost table. Before the first one of those was retrived resulting in possibly incorrect sums. Fixed it so that the row with the highest sum of costs is retrieved because the costs should be cumulative totals and so the row with highest costs should be correct.

https://helsinkisolutionoffice.atlassian.net/browse/IO-901