### PR TITLE
IO-928 Stop class budget sum absorbing prefix-named sibling classes

### DIFF
--- a/infraohjelmointi_api/serializers/FinancialSumSerializer.py
+++ b/infraohjelmointi_api/serializers/FinancialSumSerializer.py
@@ -403,14 +403,21 @@ class FinancialSumSerializer(serializers.ModelSerializer):
                     )
                     .prefetch_related("finances")  # CRITICAL: Prevents N+1 queries when aggregating ProjectFinancial
                     .filter(
+                        # IO-928: same trailing-slash boundary as the planning branch.
                         (
                             Q(projectClass__name__icontains="suurpiiri")
-                            & Q(
-                                projectClass__parent__coordinatorClass__path__startswith=instance.path
+                            & (
+                                Q(projectClass__parent__coordinatorClass=instance)
+                                | Q(
+                                    projectClass__parent__coordinatorClass__path__startswith=instance.path
+                                    + "/"
+                                )
                             )
                         )
+                        | Q(projectClass__coordinatorClass=instance)
                         | Q(
                             projectClass__coordinatorClass__path__startswith=instance.path
+                            + "/"
                         ),
                         programmed=True,
                     )

--- a/infraohjelmointi_api/serializers/FinancialSumSerializer.py
+++ b/infraohjelmointi_api/serializers/FinancialSumSerializer.py
@@ -420,12 +420,10 @@ class FinancialSumSerializer(serializers.ModelSerializer):
                     Project.objects.select_related("projectClass")
                     .prefetch_related("finances")
                     .filter(
-                        # IO-928: match descendants by path prefix WITH a trailing-slash
-                        # boundary. `path` is name-based, so without the boundary a class
-                        # whose name is a prefix of a sibling's (e.g. "…/Malmi" is a prefix
-                        # of "…/Malminkartano-Kannelmäki") pulls the sibling's projects into
-                        # this class's sum. `Q(projectClass=instance)` keeps the class's own
-                        # (non-descendant) projects.
+                        # IO-928: `path` is name-based, so the descendant prefix match
+                        # needs a trailing-slash boundary — without it ".../Malmi" also
+                        # matches the sibling ".../Malminkartano-Kannelmäki" and absorbs
+                        # its projects. Q(projectClass=instance) keeps this class's own.
                         Q(projectClass__path__startswith=instance.path + "/")
                         | Q(projectClass=instance),
                         programmed=True,

--- a/infraohjelmointi_api/serializers/FinancialSumSerializer.py
+++ b/infraohjelmointi_api/serializers/FinancialSumSerializer.py
@@ -420,7 +420,13 @@ class FinancialSumSerializer(serializers.ModelSerializer):
                     Project.objects.select_related("projectClass")
                     .prefetch_related("finances")
                     .filter(
-                        Q(projectClass__path__startswith=instance.path)
+                        # IO-928: match descendants by path prefix WITH a trailing-slash
+                        # boundary. `path` is name-based, so without the boundary a class
+                        # whose name is a prefix of a sibling's (e.g. "…/Malmi" is a prefix
+                        # of "…/Malminkartano-Kannelmäki") pulls the sibling's projects into
+                        # this class's sum. `Q(projectClass=instance)` keeps the class's own
+                        # (non-descendant) projects.
+                        Q(projectClass__path__startswith=instance.path + "/")
                         | Q(projectClass=instance),
                         programmed=True,
                     )

--- a/infraohjelmointi_api/tests/test_BalkSums.py
+++ b/infraohjelmointi_api/tests/test_BalkSums.py
@@ -1078,3 +1078,64 @@ class ClassSumSiblingNamePrefixTestCase(CacheClearingMixin, TestCase):
 
         # the shared parent legitimately includes both branches
         self.assertPlannedBudget(self.mc_id, 115)
+
+
+@patch.object(BaseViewSet, "authentication_classes", new=[])
+@patch.object(BaseViewSet, "permission_classes", new=[])
+class CoordinatorSumSiblingNamePrefixTestCase(CacheClearingMixin, TestCase):
+    """IO-928 regression (coordinator branch): same prefix-collision fix as the
+    planning branch, but with the added constraint that the coordinator query
+    must keep an equality leg — without it, projects directly mapped to the
+    viewed coordinator class are dropped from its sum.
+    """
+
+    def setUp(self):
+        super().setUp()
+
+        # Planning hierarchy: two planning classes, each with one programmed project
+        plan_a = ProjectClass.objects.create(name="Plan A", path="Plan A")
+        plan_b = ProjectClass.objects.create(name="Plan B", path="Plan B")
+
+        year = date.today().year
+        for pc, val in ((plan_a, 30), (plan_b, 70)):
+            p = Project.objects.create(
+                name="{} project".format(pc.name),
+                description="d",
+                programmed=True,
+                projectClass=pc,
+            )
+            ProjectFinancial.objects.create(project=p, year=year, value=val)
+
+        # Coordinator hierarchy: "CO/Malmi" and "CO/Malminkartano" are siblings
+        # whose names trigger the prefix bug.
+        co = ProjectClass.objects.create(
+            name="CO", path="CO", forCoordinatorOnly=True,
+        )
+        co_malmi = ProjectClass.objects.create(
+            name="Malmi", path="CO/Malmi", parent=co,
+            forCoordinatorOnly=True, relatedTo=plan_a,
+        )
+        co_kartano = ProjectClass.objects.create(
+            name="Malminkartano", path="CO/Malminkartano", parent=co,
+            forCoordinatorOnly=True, relatedTo=plan_b,
+        )
+
+        self.co_id = co.id
+        self.co_malmi_id = co_malmi.id
+        self.co_kartano_id = co_kartano.id
+
+    def assertCoordinatorPlannedBudget(self, class_id, expected):
+        response = self.client.get("/project-classes/coordinator/")
+        self.assertEqual(response.status_code, 200, msg=response.content)
+        row = next(r for r in response.json() if r["id"] == str(class_id))
+        self.assertEqual(row["finances"]["year0"]["plannedBudget"], expected)
+
+    def test_prefix_named_coordinator_sibling_not_summed(self):
+        # CO/Malmi maps to plan_a (30) — must NOT absorb plan_b's 70
+        self.assertCoordinatorPlannedBudget(self.co_malmi_id, 30)
+
+        # CO/Malminkartano maps to plan_b (70) — must keep its own
+        self.assertCoordinatorPlannedBudget(self.co_kartano_id, 70)
+
+        # shared parent includes both
+        self.assertCoordinatorPlannedBudget(self.co_id, 100)

--- a/infraohjelmointi_api/tests/test_BalkSums.py
+++ b/infraohjelmointi_api/tests/test_BalkSums.py
@@ -1032,7 +1032,8 @@ class ClassSumSiblingNamePrefixTestCase(CacheClearingMixin, TestCase):
     """
 
     def setUp(self):
-        year = date.today().year
+        super().setUp()  # CacheClearingMixin.setUp, see tests/helpers.py
+
         mc = ProjectClass.objects.create(name="MC", path="MC")
         malmi = ProjectClass.objects.create(name="Malmi", path="MC/Malmi", parent=mc)
         # sibling whose name STARTS WITH "Malmi" (the bug trigger)
@@ -1046,29 +1047,34 @@ class ClassSumSiblingNamePrefixTestCase(CacheClearingMixin, TestCase):
             name="Esirakentaminen", path="MC/Malmi/Esirakentaminen", parent=malmi
         )
 
-        p_malmi = Project.objects.create(
-            name="Malmi project", description="d", programmed=True, projectClass=malmi_sub
-        )
-        p_kartano = Project.objects.create(
-            name="Kartano project", description="d", programmed=True, projectClass=kartano
-        )
-        ProjectFinancial.objects.create(project=p_malmi, year=year, value=10)
-        ProjectFinancial.objects.create(project=p_kartano, year=year, value=100)
+        year = date.today().year
+        for projectClass, value in ((malmi, 5), (malmi_sub, 10), (kartano, 100)):
+            project = Project.objects.create(
+                name="{} project".format(projectClass.name),
+                description="d",
+                programmed=True,
+                projectClass=projectClass,
+            )
+            ProjectFinancial.objects.create(project=project, year=year, value=value)
 
         self.mc_id = mc.id
         self.malmi_id = malmi.id
         self.kartano_id = kartano.id
 
+    def assertPlannedBudget(self, class_id, expected):
+        response = self.client.get("/project-classes/{}/".format(class_id))
+        self.assertEqual(response.status_code, 200, msg=response.content)
+        self.assertEqual(
+            response.json()["finances"]["year0"]["plannedBudget"], expected
+        )
+
     def test_prefix_named_sibling_not_summed_into_class(self):
-        # Malmi: includes its descendant (10), excludes the prefix-named sibling (100).
-        resp = self.client.get("/project-classes/{}/".format(self.malmi_id))
-        self.assertEqual(resp.status_code, 200, msg=resp.content)
-        self.assertEqual(resp.json()["finances"]["year0"]["plannedBudget"], 10)
+        # Malmi: its own project (5) plus its descendant's (10). The prefix-named
+        # sibling's project (100) must stay out.
+        self.assertPlannedBudget(self.malmi_id, 15)
 
-        # sibling still sums its own project
-        resp2 = self.client.get("/project-classes/{}/".format(self.kartano_id))
-        self.assertEqual(resp2.json()["finances"]["year0"]["plannedBudget"], 100)
+        # the sibling still sums its own project
+        self.assertPlannedBudget(self.kartano_id, 100)
 
-        # shared parent legitimately includes both
-        resp3 = self.client.get("/project-classes/{}/".format(self.mc_id))
-        self.assertEqual(resp3.json()["finances"]["year0"]["plannedBudget"], 110)
+        # the shared parent legitimately includes both branches
+        self.assertPlannedBudget(self.mc_id, 115)

--- a/infraohjelmointi_api/tests/test_BalkSums.py
+++ b/infraohjelmointi_api/tests/test_BalkSums.py
@@ -1021,3 +1021,54 @@ class BalkSumTestCase(CacheClearingMixin, TestCase):
         self.assertEqual(response.json()["finances"]["projectBudgets"], 0)
 
         self.runFinancesAssertTests(response, index=None, name="plannedBudget", values=[0,0,0,0,0,0,0,0,0,0,0])
+
+
+@patch.object(BaseViewSet, "authentication_classes", new=[])
+@patch.object(BaseViewSet, "permission_classes", new=[])
+class ClassSumSiblingNamePrefixTestCase(CacheClearingMixin, TestCase):
+    """IO-928 regression: a class planned-budget sum is a path-prefix query, so a
+    class whose name is a prefix of a sibling's must NOT absorb the sibling's
+    projects. Concretely, "MC/Malmi" must not match "MC/Malminkartano-Kannelmäki".
+    """
+
+    def setUp(self):
+        year = date.today().year
+        mc = ProjectClass.objects.create(name="MC", path="MC")
+        malmi = ProjectClass.objects.create(name="Malmi", path="MC/Malmi", parent=mc)
+        # sibling whose name STARTS WITH "Malmi" (the bug trigger)
+        kartano = ProjectClass.objects.create(
+            name="Malminkartano-Kannelmäki",
+            path="MC/Malminkartano-Kannelmäki",
+            parent=mc,
+        )
+        # a genuine descendant of Malmi (must stay included in Malmi's sum)
+        malmi_sub = ProjectClass.objects.create(
+            name="Esirakentaminen", path="MC/Malmi/Esirakentaminen", parent=malmi
+        )
+
+        p_malmi = Project.objects.create(
+            name="Malmi project", description="d", programmed=True, projectClass=malmi_sub
+        )
+        p_kartano = Project.objects.create(
+            name="Kartano project", description="d", programmed=True, projectClass=kartano
+        )
+        ProjectFinancial.objects.create(project=p_malmi, year=year, value=10)
+        ProjectFinancial.objects.create(project=p_kartano, year=year, value=100)
+
+        self.mc_id = mc.id
+        self.malmi_id = malmi.id
+        self.kartano_id = kartano.id
+
+    def test_prefix_named_sibling_not_summed_into_class(self):
+        # Malmi: includes its descendant (10), excludes the prefix-named sibling (100).
+        resp = self.client.get("/project-classes/{}/".format(self.malmi_id))
+        self.assertEqual(resp.status_code, 200, msg=resp.content)
+        self.assertEqual(resp.json()["finances"]["year0"]["plannedBudget"], 10)
+
+        # sibling still sums its own project
+        resp2 = self.client.get("/project-classes/{}/".format(self.kartano_id))
+        self.assertEqual(resp2.json()["finances"]["year0"]["plannedBudget"], 100)
+
+        # shared parent legitimately includes both
+        resp3 = self.client.get("/project-classes/{}/".format(self.mc_id))
+        self.assertEqual(resp3.json()["finances"]["year0"]["plannedBudget"], 110)


### PR DESCRIPTION
The programming-view planned-budget sum for a ProjectClass filters projects by projectClass__path__startswith=instance.path. `path` is name-based, so a class whose name is a prefix of a sibling's (e.g. ".../Malmi" is a prefix of ".../Malminkartano-Kannelmäki") pulled the sibling's projects into its sum — Malmi double-counted all of Malminkartano-Kannelmäki (verified: 114 = 59 + 55 projects).

Add a trailing-slash boundary so only true descendants match; Q(projectClass=instance) still covers the class's own projects. Adds a regression test (ClassSumSiblingNamePrefixTestCase).