### PR TITLE
Prevent haamuluku creation on project schedule changes (IO-894)

### DIFF
--- a/infraohjelmointi_api/management/commands/find_out_of_schedule_finances.py
+++ b/infraohjelmointi_api/management/commands/find_out_of_schedule_finances.py
@@ -21,6 +21,7 @@ from django.db import transaction
 from django.db.models import Q
 
 from infraohjelmointi_api.models import Project, ProjectFinancial
+from infraohjelmointi_api.utils.schedule import Schedule, resolve_schedule
 
 
 logger = logging.getLogger("infraohjelmointi_api")
@@ -42,57 +43,6 @@ CSV_HEADER = [
     "value",
     "action",
 ]
-
-
-@dataclass(frozen=True)
-class Schedule:
-    """Resolved planning + construction year range for a project.
-
-    A range with ``start > end`` is treated as empty so that data with
-    inverted dates (e.g. ``estPlanningEnd < planningStartYear``) does not
-    silently mark every year as in-schedule.
-    """
-
-    planning_start: int | None
-    planning_end: int | None
-    construction_start: int | None
-    construction_end: int | None
-
-    @property
-    def is_complete(self) -> bool:
-        return all(
-            v is not None
-            for v in (
-                self.planning_start,
-                self.planning_end,
-                self.construction_start,
-                self.construction_end,
-            )
-        )
-
-    def contains(self, year: int) -> bool:
-        in_planning = (
-            self.planning_start is not None
-            and self.planning_end is not None
-            and self.planning_start <= year <= self.planning_end
-        )
-        in_construction = (
-            self.construction_start is not None
-            and self.construction_end is not None
-            and self.construction_start <= year <= self.construction_end
-        )
-        return in_planning or in_construction
-
-
-def _resolve_schedule(project: Project) -> Schedule:
-    return Schedule(
-        planning_start=project.planningStartYear,
-        planning_end=project.estPlanningEnd.year if project.estPlanningEnd else None,
-        construction_start=(
-            project.estConstructionStart.year if project.estConstructionStart else None
-        ),
-        construction_end=project.constructionEndYear,
-    )
 
 
 def _positive_int(value: str) -> int:
@@ -165,7 +115,7 @@ class Command(BaseCommand):
         report = _Report()
 
         for project in projects_qs.iterator():
-            schedule = _resolve_schedule(project)
+            schedule = resolve_schedule(project)
 
             if not schedule.is_complete:
                 self._emit_skip_row(writer, project, schedule)

--- a/infraohjelmointi_api/signals.py
+++ b/infraohjelmointi_api/signals.py
@@ -1,8 +1,10 @@
 from datetime import date
+from decimal import Decimal
 import logging
 from django.db.models.signals import post_save
 from django.db import transaction
 from infraohjelmointi_api.models import Project, ClassFinancial, LocationFinancial, ProjectClass, ProjectLocation, TalpaProjectOpening, SapCost, SapCurrentYear
+from infraohjelmointi_api.utils.schedule import resolve_schedule
 from infraohjelmointi_api.serializers import (
     ProjectClassSerializer,
     ProjectGetSerializer,
@@ -674,3 +676,84 @@ def cleanup_sap_costs_on_sap_project_change(sender, instance, created, **kwargs)
             f"deleted {deleted_sap_cost[0]} SapCost records, "
             f"{deleted_sap_current_year[0]} SapCurrentYear records"
         )
