### PR TITLE
feat: IO-900 prevent updating current year finances when bulk updating forced-to-frame finances

### DIFF
--- a/infraohjelmointi_api/tests/test_Projects.py
+++ b/infraohjelmointi_api/tests/test_Projects.py
@@ -29,6 +29,8 @@ from ..models import (
     ProjectHashTag,
     ProjectGroup,
     ProjectFinancial,
+    ClassFinancial,
+    LocationFinancial,
     User,
     ProjectProgrammer,
 )
@@ -1047,6 +1049,142 @@ class ProjectTestCase(CacheClearingMixin, TestCase):
 
         self.assertEqual(current_year_frame.value, 999)
         self.assertEqual(next_year_frame.value, 222)
+
+    def test_patch_bulk_forced_to_frame_skips_current_year_class_finances(self):
+        current_year = date.today().year
+        next_year = current_year + 1
+
+        coordinator_class = ProjectClass.objects.create(
+            name="Coordinator class for frame finance test",
+            path="Coordinator class for frame finance test",
+            forCoordinatorOnly=True,
+        )
+
+        ClassFinancial.objects.filter(
+            classRelation_id=coordinator_class.id,
+            year__in=[current_year, next_year],
+        ).delete()
+
+        ClassFinancial.objects.create(
+            classRelation_id=coordinator_class.id,
+            year=current_year,
+            frameBudget=111,
+            budgetChange=11,
+            forFrameView=False,
+        )
+        ClassFinancial.objects.create(
+            classRelation_id=coordinator_class.id,
+            year=next_year,
+            frameBudget=222,
+            budgetChange=22,
+            forFrameView=False,
+        )
+
+        ClassFinancial.objects.create(
+            classRelation_id=coordinator_class.id,
+            year=current_year,
+            frameBudget=999,
+            budgetChange=99,
+            forFrameView=True,
+        )
+        ClassFinancial.objects.create(
+            classRelation_id=coordinator_class.id,
+            year=next_year,
+            frameBudget=1,
+            budgetChange=1,
+            forFrameView=True,
+        )
+
+        response = self.client.patch(
+            "/projects/bulk-update/forced-to-frame/",
+            [],
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 200, msg=response.json())
+
+        current_year_frame = ClassFinancial.objects.get(
+            classRelation_id=coordinator_class.id,
+            year=current_year,
+            forFrameView=True,
+        )
+        next_year_frame = ClassFinancial.objects.get(
+            classRelation_id=coordinator_class.id,
+            year=next_year,
+            forFrameView=True,
+        )
+
+        self.assertEqual(current_year_frame.frameBudget, 999)
+        self.assertEqual(current_year_frame.budgetChange, 99)
+        self.assertEqual(next_year_frame.frameBudget, 222)
+        self.assertEqual(next_year_frame.budgetChange, 22)
+
+    def test_patch_bulk_forced_to_frame_skips_current_year_location_finances(self):
+        current_year = date.today().year
+        next_year = current_year + 1
+
+        coordinator_location = ProjectLocation.objects.create(
+            name="Coordinator location for frame finance test",
+            path="Coordinator location for frame finance test",
+            forCoordinatorOnly=True,
+        )
+
+        LocationFinancial.objects.filter(
+            locationRelation_id=coordinator_location.id,
+            year__in=[current_year, next_year],
+        ).delete()
+
+        LocationFinancial.objects.create(
+            locationRelation_id=coordinator_location.id,
+            year=current_year,
+            frameBudget=111,
+            budgetChange=11,
+            forFrameView=False,
+        )
+        LocationFinancial.objects.create(
+            locationRelation_id=coordinator_location.id,
+            year=next_year,
+            frameBudget=222,
+            budgetChange=22,
+            forFrameView=False,
+        )
+
+        LocationFinancial.objects.create(
+            locationRelation_id=coordinator_location.id,
+            year=current_year,
+            frameBudget=999,
+            budgetChange=99,
+            forFrameView=True,
+        )
+        LocationFinancial.objects.create(
+            locationRelation_id=coordinator_location.id,
+            year=next_year,
+            frameBudget=1,
+            budgetChange=1,
+            forFrameView=True,
+        )
+
+        response = self.client.patch(
+            "/projects/bulk-update/forced-to-frame/",
+            [],
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 200, msg=response.json())
+
+        current_year_frame = LocationFinancial.objects.get(
+            locationRelation_id=coordinator_location.id,
+            year=current_year,
+            forFrameView=True,
+        )
+        next_year_frame = LocationFinancial.objects.get(
+            locationRelation_id=coordinator_location.id,
+            year=next_year,
+            forFrameView=True,
+        )
+
+        self.assertEqual(current_year_frame.frameBudget, 999)
+        self.assertEqual(current_year_frame.budgetChange, 99)
+        self.assertEqual(next_year_frame.frameBudget, 222)
+        self.assertEqual(next_year_frame.budgetChange, 22)
 
 
     def test_notes_project(self):

