### PR TITLE
feat: IO-880 Add per-project change-history endpoint for muutoshistoria

### DIFF
--- a/infraohjelmointi_api/permissions.py
+++ b/infraohjelmointi_api/permissions.py
@@ -196,6 +196,12 @@ PROJECT_GROUP_ALL_ACTIONS = [*PROJECT_GROUP_ALL_GET_ACTIONS]
 #### Construction handover custom actions ####
 CONSTRUCTION_HANDOVER_GET_ACTIONS = ["get_construction_handovers"]
 
+#### Project change-history custom actions (IO-879) ####
+# Per-project audit-log history powering the "Näytä muutoshistoria" UI.
+# Read-only and scoped to a single project, so it is granted to every role
+# that can view a project (including plain viewers and restricted programmers).
+PROJECT_HISTORY_GET_ACTIONS = ["get_project_history"]
+
 LIST_OF_DENIED_FIELDS_FOR_PROJECT_MANAGER = [
     "finances",
     "name", #* Kohde/hanke Ei (No) # name
@@ -257,6 +263,7 @@ class IsViewer(permissions.BasePermission):
                 *PROJECT_FINANCES_PLANNING_GET_ACTIONS,
                 *PROJECT_GROUP_PLANNING_GET_ACTIONS,
                 *SAP_COST_PLANNING_GET_ACTIONS,
+                *PROJECT_HISTORY_GET_ACTIONS,
             ]
         ):
             return True
@@ -297,6 +304,7 @@ class IsCoordinator(permissions.BasePermission):
                 *SAP_COST_ALL_ACTIONS,
                 *PROJECT_NOTE_ALL_ACTIONS,
                 *CONSTRUCTION_HANDOVER_GET_ACTIONS,
+                *PROJECT_HISTORY_GET_ACTIONS,
             ]
         ):
             return True
@@ -335,6 +343,7 @@ class IsPlanner(permissions.BasePermission):
                 *SAP_COST_ALL_ACTIONS,
                 *PROJECT_NOTE_ALL_ACTIONS,
                 *CONSTRUCTION_HANDOVER_GET_ACTIONS,
+                *PROJECT_HISTORY_GET_ACTIONS,
             ]
         ):
             return True
@@ -375,6 +384,7 @@ class IsProjectManager(permissions.BasePermission):
                 *SAP_COST_ALL_GET_ACTIONS,
                 *PROJECT_NOTE_ALL_ACTIONS,
                 *CONSTRUCTION_HANDOVER_GET_ACTIONS,
+                *PROJECT_HISTORY_GET_ACTIONS,
             ]
         ):
             return True
@@ -461,7 +471,8 @@ class IsPlannerOfProjectAreas(BaseProjectAreaPermissions):
                 *PROJECT_ALL_ACTIONS,
                 *PROJECT_FINANCES_ALL_GET_ACTIONS,
                 *SAP_COST_ALL_GET_ACTIONS,
-                *PROJECT_NOTE_ALL_ACTIONS
+                *PROJECT_NOTE_ALL_ACTIONS,
+                *PROJECT_HISTORY_GET_ACTIONS,
             ]
         ):
             return True
@@ -528,6 +539,7 @@ class IsAdmin(permissions.BasePermission):
                 *PROJECT_NOTE_ALL_ACTIONS,
                 *PROJECT_FORCED_TO_FRAME_PATCH,
                 *CONSTRUCTION_HANDOVER_GET_ACTIONS,
+                *PROJECT_HISTORY_GET_ACTIONS,
             ]
         ):
             return True
@@ -592,6 +604,7 @@ class IsClassProgrammer(permissions.BasePermission):
             *PROJECT_GROUP_ALL_GET_ACTIONS,
             *SAP_COST_ALL_GET_ACTIONS,
             *PROJECT_NOTE_ALL_GET_ACTIONS,
+            *PROJECT_HISTORY_GET_ACTIONS,
         ]:
             return True
 