+
+
+@receiver(pre_save, sender=Project)
+def reconcile_finances_on_schedule_change(sender, instance, **kwargs):
+    """Move out-of-schedule budgets into the nearest in-schedule year when a
+    project's planning/construction schedule tightens past existing money.
+
+    Server-side backstop for the UI's form-only prevention (IO-826/IO-894):
+    it fires on every ``Project.save()`` — the project card, the programming
+    view timeline drag, bulk edits, Excel import and direct ORM writes — and
+    works straight on the DB rows, so it also rescues rows the form skips
+    because they fall outside its 11-year window (the documented gap that
+    keeps regenerating haamuluvut).
+
+    Behaviour mirrors the UI's ``moveBudget*`` helpers: the orphaned value is
+    moved into the nearest in-schedule year (later year wins on a tie) and the
+    source row is zeroed. Frame-view rows are out of scope, matching IO-826
+    and the IO-841 cleanup command.
+    """
+    if instance.pk is None:
+        return
+
+    try:
+        old = Project.objects.only(
+            "planningStartYear",
+            "estPlanningEnd",
+            "estConstructionStart",
+            "constructionEndYear",
+        ).get(pk=instance.pk)
+    except Project.DoesNotExist:
+        return
+
+    old_schedule = resolve_schedule(old)
+    new_schedule = resolve_schedule(instance)
+
+    if old_schedule == new_schedule:
+        return
+
+    # Conservative stance shared with IO-841: without a fully defined schedule
+    # we cannot decide what is in range, so leave every row untouched.
+    if not new_schedule.is_complete:
+        return
+
+    with transaction.atomic():
+        affected = (
+            ProjectFinancial.objects.select_for_update()
+            .filter(project_id=instance.pk, forFrameView=False)
+            .exclude(value=0)
+            .exclude(value__isnull=True)
+            .order_by("year")
+        )
+
+        moved_rows = 0
+        for fin in affected:
+            if new_schedule.contains(fin.year):
+                continue
+
+            target_year = new_schedule.nearest_in_schedule_year(fin.year)
+            # No in-schedule year exists (e.g. every phase inverted): don't
+            # destroy money on an unusable schedule, leave it for review.
+            if target_year is None or target_year == fin.year:
+                continue
+
+            target, _ = ProjectFinancial.objects.get_or_create(
+                project_id=instance.pk,
+                year=target_year,
+                forFrameView=False,
+                defaults={"value": Decimal("0")},
+            )
+            target.value = (target.value or Decimal("0")) + fin.value
+            target.save(update_fields=["value", "updatedDate"])
+
+            fin.value = Decimal("0")
+            fin.save(update_fields=["value", "updatedDate"])
+            moved_rows += 1
+
+        if moved_rows:
+            logger.info(
+                f"Reconciled {moved_rows} out-of-schedule finance row(s) for "
+                f"project {instance.pk} after a schedule change."
+            )

--- a/infraohjelmointi_api/tests/test_ProjectSignals.py
+++ b/infraohjelmointi_api/tests/test_ProjectSignals.py
@@ -1,6 +1,13 @@
 from datetime import date
+from decimal import Decimal
 from django.test import TestCase
-from infraohjelmointi_api.models import Project, ProjectPhase, ProjectCategory, ProjectType
+from infraohjelmointi_api.models import (
+    Project,
+    ProjectPhase,
+    ProjectCategory,
+    ProjectType,
+    ProjectFinancial,
+)
 
 
 class ProjectSignalTestCase(TestCase):
@@ -166,3 +173,212 @@ class ProjectSignalTestCase(TestCase):
 
         self.assertEqual(project.suspendedDate, saved_date)
         self.assertEqual(project.suspendedFromPhase, saved_from)