--- a/infraohjelmointi_api/tests/test_Projects.py
+++ b/infraohjelmointi_api/tests/test_Projects.py
@@ -989,6 +989,65 @@ class ProjectTestCase(CacheClearingMixin, TestCase):
         )
         self.assertEqual(response.status_code, 200)
 
+    def test_patch_bulk_forced_to_frame_skips_current_year_project_finances(self):
+        current_year = date.today().year
+        next_year = current_year + 1
+
+        # Keep this test deterministic regardless of other test data.
+        ProjectFinancial.objects.filter(
+            project_id=self.project_1_Id,
+            year__in=[current_year, next_year],
+        ).delete()
+
+        # Planning view source values.
+        ProjectFinancial.objects.create(
+            project_id=self.project_1_Id,
+            year=current_year,
+            value=111,
+            forFrameView=False,
+        )
+        ProjectFinancial.objects.create(
+            project_id=self.project_1_Id,
+            year=next_year,
+            value=222,
+            forFrameView=False,
+        )
+
+        # Existing frame view values that action may update.
+        ProjectFinancial.objects.create(
+            project_id=self.project_1_Id,
+            year=current_year,
+            value=999,
+            forFrameView=True,
+        )
+        ProjectFinancial.objects.create(
+            project_id=self.project_1_Id,
+            year=next_year,
+            value=1,
+            forFrameView=True,
+        )
+
+        response = self.client.patch(
+            "/projects/bulk-update/forced-to-frame/",
+            [],
+            content_type="application/json",
+        )
+        self.assertEqual(response.status_code, 200, msg=response.json())
+
+        current_year_frame = ProjectFinancial.objects.get(
+            project_id=self.project_1_Id,
+            year=current_year,
+            forFrameView=True,
+        )
+        next_year_frame = ProjectFinancial.objects.get(
+            project_id=self.project_1_Id,
+            year=next_year,
+            forFrameView=True,
+        )
+
+        self.assertEqual(current_year_frame.value, 999)
+        self.assertEqual(next_year_frame.value, 222)
+
 
     def test_notes_project(self):
         Note.objects.create(

--- a/infraohjelmointi_api/views/ProjectViewSet.py
+++ b/infraohjelmointi_api/views/ProjectViewSet.py
@@ -1247,8 +1247,12 @@ class ProjectViewSet(BaseViewSet):
                 yield queryset[start:end]
 
         bulk_size = 100
+        current_year = date.today().year
 
         new_project_finances, update_project_finances = self.update_forced_to_frame_projects()
+        # Filter out the finances for the current year as they should not be updated
+        new_project_finances = [finance for finance in new_project_finances if finance.year != current_year]
+        update_project_finances = [finance for finance in update_project_finances if finance.year != current_year]
 
         # Bulk create new ProjectFinancial entries
         ProjectFinancial.objects.bulk_create(new_project_finances, bulk_size)
@@ -1259,6 +1263,9 @@ class ProjectViewSet(BaseViewSet):
                 ProjectFinancial.objects.bulk_update(batch, ['value'])
 
         new_class_finances, update_class_finances = self.update_forced_to_frame_classes()
+        # Filter out the finances for the current year as they should not be updated
+        new_class_finances = [finance for finance in new_class_finances if finance.year != current_year]
+        update_class_finances = [finance for finance in update_class_finances if finance.year != current_year]
 
         # Bulk create new ClassFinancial entries
         ClassFinancial.objects.bulk_create(new_class_finances, bulk_size)
@@ -1269,6 +1276,9 @@ class ProjectViewSet(BaseViewSet):
                 ClassFinancial.objects.bulk_update(batch, ['frameBudget', 'budgetChange'])
 
         new_location_finances, update_location_finances = self.update_forced_to_frame_locations()
+        # Filter out the finances for the current year as they should not be updated
+        new_location_finances = [finance for finance in new_location_finances if finance.year != current_year]
+        update_location_finances = [finance for finance in update_location_finances if finance.year != current_year]
 
         # Bulk create new LocationFinancial entries
         LocationFinancial.objects.bulk_create(new_location_finances, bulk_size)
@@ -1278,7 +1288,6 @@ class ProjectViewSet(BaseViewSet):
             for batch in batch_process(update_location_finances, bulk_size):
                 LocationFinancial.objects.bulk_update(batch, ['frameBudget', 'budgetChange'])
 
-        current_year = date.today().year
         for year_offset in range(-2, 13):
             year = current_year + year_offset
             CacheService.invalidate_frame_budgets(year=year)


### PR DESCRIPTION
Filter out current year finances from project_finances, class_finances and location_finances in patch_bulk_forced_to_frame action in ProjectViewSet, so that when copying finance data from planning/coordination view to forced-to-frame view, current year forced-to-frame finances are preserved.

https://helsinkisolutionoffice.atlassian.net/browse/IO-900