--- a/infraohjelmointi_api/serializers/AuditLogSerializer.py
+++ b/infraohjelmointi_api/serializers/AuditLogSerializer.py
@@ -18,12 +18,25 @@ class AuditLogSerializer(serializers.ModelSerializer):
     project_group_name = serializers.CharField(source='project_group.name', read_only=True)
     project_class_name = serializers.CharField(source='project_class.name', read_only=True)
 
+    # Convenience for the change-history UI (IO-879): the union of the keys in
+    # old_values / new_values, i.e. the years (financial) or field names (form)
+    # that this entry changed, so the frontend doesn't have to derive it.
+    changed_fields = serializers.SerializerMethodField()
+
     class Meta:
         model = AuditLog
         fields = [
             'id', 'actor', 'actor_username', 'actor_first_name', 'actor_last_name',
             'operation', 'log_level', 'origin', 'status', 'project', 'project_name',
             'project_hkr_id', 'project_group', 'project_group_name', 'project_class',
-            'project_class_name', 'old_values', 'new_values', 'endpoint',
-            'createdDate', 'updatedDate'
+            'project_class_name', 'old_values', 'new_values', 'changed_fields',
+            'endpoint', 'createdDate', 'updatedDate'
         ]
+
+    def get_changed_fields(self, obj) -> list:
+        keys = set()
+        if isinstance(obj.old_values, dict):
+            keys.update(obj.old_values.keys())
+        if isinstance(obj.new_values, dict):
+            keys.update(obj.new_values.keys())
+        return sorted(keys)