+
+
+class ReconcileFinancesOnScheduleChangeTestCase(TestCase):
+    """The pre_save reconcile signal (IO-894) moves out-of-schedule budgets
+    into the nearest in-schedule year whenever a project's planning /
+    construction schedule changes.
+
+    Baseline schedule for most tests: planning 2024-2025 + construction
+    2026-2028, so the in-schedule years are {2024, 2025, 2026, 2027, 2028}.
+    """
+
+    def _create_project(
+        self,
+        *,
+        name="Schedule project",
+        planning_start_year=2024,
+        est_planning_end=date(2025, 12, 31),
+        est_construction_start=date(2026, 1, 1),
+        construction_end_year=2028,
+    ) -> Project:
+        return Project.objects.create(
+            name=name,
+            description="-",
+            planningStartYear=planning_start_year,
+            estPlanningEnd=est_planning_end,
+            estConstructionStart=est_construction_start,
+            constructionEndYear=construction_end_year,
+        )
+
+    def _finance(self, project, *, year, value, for_frame_view=False):
+        return ProjectFinancial.objects.create(
+            project=project,
+            year=year,
+            value=Decimal(value),
+            forFrameView=for_frame_view,
+        )
+
+    def _value_at(self, project, year, *, for_frame_view=False) -> Decimal:
+        return ProjectFinancial.objects.get(
+            project=project, year=year, forFrameView=for_frame_view
+        ).value
+
+    def test_no_schedule_change_leaves_existing_haamuluku_untouched(self):
+        project = self._create_project()
+        haamu = self._finance(project, year=2030, value="100.00")
+
+        project.name = "Renamed"
+        project.save()
+
+        haamu.refresh_from_db()
+        self.assertEqual(haamu.value, Decimal("100.00"))
+
+    def test_planning_start_later_moves_money_to_new_start(self):
+        project = self._create_project()
+        orphan = self._finance(project, year=2024, value="500.00")
+
+        project.planningStartYear = 2025
+        project.save()
+
+        orphan.refresh_from_db()
+        self.assertEqual(orphan.value, Decimal("0"))
+        self.assertEqual(self._value_at(project, 2025), Decimal("500.00"))
+
+    def test_construction_end_earlier_moves_money_to_new_end(self):
+        project = self._create_project()
+        orphan = self._finance(project, year=2028, value="700.00")
+
+        project.constructionEndYear = 2026
+        project.save()
+
+        orphan.refresh_from_db()
+        self.assertEqual(orphan.value, Decimal("0"))
+        self.assertEqual(self._value_at(project, 2026), Decimal("700.00"))
+
+    def test_both_start_and_end_change_in_one_save(self):
+        project = self._create_project()
+        early = self._finance(project, year=2024, value="300.00")
+        late = self._finance(project, year=2028, value="400.00")
+
+        project.planningStartYear = 2025
+        project.constructionEndYear = 2027
+        project.save()
+
+        early.refresh_from_db()
+        late.refresh_from_db()
+        self.assertEqual(early.value, Decimal("0"))
+        self.assertEqual(late.value, Decimal("0"))
+        self.assertEqual(self._value_at(project, 2025), Decimal("300.00"))
+        self.assertEqual(self._value_at(project, 2027), Decimal("400.00"))
+
+    def test_schedule_loosening_without_orphans_moves_nothing(self):
+        project = self._create_project()
+        in_schedule = self._finance(project, year=2026, value="100.00")
+
+        project.constructionEndYear = 2030
+        project.save()
+
+        in_schedule.refresh_from_db()
+        self.assertEqual(in_schedule.value, Decimal("100.00"))
+        self.assertEqual(
+            ProjectFinancial.objects.filter(project=project)
+            .exclude(value=0)
+            .count(),
+            1,
+        )
+
+    def test_form_invisible_past_row_is_rescued(self):
+        """Reproduces the IO-826 gap: a row at a year the form's 11-year
+        window cannot represent stays in the DB; tightening the schedule
+        orphans it and the signal rescues it into the new start year."""
+        project = self._create_project()
+        stranded = self._finance(project, year=2020, value="160.00")
+
+        project.planningStartYear = 2025
+        project.save()
+
+        stranded.refresh_from_db()
+        self.assertEqual(stranded.value, Decimal("0"))
+        self.assertEqual(self._value_at(project, 2025), Decimal("160.00"))
+
+    def test_value_accumulates_into_existing_target_year(self):
+        project = self._create_project()
+        orphan = self._finance(project, year=2024, value="500.00")
+        existing = self._finance(project, year=2025, value="200.00")
+
+        project.planningStartYear = 2025
+        project.save()
+
+        orphan.refresh_from_db()
+        existing.refresh_from_db()
+        self.assertEqual(orphan.value, Decimal("0"))
+        self.assertEqual(existing.value, Decimal("700.00"))
+
+    def test_frame_view_row_is_not_touched(self):
+        project = self._create_project()
+        frame_orphan = self._finance(
+            project, year=2024, value="123.00", for_frame_view=True
+        )
+
+        project.planningStartYear = 2025
+        project.save()
+
+        frame_orphan.refresh_from_db()
+        self.assertEqual(frame_orphan.value, Decimal("123.00"))
+
+    def test_zero_valued_orphan_is_ignored(self):
+        project = self._create_project()
+        self._finance(project, year=2024, value="0.00")
+
+        project.planningStartYear = 2025
+        project.save()
+
+        # Nothing moved into the new start year, no row created there.
+        self.assertFalse(
+            ProjectFinancial.objects.filter(
+                project=project, year=2025, forFrameView=False
+            ).exists()
+        )
+
+    def test_null_schedule_field_after_change_is_noop(self):
+        project = self._create_project()
+        orphan = self._finance(project, year=2024, value="500.00")
+
+        project.estPlanningEnd = None
+        project.save()
+
+        orphan.refresh_from_db()
+        self.assertEqual(orphan.value, Decimal("500.00"))
+
+    def test_fully_inverted_schedule_leaves_money_untouched(self):
+        """If no in-schedule year exists at all, the signal refuses to
+        destroy money and leaves the rows for manual review."""
+        project = self._create_project()
+        orphan = self._finance(project, year=2024, value="500.00")
+
+        # Invert both phases: planning 2030->2029, construction 2032->2031.
+        project.planningStartYear = 2030
+        project.estPlanningEnd = date(2029, 12, 31)
+        project.estConstructionStart = date(2032, 1, 1)
+        project.constructionEndYear = 2031
+        project.save()
+
+        orphan.refresh_from_db()
+        self.assertEqual(orphan.value, Decimal("500.00"))
+
+    def test_updated_date_bumped_on_moved_row(self):
+        project = self._create_project()
+        orphan = self._finance(project, year=2024, value="500.00")
+        original_updated = orphan.updatedDate
+
+        project.planningStartYear = 2025
+        project.save()
+
+        orphan.refresh_from_db()
+        self.assertGreater(orphan.updatedDate, original_updated)
+
+    def test_null_valued_orphan_is_ignored(self):
+        project = self._create_project()
+        orphan = self._finance(project, year=2024, value="0")
+        ProjectFinancial.objects.filter(pk=orphan.pk).update(value=None)
+
+        project.planningStartYear = 2025
+        project.save()
+
+        self.assertFalse(
+            ProjectFinancial.objects.filter(
+                project=project, year=2025, forFrameView=False
+            ).exists()
+        )

--- a/infraohjelmointi_api/utils/schedule.py
+++ b/infraohjelmointi_api/utils/schedule.py
@@ -1,0 +1,90 @@
+"""Shared planning/construction schedule helpers.
+
+A project's money may only land in years covered by its planning or
+construction phase. Values at any other year are the data artefacts known
+internally as "haamuluvut" (ghost numbers). Both the cleanup command
+(``find_out_of_schedule_finances``) and the server-side prevention signal
+(``reconcile_finances_on_schedule_change``) reason about the same year
+range, so the logic lives here and is imported from both sites.
+"""
+
+from dataclasses import dataclass
+
+from infraohjelmointi_api.models import Project
+
+
+@dataclass(frozen=True)
+class Schedule:
+    """Resolved planning + construction year range for a project.
+
+    A range with ``start > end`` is treated as empty so that data with
+    inverted dates (e.g. ``estPlanningEnd < planningStartYear``) does not
+    silently mark every year as in-schedule.
+    """
+
+    planning_start: int | None
+    planning_end: int | None
+    construction_start: int | None
+    construction_end: int | None
+
+    @property
+    def is_complete(self) -> bool:
+        return all(
+            v is not None
+            for v in (
+                self.planning_start,
+                self.planning_end,
+                self.construction_start,
+                self.construction_end,
+            )
+        )
+
+    def contains(self, year: int) -> bool:
+        in_planning = (
+            self.planning_start is not None
+            and self.planning_end is not None
+            and self.planning_start <= year <= self.planning_end
+        )
+        in_construction = (
+            self.construction_start is not None
+            and self.construction_end is not None
+            and self.construction_start <= year <= self.construction_end
+        )
+        return in_planning or in_construction
+
+    def nearest_in_schedule_year(self, year: int) -> int | None:
+        """Return the in-schedule year closest to ``year``.
+
+        The candidates are the four phase boundaries; for any out-of-range
+        year the nearest in-schedule year is always the closest edge of the
+        nearest phase, so the boundaries are sufficient. Boundaries from an
+        inverted/empty phase are dropped because they are not themselves
+        in-schedule. On a tie the later year wins, mirroring the UI's
+        "move forward" preference (``moveBudgetForwards`` /
+        ``moveBudgetBackwards`` in ``financesUtils.ts``).
+
+        Returns ``None`` when the project has no in-schedule year at all
+        (e.g. every phase is empty), signalling the caller to leave the
+        row untouched rather than destroy money on an unusable schedule.
+        """
+        candidates: list[int] = []
+        if self.planning_start is not None and self.planning_end is not None:
+            candidates += [self.planning_start, self.planning_end]
+        if self.construction_start is not None and self.construction_end is not None:
+            candidates += [self.construction_start, self.construction_end]
+
+        in_range = [c for c in candidates if self.contains(c)]
+        if not in_range:
+            return None
+        return min(in_range, key=lambda c: (abs(c - year), -c))
+
+
+def resolve_schedule(project: Project) -> Schedule:
+    return Schedule(
+        planning_start=project.planningStartYear,
+        planning_end=project.estPlanningEnd.year if project.estPlanningEnd else None,
+        construction_start=(
+            project.estConstructionStart.year if project.estConstructionStart else None
+        ),
+        construction_end=project.constructionEndYear,
+    )


### PR DESCRIPTION
* add a pre_save Project signal that moves out-of-schedule finance values into the nearest in-schedule year and zeroes the source row, covering the programming-view drag, bulk edits, imports and direct ORM writes the form cannot reach
* extract the shared Schedule helper into utils/schedule.py (with nearest_in_schedule_year) so the IO-841 cleanup command and the signal reason about the identical year range
* leave frame-view rows and incomplete/inverted schedules untouched to avoid destroying money on an unusable schedule
* cover the behaviour with ProjectSignals tests (move, accumulate, rescue of form-invisible rows, and the conservative no-ops)