--- a/infraohjelmointi_api/tests/test_project_history.py
+++ b/infraohjelmointi_api/tests/test_project_history.py
@@ -1,0 +1,241 @@
+"""Tests for the per-project change-history endpoint (IO-879 / IO-880 / IO-882).
+
+GET /projects/<id>/history/ exposes the project's AuditLog entries to any user
+who can view the project, powering the "Muutoshistoria" UI. This is distinct
+from the admin-only /audit-logs/ endpoint, so the permission contract (a plain
+viewer may read it) is part of what these tests pin down.
+"""
+import uuid
+from datetime import datetime, timezone
+
+from django.test import TestCase
+from django.contrib.auth import get_user_model
+from helusers.models import ADGroup
+from rest_framework.test import APIRequestFactory, force_authenticate
+
+from infraohjelmointi_api.models import (
+    AuditLog,
+    ConstructionProcurementMethod,
+    Project,
+)
+from infraohjelmointi_api.views import BaseViewSet
+from infraohjelmointi_api.views.ProjectViewSet import ProjectViewSet
+from unittest.mock import patch
+
+User = get_user_model()
+
+HISTORY_VIEW = ProjectViewSet.as_view({"get": "get_project_history"})
+
+
+def _set_created(audit_log, when):
+    """createdDate is auto_now_add, so override it via update() for deterministic ordering."""
+    AuditLog.objects.filter(pk=audit_log.pk).update(createdDate=when)
+
+
+@patch.object(BaseViewSet, "authentication_classes", new=[])
+@patch.object(BaseViewSet, "permission_classes", new=[])
+class ProjectHistoryEndpointTestCase(TestCase):
+    """Behaviour of the history endpoint with auth/permissions patched out."""
+
+    def setUp(self):
+        self.factory = APIRequestFactory()
+        self.actor = User.objects.create(
+            first_name="Anna", last_name="Hakala", username="anna", email="anna@example.com"
+        )
+        self.project = Project.objects.create(
+            name="Hakaniemen tori", description="History test project", hkrId=11111
+        )
+        self.other_project = Project.objects.create(
+            name="Other Project", description="Other test project", hkrId=22222
+        )
+
+        # Financial change touching 2026
+        self.finance_entry = AuditLog.objects.create(
+            actor=self.actor, operation="UPDATE", log_level="INFO",
+            origin="infrahankkeiden_ohjelmointi", status="SUCCESS", project=self.project,
+            old_values={"2026": "100.00"}, new_values={"2026": "250.00"},
+            endpoint="/projects/x/",
+        )
+        # Form field change (phase)
+        self.form_entry = AuditLog.objects.create(
+            actor=self.actor, operation="UPDATE", log_level="INFO",
+            origin="infrahankkeiden_ohjelmointi", status="SUCCESS", project=self.project,
+            old_values={"phase": "proposal"}, new_values={"phase": "design"},
+            endpoint="/projects/x/",
+        )
+        # Deletion snapshot touching name + 2026
+        self.delete_entry = AuditLog.objects.create(
+            actor=self.actor, operation="DELETE", log_level="INFO",
+            origin="infrahankkeiden_ohjelmointi", status="SUCCESS", project=self.project,
+            old_values={"name": "Hakaniemen tori", "2026": "250.00"}, new_values={},
+            endpoint="/projects/x/",
+        )
+        # Entry on a different project (must never leak into this project's history)
+        self.other_entry = AuditLog.objects.create(
+            actor=self.actor, operation="UPDATE", log_level="INFO",
+            origin="infrahankkeiden_ohjelmointi", status="SUCCESS", project=self.other_project,
+            old_values={"2026": "1.00"}, new_values={"2026": "2.00"},
+            endpoint="/projects/y/",
+        )
+
+        _set_created(self.finance_entry, datetime(2026, 3, 10, 9, 0, tzinfo=timezone.utc))
+        _set_created(self.form_entry, datetime(2026, 3, 11, 9, 0, tzinfo=timezone.utc))
+        _set_created(self.delete_entry, datetime(2026, 3, 12, 9, 0, tzinfo=timezone.utc))
+
+    def _get(self, pk, **params):
+        request = self.factory.get(f"/projects/{pk}/history/", params)
+        return HISTORY_VIEW(request, pk=str(pk))
+
+    def test_returns_project_entries_newest_first(self):
+        response = self._get(self.project.id)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["count"], 3)
+        ids = [row["id"] for row in response.data["results"]]
+        self.assertEqual(
+            ids,
+            [str(self.delete_entry.id), str(self.form_entry.id), str(self.finance_entry.id)],
+        )
+
+    def test_history_is_scoped_to_the_project(self):
+        response = self._get(self.project.id)
+        returned_ids = {row["id"] for row in response.data["results"]}
+        self.assertNotIn(str(self.other_entry.id), returned_ids)
+
+    def test_year_filter_matches_old_or_new_values(self):
+        response = self._get(self.project.id, year="2026")
+        ids = [row["id"] for row in response.data["results"]]
+        # finance_entry (old+new) and delete_entry (old) touch 2026; form_entry does not.
+        self.assertEqual(ids, [str(self.delete_entry.id), str(self.finance_entry.id)])
+
+    def test_field_filter_matches_form_field(self):
+        response = self._get(self.project.id, field="phase")
+        ids = [row["id"] for row in response.data["results"]]
+        self.assertEqual(ids, [str(self.form_entry.id)])
+
+    def test_operation_filter(self):
+        update_ids = [r["id"] for r in self._get(self.project.id, operation="UPDATE").data["results"]]
+        self.assertEqual(set(update_ids), {str(self.finance_entry.id), str(self.form_entry.id)})
+
+        delete_ids = [r["id"] for r in self._get(self.project.id, operation="DELETE").data["results"]]
+        self.assertEqual(delete_ids, [str(self.delete_entry.id)])
+
+    def test_changed_fields_exposed(self):
+        response = self._get(self.project.id, operation="DELETE")
+        self.assertEqual(response.data["results"][0]["changed_fields"], ["2026", "name"])
+
+    def test_empty_project_returns_empty_list(self):
+        empty_project = Project.objects.create(
+            name="Empty", description="Empty history project", hkrId=33333
+        )
+        response = self._get(empty_project.id)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["count"], 0)
+        self.assertEqual(response.data["results"], [])
+
+    def test_invalid_uuid_returns_400(self):
+        request = self.factory.get("/projects/not-a-uuid/history/")
+        response = HISTORY_VIEW(request, pk="not-a-uuid")
+        self.assertEqual(response.status_code, 400)
+
+    def test_unknown_project_returns_404(self):
+        response = self._get(uuid.uuid4())
+        self.assertEqual(response.status_code, 404)
+
+
+class ProjectHistoryPermissionTestCase(TestCase):
+    """The history endpoint must be reachable by non-admin viewers (IO-879)."""
+
+    def setUp(self):
+        self.factory = APIRequestFactory()
+        self.viewer_group = ADGroup.objects.create(
+            name="sl_dyn_kymp_sso_io_katselijat", display_name="Viewers"
+        )
+        self.admin_group = ADGroup.objects.create(
+            name="sg_kymp_sso_io_admin", display_name="Admins"
+        )
+        self.viewer = User.objects.create_user(username="viewer@test.fi", email="viewer@test.fi")
+        self.viewer.ad_groups.add(self.viewer_group)
+        self.admin = User.objects.create_user(username="admin@test.fi", email="admin@test.fi")
+        self.admin.ad_groups.add(self.admin_group)
+
+        self.project = Project.objects.create(
+            name="Visible Project", description="Visible test project", hkrId=44444
+        )
+        AuditLog.objects.create(
+            actor=self.admin, operation="UPDATE", log_level="INFO",
+            origin="infrahankkeiden_ohjelmointi", status="SUCCESS", project=self.project,
+            old_values={"phase": "a"}, new_values={"phase": "b"}, endpoint="/projects/x/",
+        )
+
+    def _call_as(self, user):
+        request = self.factory.get(f"/projects/{self.project.id}/history/")
+        if user is not None:
+            force_authenticate(request, user=user)
+        return HISTORY_VIEW(request, pk=str(self.project.id))
+
+    def test_viewer_can_read_history(self):
+        response = self._call_as(self.viewer)
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data["count"], 1)
+
+    def test_admin_can_read_history(self):
+        response = self._call_as(self.admin)
+        self.assertEqual(response.status_code, 200)
+
+    def test_anonymous_is_denied(self):
+        response = self._call_as(None)
+        self.assertIn(response.status_code, (401, 403))
+
+
+@patch.object(BaseViewSet, "authentication_classes", new=[])
+@patch.object(BaseViewSet, "permission_classes", new=[])
+class ProjectAuditProducerTestCase(TestCase):
+    """The PATCH producer must record the form fields the Muutoshistoria UI shows.
+
+    `description` (Hankkeen kuvaus) and `constructionProcurementMethod`
+    (Hankintatapa) are part of the change-history design, so editing them has to
+    leave an AuditLog entry the history endpoint can serve.
+    """
+
+    def setUp(self):
+        self.method_old = ConstructionProcurementMethod.objects.create(value="kilpailutus")
+        self.method_new = ConstructionProcurementMethod.objects.create(value="suorahankinta")
+        # No hkrId so the PATCH never reaches the ProjectWise sync step.
+        self.project = Project.objects.create(
+            name="Producer Project",
+            description="Original description",
+            hkrId=None,
+            constructionProcurementMethod=self.method_old,
+        )
+
+    def test_patch_records_description_and_procurement_method(self):
+        response = self.client.patch(
+            f"/projects/{self.project.id}/",
+            {
+                "description": "Updated description",
+                "constructionProcurementMethod": str(self.method_new.id),
+            },
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 200, msg=response.content)
+
+        entry = AuditLog.objects.get(project=self.project, operation="UPDATE")
+        self.assertEqual(entry.old_values["description"], "Original description")
+        self.assertEqual(entry.new_values["description"], "Updated description")
+        self.assertEqual(
+            entry.old_values["constructionProcurementMethod"], str(self.method_old.id)
+        )
+        self.assertEqual(
+            entry.new_values["constructionProcurementMethod"], str(self.method_new.id)
+        )
+
+    def test_patch_without_audited_fields_creates_no_entry(self):
+        response = self.client.patch(
+            f"/projects/{self.project.id}/",
+            {"address": "Some Street 1"},
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 200, msg=response.content)
+        self.assertFalse(
+            AuditLog.objects.filter(project=self.project, operation="UPDATE").exists()
+        )

--- a/infraohjelmointi_api/tests/test_project_history.py
+++ b/infraohjelmointi_api/tests/test_project_history.py
@@ -229,6 +229,28 @@ class ProjectAuditProducerTestCase(TestCase):
             entry.new_values["constructionProcurementMethod"], str(self.method_new.id)
         )
 
+    def test_patch_records_empty_relation_as_null(self):
+        """A previously-empty relation must be audited as null, not the string
+        "None", so the Muutoshistoria UI renders an empty previous value."""
+        project = Project.objects.create(
+            name="No Method Project",
+            description="No method",
+            hkrId=None,
+            constructionProcurementMethod=None,
+        )
+        response = self.client.patch(
+            f"/projects/{project.id}/",
+            {"constructionProcurementMethod": str(self.method_new.id)},
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 200, msg=response.content)
+
+        entry = AuditLog.objects.get(project=project, operation="UPDATE")
+        self.assertIsNone(entry.old_values["constructionProcurementMethod"])
+        self.assertEqual(
+            entry.new_values["constructionProcurementMethod"], str(self.method_new.id)
+        )
+
     def test_patch_without_audited_fields_creates_no_entry(self):
         response = self.client.patch(
             f"/projects/{self.project.id}/",

--- a/infraohjelmointi_api/views/ProjectViewSet.py
+++ b/infraohjelmointi_api/views/ProjectViewSet.py
@@ -15,6 +15,7 @@ from infraohjelmointi_api.serializers import (
     SearchResultSerializer,
     ProjectNoteGetSerializer,
     ConstructionHandoverGetSerializer,
+    AuditLogSerializer,
 )
 from infraohjelmointi_api.models import (
     AuditLog,
@@ -157,8 +158,10 @@ class ProjectViewSet(BaseViewSet):
             "category",
             "projectClass",
             "name",
+            "description",
             "phase",
             "phaseDetail",
+            "constructionProcurementMethod",
             "planningStartYear",
             "constructionEndYear",
             "estPlanningStart",
@@ -1953,4 +1956,86 @@ class ProjectViewSet(BaseViewSet):
             return Response(
                 data={"message": "Invalid UUID"}, status=status.HTTP_400_BAD_REQUEST
             )
+
+    @action(methods=["get"], detail=True, url_path=r"history", name="get_project_history")
+    def get_project_history(self, request, pk):
+        """
+        Custom action returning the change history (audit log) of a single
+        project, powering the "Muutoshistoria" UI (IO-879).
+
+        Unlike the admin-only /audit-logs/ endpoint, this is scoped to one
+        project, so it is available to any user allowed to view that project
+        (the same role-based permissions as the rest of ProjectViewSet).
+
+            URL Parameters
+            ----------
+
+            project_id : UUID string
+
+            Query Parameters
+            ----------
+
+            year : keep only entries whose old/new values touch that year.
+                   Financial figures are stored keyed by year, so this narrows
+                   the history to a single budget cell (IO-880).
+            field : keep only entries whose old/new values touch that field
+                    name. Form fields are stored keyed by field name, so this
+                    narrows the history to a single form field (IO-882).
+            operation : CREATE / UPDATE / DELETE passthrough filter.
+
+            Usage
+            ----------
+
+            projects/<project_id>/history/
+
+            Returns
+            -------
+
+            JSON
+                Paginated list of AuditLog entries for the project, newest first
+        """
+        try:
+            uuid.UUID(str(pk))  # validating UUID
+        except ValueError:
+            return Response(
+                data={"message": "Invalid UUID"}, status=status.HTTP_400_BAD_REQUEST
+            )
+
+        project = Project.objects.filter(pk=pk).first()
+        if project is None:
+            return Response(
+                data={"message": "Project not found"},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+
+        queryset = (
+            AuditLog.objects.select_related("actor")
+            .filter(project=project)
+            .order_by("-createdDate")
+        )
+
+        operation = request.query_params.get("operation")
+        if operation:
+            queryset = queryset.filter(operation=operation)
+
+        # Financial figures and form fields are both stored as JSON objects in
+        # old_values / new_values - financial ones keyed by year ("2026"), form
+        # ones keyed by field name ("phase"). A JSONB key-existence match on
+        # either side narrows the history to a single budget cell or a single
+        # form field without unpacking the JSON in Python.
+        year = request.query_params.get("year")
+        if year:
+            queryset = queryset.filter(
+                Q(old_values__has_key=year) | Q(new_values__has_key=year)
+            )
+
+        field = request.query_params.get("field")
+        if field:
+            queryset = queryset.filter(
+                Q(old_values__has_key=field) | Q(new_values__has_key=field)
+            )
+
+        page = self.paginate_queryset(queryset)
+        serializer = AuditLogSerializer(page, many=True)
+        return self.get_paginated_response(serializer.data)
 

--- a/infraohjelmointi_api/views/ProjectViewSet.py
+++ b/infraohjelmointi_api/views/ProjectViewSet.py
@@ -176,11 +176,7 @@ class ProjectViewSet(BaseViewSet):
             "visibilityEnd",
         ]
         old_values_for_audit_log = {
-            field: (
-                str(getattr(getattr(project, field), 'id', None))
-                if hasattr(getattr(project, field), 'id')
-                else str(getattr(project, field))
-            )
+            field: self._serialize_audit_value(project, field)
             for field in audit_loggable_fields
             if field in request.data
         }
@@ -324,7 +320,14 @@ class ProjectViewSet(BaseViewSet):
 
         # saving audit logs after project data was changed
         if (old_values_for_audit_log):
-            new_values_for_audit_log = {field: request.data[field] for field in audit_loggable_fields if field in request.data}
+            # Read new values from the saved project rather than request.data so
+            # relations are stored consistently as their id (matching old_values),
+            # regardless of how the client sent them.
+            new_values_for_audit_log = {
+                field: self._serialize_audit_value(updated_project, field)
+                for field in audit_loggable_fields
+                if field in request.data
+            }
             self.audit_log_project_card_changes(
                 old_values_for_audit_log,
                 new_values_for_audit_log,
@@ -342,6 +345,18 @@ class ProjectViewSet(BaseViewSet):
         if isinstance(date, str):
             return datetime.strptime(date, '%d.%m.%Y').date()
         return date
+
+    def _serialize_audit_value(self, instance, field):
+        # Relations are stored as their id, scalars as a string, and an absent
+        # value as null (not the string "None") so the Muutoshistoria UI can show
+        # an empty previous/next value cleanly.
+        value = getattr(instance, field)
+        if value is None:
+            return None
+        related_id = getattr(value, 'id', None)
+        if related_id is not None:
+            return str(related_id)
+        return str(value)
 
     def audit_log_project_card_changes(self, old_values, new_values, project, user, url, operation):
         audit_log = AuditLog(


### PR DESCRIPTION
* Add GET /projects/<id>/history/ (ProjectViewSet.get_project_history) returning the project's AuditLog entries newest-first, powering the IO-879 "Näytä muutoshistoria" UI. Unlike admin-only /audit-logs/ it is scoped to one project, so every role that can view the project can read its history.
* Support optional year / field / operation filters; year and field use JSONB key-existence matches so a financial cell (keyed by year) or a form field (keyed by name) is isolated without unpacking the stored JSON. Folds in IO-882 (form fields) since it is the same endpoint with one extra filter.
* Whitelist the new action across every viewing role in permissions.py (custom actions are gated by method name) so viewers and restricted programmers can read history too, not just admins.
* Add AuditLogSerializer.changed_fields (union of old/new value keys) so the form modal needn't derive it; test_project_history covers scoping, ordering, the three filters, changed_fields, 400/404 and the non-admin permission contract.